### PR TITLE
fix cors issue: add permissions to fetch every url

### DIFF
--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -25,7 +25,13 @@
     "default_title": "Tally",
     "default_popup": "popup.html"
   },
-  "permissions": ["alarms", "storage", "unlimitedStorage", "notifications"],
+  "permissions": [
+    "alarms",
+    "storage",
+    "unlimitedStorage",
+    "notifications",
+    "<all_urls>"
+  ],
   "background": {
     "persistent": true,
     "scripts": ["background.js", "background-ui.js"]


### PR DESCRIPTION
https://groups.google.com/a/chromium.org/g/chromium-extensions/c/aVn9F6S_z68?pli=1
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns#all_urls

If the tally/indexing is not populated when the extension starts. We get cors issues.
Not sure what has changed, or when but with this permission fetch works again. 

Steps to reproduce: 
- remove tally/indexing from indexdb
- reload extension

Might be a good idea to find out how/when this was introduced and how could we adapt our workflow to catch up on these things. 

fun fact: for some reason adding content_scripts to the manifest.json fixes the problem 🤪