### PR TITLE
🧙 Default nvmrc for local development

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/fermium

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Builds are designed to be run from the top level of the repository.
 ### Quickstart
 
 ```sh
+$ nvm use
 $ yarn install # install all dependencies; rerun with --ignore-scripts if
                # scrypt node-gyp failures prevent the install from completing
 $ yarn start # start a continuous webpack build that will auto-update with changes


### PR DESCRIPTION
I don't see a reason to test across multiple Node versions considering the transpilation, and using the same version of Node will save us a bunch of headaches.

Down to revisit Node matrix testing later.. but I have a feeling that's not controversial :grin: 