### PR TITLE
✨ Ethereal Symbols

### DIFF
--- a/ui/components/Shared/SharedAssetIcon.tsx
+++ b/ui/components/Shared/SharedAssetIcon.tsx
@@ -71,7 +71,7 @@ export default function SharedAssetIcon(props: Props): ReactElement {
           align-items: center;
           justify-content: center;
           ${hasHardcodedIcon
-            ? `background: url("${`./images/${symbol}@2x.png`}") center no-repeat;
+            ? `background: url("${`./images/${symbol.toLowerCase()}@2x.png`}") center no-repeat;
             background-size: 45% auto;`
             : `background: url("${logoURL}");
             background-size: cover;`}


### PR DESCRIPTION
Simple bugfix to display the ETH asset logo consistently

Before

![Screenshot from 2021-10-16 00-10-43](https://user-images.githubusercontent.com/427505/137573592-52157f29-9dc3-4a19-b5f0-d57474db806c.png)

After

![Screenshot from 2021-10-16 00-19-50](https://user-images.githubusercontent.com/427505/137573596-3626d84d-10b3-4315-bf29-d0eff2e4437a.png)

Considering the caps, this might be platform specific :thinking: 