### PR TITLE
🐛 Fix Redux state deserialization

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -33,7 +33,9 @@ export async function newProxyStore(): Promise<
       ),
     deserializer: (payload: string) =>
       JSON.parse(payload, (_, value) =>
-        "B_I_G_I_N_T" in value ? BigInt(value.B_I_G_I_N_T) : value
+        typeof value === "object" && "B_I_G_I_N_T" in value
+          ? BigInt(value.B_I_G_I_N_T)
+          : value
       ),
   })
   await proxyStore.ready()

--- a/api/main.ts
+++ b/api/main.ts
@@ -153,7 +153,9 @@ export default class Main {
         ),
       deserializer: (payload: string) =>
         JSON.parse(payload, (_, value) =>
-          "B_I_G_I_N_T" in value ? BigInt(value.B_I_G_I_N_T) : value
+          typeof value === "object" && "B_I_G_I_N_T" in value
+            ? BigInt(value.B_I_G_I_N_T)
+            : value
         ),
     })
 


### PR DESCRIPTION
`bigint` deserialization introduced a bug deserializing any non-object state. This is a quick fix.

NB: This is a really good candidate for a regression test of some sort. Not sure where to put it though.