### PR TITLE
Basic logging setup

### DIFF
--- a/background/lib/logger.ts
+++ b/background/lib/logger.ts
@@ -1,14 +1,14 @@
 // eslint-disable no-console
 
 enum LogLevel {
-  Log = "log",
-  Info = "info",
-  Warn = "warn",
-  Error = "error",
+  log = "log",
+  info = "info",
+  warn = "warn",
+  error = "error",
 }
 
 function genericLogger(level: LogLevel, input: any[]) {
-  console[level].apply(this, input)
+  console[level](...input)
 
   const stackTrace = new Error().stack.split("\n").filter((line) => {
     // Remove empty lines from the output
@@ -27,19 +27,19 @@ function genericLogger(level: LogLevel, input: any[]) {
 
 const logger = {
   log(...input: any[]) {
-    genericLogger(LogLevel.Log, input)
+    genericLogger(LogLevel.log, input)
   },
 
   info(...input: any[]) {
-    genericLogger(LogLevel.Info, input)
+    genericLogger(LogLevel.info, input)
   },
 
   warn(...input: any[]) {
-    genericLogger(LogLevel.Warn, input)
+    genericLogger(LogLevel.warn, input)
   },
 
   error(...input: any[]) {
-    genericLogger(LogLevel.Error, input)
+    genericLogger(LogLevel.error, input)
   },
 }
 

--- a/background/networks/ethereum/index.ts
+++ b/background/networks/ethereum/index.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from "events"
 import Provider from "./provider"
 import Subscription from "./subscription"
-import Logger from "../../lib/logger"
+import logger from "../../lib/logger"
 
 /*
   should do caching
@@ -104,7 +104,7 @@ export default class EthereumNetworkProvider extends Provider {
         )
         this.request({ method: "eth_unsubscribe", params: [subscription.id] })
       } catch (e) {
-        Logger.error(e)
+        logger.error(e)
       }
     })
     await this.transport.close()

--- a/background/networks/ethereum/subscription.ts
+++ b/background/networks/ethereum/subscription.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "events"
 import { TRANSPORT_TYPES } from "../../constants"
-import Logger from "../../lib/logger"
+import logger from "../../lib/logger"
 
 /*
 
@@ -33,7 +33,7 @@ export default class Subscription extends EventEmitter {
         this.emit("update", result)
       }
     } catch (e) {
-      Logger.error(e)
+      logger.error(e)
     }
   }
 }

--- a/background/networks/index.ts
+++ b/background/networks/index.ts
@@ -1,7 +1,7 @@
 import ObsStore from "../lib/ob-store"
 import EtherumNetworkProvider from "./ethereum"
 import { NETWORK_ERRORS } from "../constants/errors"
-import Logger from "../lib/logger"
+import logger from "../lib/logger"
 
 export const providers = {
   ethereum: EtherumNetworkProvider,
@@ -67,7 +67,7 @@ export default class Network {
       this.providers[type][endpoint] = new providers[type]({ endpoint })
       this.providers[type].selected = this.providers[type][endpoint]
     } catch (e) {
-      Logger.error(e)
+      logger.error(e)
     }
     this.state.putState(networks)
   }

--- a/background/services/chain/service.ts
+++ b/background/services/chain/service.ts
@@ -7,7 +7,7 @@ import { Block as EthersBlock } from "@ethersproject/abstract-provider"
 import { Transaction as EthersTransaction } from "@ethersproject/transactions"
 import { BigNumber, utils } from "ethers"
 import Emittery from "emittery"
-import Logger from "../../lib/logger"
+import logger from "../../lib/logger"
 
 import {
   AccountBalance,
@@ -396,7 +396,7 @@ export default class ChainService implements Service<Events> {
       ])
     } catch (error) {
       // TODO proper logging
-      Logger.error(`Error broadcasting transaction ${tx}`, error)
+      logger.error(`Error broadcasting transaction ${tx}`, error)
       throw error
     }
   }
@@ -435,7 +435,7 @@ export default class ChainService implements Service<Events> {
         this.queueTransactionHashToRetrieve(ETHEREUM, a.txHash)
       )
     } catch (err) {
-      Logger.error(err)
+      logger.error(err)
     }
   }
 
@@ -467,7 +467,7 @@ export default class ChainService implements Service<Events> {
           await this.saveTransaction(tx, "alchemy")
         } catch (error) {
           // TODO proper logging
-          Logger.error(`Error retrieving transaction ${hash}`, error)
+          logger.error(`Error retrieving transaction ${hash}`, error)
           this.queueTransactionHashToRetrieve(ETHEREUM, hash)
         }
       })
@@ -484,7 +484,7 @@ export default class ChainService implements Service<Events> {
     } catch (err) {
       // TODO proper logging
       error = err
-      Logger.error(`Error saving tx ${tx}`, error)
+      logger.error(`Error saving tx ${tx}`, error)
     }
     try {
       // emit in a separate try so outside services still get the tx
@@ -492,7 +492,7 @@ export default class ChainService implements Service<Events> {
     } catch (err) {
       // TODO proper logging
       error = err
-      Logger.error(`Error emitting tx ${tx}`, error)
+      logger.error(`Error emitting tx ${tx}`, error)
     }
     if (error) {
       throw error
@@ -544,7 +544,7 @@ export default class ChainService implements Service<Events> {
           )
         } catch (error) {
           // TODO proper logging
-          Logger.error(`Error saving tx: ${result}`, error)
+          logger.error(`Error saving tx: ${result}`, error)
         }
       }
     )

--- a/background/services/indexing/service.ts
+++ b/background/services/indexing/service.ts
@@ -1,6 +1,6 @@
 import { browser, Alarms } from "webextension-polyfill-ts"
 import Emittery from "emittery"
-import Logger from "../../lib/logger"
+import logger from "../../lib/logger"
 
 import {
   AccountBalance,
@@ -290,7 +290,7 @@ export default class IndexingService implements Service<Events> {
             const newListRef = await fetchAndValidateTokenList(url)
             await this.db.saveTokenList(url, newListRef.tokenList)
           } catch (err) {
-            Logger.error(
+            logger.error(
               `Error fetching, validating, and saving token list ${url}`
             )
           }

--- a/background/transactions/index.ts
+++ b/background/transactions/index.ts
@@ -2,7 +2,7 @@
 import ObsStore from "../lib/ob-store"
 import { createEthProviderWrapper } from "../lib/utils"
 import { formatTransaction } from "./utils"
-import Logger from "../lib/logger"
+import logger from "../lib/logger"
 
 /*
 STATE
@@ -101,7 +101,7 @@ export default class Transactions {
                 fiatValue
               )
             } catch (e) {
-              Logger.error(e)
+              logger.error(e)
               throw e
             }
           })


### PR DESCRIPTION
Closes #210

Adds a super simple logging library that outputs to console.log, console.error, etc. along with a stack trace. All direct references to `console.error` in the project were replaced with the new logger function. There is still a reference to `console` in the websocket handling code but it wasn't a direct reference to a logging function so I didn't want to mess with it yet 