### PR TITLE
Null Attack: Fix an issue where asset-specific activities would fail to render

### DIFF
--- a/ui/components/Wallet/WalletActivityList.tsx
+++ b/ui/components/Wallet/WalletActivityList.tsx
@@ -39,7 +39,11 @@ export default function WalletActivityList(props: Props): ReactElement {
         isOpen={showingActivityDetail && true}
         close={handleClose}
       >
-        <WalletActivityDetails activityItem={showingActivityDetail} />
+        {showingActivityDetail ? (
+          <WalletActivityDetails activityItem={showingActivityDetail} />
+        ) : (
+          <></>
+        )}
       </SharedSlideUpMenu>
       <ul>
         {activity.map((activityItem) => (


### PR DESCRIPTION
This was happening because the slide-up menu's contents were rendered
even if there were no wallet activity details to display. Here, the
approach taken is to only render the contents when there is an actual
asset selected for display.

Fixes #253 .