### PR TITLE
Fix Fairy: Fix a few nits and bugs in current main

### DIFF
--- a/background/assets.ts
+++ b/background/assets.ts
@@ -275,6 +275,39 @@ export function convertAssetAmountViaPricePoint<T extends AnyAssetAmount>(
 }
 
 /**
+ * Looks at the provided price point and extracts a unit price for the first
+ * asset in the price point, i.e. returns the number of the second asset
+ * equivalent to one of the first asset. In addition to handling strange
+ * ratios, recognizes a unit in the appropriate fixed point decimal count of
+ * the target asset.
+ */
+export function unitPricePointForPricePoint(
+  assetPricePoint: PricePoint
+): (UnitPricePoint & { unitPrice: FungibleAssetAmount }) | undefined {
+  const sourceAsset = assetPricePoint.pair[0]
+
+  const unitPrice = convertAssetAmountViaPricePoint(
+    {
+      amount:
+        "decimals" in sourceAsset
+          ? 1n * 10n ** BigInt(sourceAsset.decimals)
+          : 1n,
+      asset: sourceAsset,
+    },
+    assetPricePoint
+  )
+
+  if (typeof unitPrice !== "undefined") {
+    return {
+      unitPrice,
+      time: assetPricePoint.time,
+    }
+  }
+
+  return undefined
+}
+
+/**
  * Given a FungibleAssetAmount and a desired number of decimals, convert the
  * amount to a floating point JavaScript number with the specified number of
  * decimal points (modulo floating point precision oddities).

--- a/background/assets.ts
+++ b/background/assets.ts
@@ -230,44 +230,36 @@ export function convertAssetAmountViaPricePoint<T extends AnyAssetAmount>(
     isFungibleAsset(sourceAsset) &&
     isFungibleAsset(targetAsset)
   ) {
-    const [sourceDecimals, targetDecimals] = [
-      sourceAsset.decimals,
-      targetAsset.decimals,
-    ]
-
-    const combinedDecimals = sourceDecimals + targetDecimals
-
     // A price point gives us X of the source asset = Y of the target asset, as
     // a pair of fixed-point values. We have M of the source asset, and want to
     // find out how much of the target asset that is.
     //
-    // The simple version is that we want to do M * X / Y; however, we also
-    // need to deal with the different fixed-point decimal amounts, and want to
-    // end up reporting the converted amount in the decimals of the target
-    // asset.
+    // The simple version is that we want to do M * X / Y; however, we have the
+    // conversion _factor_ for X and Y, which are the mathematical inverse of
+    // what we refer to as X and Y above. As such, we can instead express this as
+    // M * T / S, where S is the source conversion factor and T is the target
+    // conversion factor.
     //
-    // Below, M is the source asset amount, X is the sourceConversionFactor,
-    // and Y is the targetConversionFactor. Extra parentheses are added around
-    // the multiplication to emphasize order matters! If we computed X / Y
+    // Below, M is the source asset amount, S is the sourceConversionFactor,
+    // and T is the targetConversionFactor. Extra parentheses are added around
+    // the multiplication to emphasize order matters! If we computed M / S
     // first we would risk losing precision in the integer division.
     const targetCurrencyAmount =
-      (sourceAssetAmount.amount * sourceConversionFactor) /
-      targetConversionFactor
+      (sourceAssetAmount.amount * targetConversionFactor) /
+      sourceConversionFactor
 
     // Reduce the fixed-point representation to the target asset's decimals.
     return {
       asset: targetAsset,
-      amount: convertFixedPoint(
-        targetCurrencyAmount,
-        combinedDecimals,
-        targetDecimals
-      ),
+      amount: targetCurrencyAmount,
     }
   }
 
   // For non-fungible assets, require that the target asset be fungible and
   // that the source conversion factor be 1, i.e. that the price point tells us
-  // what 1 of the source asset is in target asset terms.
+  // what 1 of the source asset is in target asset terms. Generally in these
+  // cases we expect the source asset amount to be 1, but we multiply out just
+  // in case.
   if (
     sourceAssetAmount.asset.symbol === sourceAsset.symbol &&
     isFungibleAsset(targetAsset) &&
@@ -275,7 +267,7 @@ export function convertAssetAmountViaPricePoint<T extends AnyAssetAmount>(
   ) {
     return {
       asset: targetAsset,
-      amount: targetConversionFactor,
+      amount: sourceAssetAmount.amount * targetConversionFactor,
     }
   }
 

--- a/background/lib/alchemy.ts
+++ b/background/lib/alchemy.ts
@@ -200,27 +200,33 @@ export async function getTokenBalances(
   }
 
   // TODO log balances with errors, consider returning an error type
-  return json.tokenBalances
-    .filter(
-      (
-        b
-      ): b is typeof json["tokenBalances"][0] & {
-        tokenBalance: Exclude<
-          typeof json["tokenBalances"][0]["tokenBalance"],
-          null
-        >
-      } => b.error === null && b.tokenBalance !== null
-    )
-    .map((tokenBalance) => {
-      let balance = tokenBalance.tokenBalance
-      if (balance.length > 66) {
-        balance = balance.substring(0, 66)
-      }
-      return {
-        contractAddress: tokenBalance.contractAddress,
-        amount: balance === "0x" ? BigInt(0) : BigInt(balance),
-      }
-    })
+  return (
+    json.tokenBalances
+      .filter(
+        (
+          b
+        ): b is typeof json["tokenBalances"][0] & {
+          tokenBalance: Exclude<
+            typeof json["tokenBalances"][0]["tokenBalance"],
+            null
+          >
+        } => b.error === null && b.tokenBalance !== null
+      )
+      // A hex value of 0x without any subsequent numbers generally means "no
+      // value" (as opposed to 0) in Ethereum implementations, so filter it out
+      // as effectively undefined.
+      .filter(({ tokenBalance }) => tokenBalance !== "0x")
+      .map((tokenBalance) => {
+        let balance = tokenBalance.tokenBalance
+        if (balance.length > 66) {
+          balance = balance.substring(0, 66)
+        }
+        return {
+          contractAddress: tokenBalance.contractAddress,
+          amount: BigInt(balance),
+        }
+      })
+  )
 }
 
 // JSON Type Definition for the Alchemy token metadata API.

--- a/background/services/base.ts
+++ b/background/services/base.ts
@@ -29,10 +29,15 @@ type AlarmSchedule =
  * also provides a handler to handle the specified alarm. Designed for use with
  * {@link AlarmHandlerScheduleMap}, which allows for disambiguating between
  * different alarms.
+ *
+ * Also provides an optional `runAtStart` property that will immediately fire
+ * the handler at service start for the first time instead of waiting for the
+ * first scheduled run to execute.
  */
 export type AlarmHandlerSchedule = {
   schedule: AlarmSchedule
   handler: (alarm?: Alarms.Alarm) => void
+  runAtStart?: boolean
 }
 
 /**
@@ -114,8 +119,12 @@ export default abstract class BaseService<Events extends ServiceLifecycleEvents>
   protected async internalStartService(): Promise<void> {
     const scheduleEntries = Object.entries(this.alarmSchedules)
 
-    scheduleEntries.forEach(([name, { schedule }]) => {
+    scheduleEntries.forEach(([name, { schedule, runAtStart, handler }]) => {
       browser.alarms.create(name, schedule)
+
+      if (runAtStart) {
+        handler()
+      }
     })
 
     if (scheduleEntries.length > 0) {

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -144,6 +144,7 @@ export default class ChainService extends BaseService<Events> {
         handler: () => {
           this.handleHistoricAssetTransferAlarm()
         },
+        runAtStart: true,
       },
     })
 

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -75,6 +75,7 @@ export default class IndexingService extends BaseService<Events> {
           periodInMinutes: 30,
         },
         handler: () => this.handleTokenAlarm(),
+        runAtStart: true,
       },
       prices: {
         schedule: {
@@ -82,6 +83,7 @@ export default class IndexingService extends BaseService<Events> {
           periodInMinutes: 10,
         },
         handler: () => this.handlePriceAlarm(),
+        runAtStart: true,
       },
     })
   }

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -212,6 +212,9 @@ export default class IndexingService extends BaseService<Events> {
         // default list and add any non-zero tokens to the tracking list
         const balances = await this.retrieveTokenBalances(addressNetwork)
 
+        // FIXME Refactor this to only update prices for tokens with balances.
+        await this.handlePriceAlarm()
+
         // Every asset we have that hasn't already been balance checked and is
         // on the currently selected network should be checked once.
         //

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -390,7 +390,7 @@ export default class IndexingService extends BaseService<Events> {
       const measuredAt = Date.now()
       const activeAssetPrices = await getEthereumTokenPrices(
         Object.keys(activeAssetsByAddress),
-        "USD"
+        USD
       )
       Object.entries(activeAssetPrices).forEach(
         ([contractAddress, unitPricePoint]) => {
@@ -400,7 +400,7 @@ export default class IndexingService extends BaseService<Events> {
             const pricePoint = {
               pair: [asset, USD],
               amounts: [
-                BigInt(1),
+                1n * 10n ** BigInt(asset.decimals),
                 BigInt(
                   Math.trunc(
                     (Number(unitPricePoint.unitPrice.amount) /

--- a/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
+++ b/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
@@ -94,20 +94,22 @@ export default function AccountsNotificationPanelAccounts(): ReactElement {
         {accountAddresses.map((item, index) => {
           const lowerCaseItem = item.toLocaleLowerCase()
           return (
-            <button
-              type="button"
-              onClick={() => {
-                setSelectedWallet(0)
-                setSelectedAccount(index)
-                dispatch(setSelectedAccount(lowerCaseItem))
-              }}
-            >
-              <AccountsNotificationPanelAccountItem
-                key={lowerCaseItem}
-                address={lowerCaseItem.slice(0, 16)}
-                isSelected={lowerCaseItem === selectedAccount}
-              />
-            </button>
+            <li key={item}>
+              <button
+                type="button"
+                onClick={() => {
+                  setSelectedWallet(0)
+                  setSelectedAccount(index)
+                  dispatch(setSelectedAccount(lowerCaseItem))
+                }}
+              >
+                <AccountsNotificationPanelAccountItem
+                  key={lowerCaseItem}
+                  address={lowerCaseItem.slice(0, 16)}
+                  isSelected={lowerCaseItem === selectedAccount}
+                />
+              </button>
+            </li>
           )
         })}
       </ul>

--- a/ui/components/Core/CorePage.tsx
+++ b/ui/components/Core/CorePage.tsx
@@ -55,11 +55,10 @@ export default function CorePage(props: Props): ReactElement {
       <div className="page">
         <div className="alpha_label">Alpha</div>
         {hasTopBar ? (
-          <button
-            type="button"
-            className="top_menu_wrap"
-            onClick={handleOpenHiddenDevMenu}
-          >
+          // Don't lint the extremely-custom-behavior completely-not-accessible
+          // hidden dev menu for now.
+          // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+          <div className="top_menu_wrap" onClick={handleOpenHiddenDevMenu}>
             <TopMenu
               toggleOpenProtocolList={() => {
                 setIsProtocolListOpen(!isProtocolListOpen)
@@ -68,7 +67,7 @@ export default function CorePage(props: Props): ReactElement {
                 setIsNotificationsOpen(!isNotificationsOpen)
               }}
             />
-          </button>
+          </div>
         ) : null}
         <div className="page_content">{children}</div>
         {hasTabBar ? <TabBar /> : null}

--- a/ui/components/Overview/OverviewAssetsTable.tsx
+++ b/ui/components/Overview/OverviewAssetsTable.tsx
@@ -35,10 +35,10 @@ export default function OverviewAssetsTable(props: Props): ReactElement {
               </div>
             </td>
             <td>
-              {asset.localizedPricePerToken ? (
+              {asset.localizedUnitPrice ? (
                 <div>
                   <span className="lighter_color">$</span>
-                  {asset.localizedPricePerToken}
+                  {asset.localizedUnitPrice}
                 </div>
               ) : (
                 <div className="loading_wrap">

--- a/ui/components/TabBar/TabBar.tsx
+++ b/ui/components/TabBar/TabBar.tsx
@@ -16,7 +16,11 @@ export default function TabBar(): ReactElement {
   return (
     <nav>
       {tabs.map((tabName) => (
-        <TabBarIcon name={tabName} isActive={activeTabName === tabName} />
+        <TabBarIcon
+          key={tabName}
+          name={tabName}
+          isActive={activeTabName === tabName}
+        />
       ))}
       <style jsx>
         {`

--- a/ui/components/TopMenu/TopMenu.tsx
+++ b/ui/components/TopMenu/TopMenu.tsx
@@ -29,16 +29,13 @@ export default function TopMenu(props: Props): ReactElement {
   return (
     <div className="nav_wrap">
       <nav className="standard_width_padded">
-        <button type="button" onClick={toggleOpenProtocolList}>
-          <TopMenuProtocolSwitcher />
-        </button>
-        <button type="button" onClick={toggleOpenNotifications}>
-          <TopMenuProfileButton
-            address={truncatedAddress}
-            nickname={name || undefined}
-            avatar={avatarURL || undefined}
-          />
-        </button>
+        <TopMenuProtocolSwitcher onClick={toggleOpenProtocolList} />
+        <TopMenuProfileButton
+          address={truncatedAddress}
+          nickname={name || undefined}
+          avatar={avatarURL || undefined}
+          onClick={toggleOpenNotifications}
+        />
       </nav>
       <style jsx>
         {`

--- a/ui/components/TopMenu/TopMenuProfileButton.tsx
+++ b/ui/components/TopMenu/TopMenuProfileButton.tsx
@@ -4,10 +4,11 @@ export default function TopMenuProfileButton(props: {
   address: string
   nickname?: string
   avatar?: string
+  onClick?: () => void
 }): ReactElement {
-  const { address, nickname, avatar } = props
+  const { address, nickname, avatar, onClick } = props
   return (
-    <button type="button">
+    <button type="button" onClick={onClick}>
       {nickname ?? address}
       <div className="avatar" />
       <style jsx>

--- a/ui/components/TopMenu/TopMenuProtocolSwitcher.tsx
+++ b/ui/components/TopMenu/TopMenuProtocolSwitcher.tsx
@@ -1,8 +1,14 @@
 import React, { ReactElement } from "react"
 
-export default function TopMenuProtocolSwitcher(): ReactElement {
+type Props = {
+  onClick?: () => void
+}
+
+export default function TopMenuProtocolSwitcher({
+  onClick,
+}: Props): ReactElement {
   return (
-    <button type="button">
+    <button type="button" onClick={onClick}>
       Ethereum
       <span className="icon_chevron_down" />
       <style jsx>


### PR DESCRIPTION
During testing, we realized the asset price point conversions landed
in #490 weren't working quite as expected. This PR fixes that issue, as
well as a handful of others:
- All remaining React warnings in common paths are gone.
- Certain lookups that were waiting 1 minute to run due to being hooked up
  as alarms now run immediately.
- Initial balance checks for a new account are immediately followed by price
  checks for those assets.