### PR TITLE
v0.0.4

### DIFF
--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Tally",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "The community owned and operated Web3 wallet.",
   "homepage_url": "https://tally.cash",
   "author": "https://tally.cash",


### PR DESCRIPTION
Removes the `tabs` permission we also got rejected for,

<img width="500" alt="Screen Shot Tabs" src="https://user-images.githubusercontent.com/1918798/137011913-f51b1d8f-e600-4cfe-969a-899f2c5ab1bf.png">

