### PR TITLE
Don't bubble out empty token balances from Alchemy

### DIFF
--- a/background/lib/alchemy.ts
+++ b/background/lib/alchemy.ts
@@ -200,27 +200,33 @@ export async function getTokenBalances(
   }
 
   // TODO log balances with errors, consider returning an error type
-  return json.tokenBalances
-    .filter(
-      (
-        b
-      ): b is typeof json["tokenBalances"][0] & {
-        tokenBalance: Exclude<
-          typeof json["tokenBalances"][0]["tokenBalance"],
-          null
-        >
-      } => b.error === null && b.tokenBalance !== null
-    )
-    .map((tokenBalance) => {
-      let balance = tokenBalance.tokenBalance
-      if (balance.length > 66) {
-        balance = balance.substring(0, 66)
-      }
-      return {
-        contractAddress: tokenBalance.contractAddress,
-        amount: balance === "0x" ? BigInt(0) : BigInt(balance),
-      }
-    })
+  return (
+    json.tokenBalances
+      .filter(
+        (
+          b
+        ): b is typeof json["tokenBalances"][0] & {
+          tokenBalance: Exclude<
+            typeof json["tokenBalances"][0]["tokenBalance"],
+            null
+          >
+        } => b.error === null && b.tokenBalance !== null
+      )
+      // A hex value of 0x without any subsequent numbers generally means "no
+      // value" (as opposed to 0) in Ethereum implementations, so filter it out
+      // as effectively undefined.
+      .filter(({ tokenBalance }) => tokenBalance !== "0x")
+      .map((tokenBalance) => {
+        let balance = tokenBalance.tokenBalance
+        if (balance.length > 66) {
+          balance = balance.substring(0, 66)
+        }
+        return {
+          contractAddress: tokenBalance.contractAddress,
+          amount: BigInt(balance),
+        }
+      })
+  )
 }
 
 // JSON Type Definition for the Alchemy token metadata API.


### PR DESCRIPTION
In certain cases, Alchemy returns token balance data with a token
balance of `0x`. In these cases, Alchemy has no data for the token
balance in question—however, that data may be available elsewhere.

Originally, this result was converted into a 0 balance, which would
result in updating the recorded balance elsewhere in the extension
to 0, manifesting in the token “disappearing”. getTokenBalances now
discards these entries entirely, letting any existing balance stand
on its own.