### PR TITLE
🦎 CoinGecko Validation

### DIFF
--- a/background/lib/prices.ts
+++ b/background/lib/prices.ts
@@ -17,7 +17,7 @@ export async function getPrice(
   const url = `${COINGECKO_API_ROOT}/simple/price?ids=${coingeckoCoinId}&vs_currencies=${currencySymbol}&include_last_updated_at=true`
 
   const json = await fetchJson(url)
-  const validate = getSimplePriceValidator(coingeckoCoinId, currencySymbol)
+  const validate = getSimplePriceValidator()
 
   if (!validate(json)) {
     logger.warn(
@@ -43,18 +43,18 @@ export async function getPrices(
   assets: CoinGeckoAsset[],
   vsCurrencies: FiatCurrency[]
 ): Promise<PricePoint[]> {
-  const coinIds = assets.map((a) => a.metadata.coinGeckoId)
+  const coinIds = assets.map((a) => a.metadata.coinGeckoId).join(",")
 
-  const currencySymbols = vsCurrencies.map((c) => c.symbol.toLowerCase())
+  const currencySymbols = vsCurrencies
+    .map((c) => c.symbol.toLowerCase())
+    .join(",")
 
-  const url = `${COINGECKO_API_ROOT}/simple/price?ids=${coinIds.join(
-    ","
-  )}&include_last_updated_at=true&vs_currencies=${currencySymbols.join(",")}`
+  const url = `${COINGECKO_API_ROOT}/simple/price?ids=${coinIds}&include_last_updated_at=true&vs_currencies=${currencySymbols}`
 
   const json = await fetchJson(url)
   // TODO fix loss of precision from json
   // TODO: TESTME
-  const validate = getSimplePriceValidator(coinIds, currencySymbols)
+  const validate = getSimplePriceValidator()
 
   if (!validate(json)) {
     logger.warn(


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7690112/136708401-188176b1-cf02-4532-b941-9c5a8b835c5a.png)

I wanted to harden the validation so in the code after the validation is ran we can be 100% sure that the data is as intended. 
Also realised that schema compilation is costly so put together a solution that is as lazy as it can be. 

one api endpoint is still missing to close  #215 but  for that I will need sample data