### PR TITLE
Wen Account Selector: Fill in the rest of the account selector data, adjust the wallet tab to only display current account

### DIFF
--- a/background/index.ts
+++ b/background/index.ts
@@ -5,11 +5,13 @@ import { AnyAction } from "@reduxjs/toolkit"
 
 import Main from "./main"
 import { encodeJSON, decodeJSON } from "./lib/utils"
-import logger from "./lib/logger"
+
+import { RootState } from "./redux-slices"
 
 export { browser }
 
-export type RootState = ReturnType<Main["store"]["getState"]>
+export type { RootState }
+
 export type BackgroundDispatch = Main["store"]["dispatch"]
 
 /**

--- a/background/redux-slices/accounts.ts
+++ b/background/redux-slices/accounts.ts
@@ -294,7 +294,12 @@ export const emitter = new Emittery<Events>()
 export const addAddressNetwork = createBackgroundAsyncThunk(
   "account/addAccount",
   async (addressNetwork: AddressNetwork, { dispatch }) => {
-    dispatch(loadAccount(addressNetwork.address))
-    await emitter.emit("addAccount", addressNetwork)
+    const normalizedAddressNetwork = {
+      address: addressNetwork.address.toLowerCase(),
+      network: addressNetwork.network,
+    }
+
+    dispatch(loadAccount(normalizedAddressNetwork.address))
+    await emitter.emit("addAccount", normalizedAddressNetwork)
   }
 )

--- a/background/redux-slices/index.ts
+++ b/background/redux-slices/index.ts
@@ -8,7 +8,7 @@ import swapReducer from "./0x-swap"
 import transactionConstructionReducer from "./transaction-construction"
 import uiReducer from "./ui"
 
-export default combineReducers({
+const mainReducer = combineReducers({
   account: accountsReducer,
   assets: assetsReducer,
   activities: activitiesReducer,
@@ -17,3 +17,7 @@ export default combineReducers({
   transactionConstruction: transactionConstructionReducer,
   ui: uiReducer,
 })
+
+export default mainReducer
+
+export type RootState = ReturnType<typeof mainReducer>

--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -32,21 +32,6 @@ export const selectAccountAndTimestampedActivities = createSelector(
   getAssetsState,
   selectHideDust,
   (account, assets, hideDust) => {
-    // Derive activities with timestamps included
-    const activity = account.combinedData.activity.map((activityItem) => {
-      const isSent =
-        activityItem.from.toLowerCase() ===
-        Object.keys(account.accountsData)[0].toLowerCase()
-
-      return {
-        ...activityItem,
-        ...(activityItem.blockHeight && {
-          timestamp: account?.blocks[activityItem.blockHeight]?.timestamp,
-        }),
-        isSent,
-      }
-    })
-
     // Keep a tally of the total user value; undefined if no main currency data
     // is available.
     let totalMainCurrencyAmount: number | undefined
@@ -102,10 +87,8 @@ export const selectAccountAndTimestampedActivities = createSelector(
               desiredDecimals
             )
           : undefined,
-        activity: account.combinedData.activity,
       },
       accountData: account.accountsData,
-      activity,
     }
   }
 )

--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -98,7 +98,7 @@ export const selectCurrentAccountBalances = createSelector(
   getAssetsState,
   selectHideDust,
   (currentAccount, assets, hideDust) => {
-    if (currentAccount === "loading") {
+    if (typeof currentAccount === "undefined" || currentAccount === "loading") {
       return undefined
     }
 

--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -22,6 +22,9 @@ const mainCurrencySymbol = "USD"
 const userValueDustThreshold = 2
 
 const getAccountState = (state: RootState) => state.account
+const getCurrentAccountState = (state: RootState) => {
+  return state.account.accountsData[state.ui.selectedAccount.address]
+}
 const getAssetsState = (state: RootState) => state.assets
 
 export const selectAccountAndTimestampedActivities = createSelector(
@@ -103,6 +106,73 @@ export const selectAccountAndTimestampedActivities = createSelector(
       },
       accountData: account.accountsData,
       activity,
+    }
+  }
+)
+
+export const selectCurrentAccountBalances = createSelector(
+  getCurrentAccountState,
+  getAssetsState,
+  selectHideDust,
+  (currentAccount, assets, hideDust) => {
+    if (currentAccount === "loading") {
+      return undefined
+    }
+
+    // Keep a tally of the total user value; undefined if no main currency data
+    // is available.
+    let totalMainCurrencyAmount: number | undefined
+
+    // Derive account "assets"/assetAmount which include USD values using
+    // data from the assets slice
+    const accountAssetAmounts = Object.values(currentAccount.balances)
+      .map<CompleteAssetAmount>(({ assetAmount }) => {
+        const assetPricePoint = selectAssetPricePoint(
+          assets,
+          assetAmount.asset.symbol,
+          mainCurrencySymbol
+        )
+
+        if (assetPricePoint) {
+          const enrichedAssetAmount = enrichAssetAmountWithDecimalValues(
+            enrichAssetAmountWithMainCurrencyValues(
+              assetAmount,
+              assetPricePoint,
+              desiredDecimals
+            ),
+            desiredDecimals
+          )
+
+          if (typeof enrichedAssetAmount.mainCurrencyAmount !== "undefined") {
+            totalMainCurrencyAmount ??= 0 // initialize if needed
+            totalMainCurrencyAmount += enrichedAssetAmount.mainCurrencyAmount
+          }
+
+          return enrichedAssetAmount
+        }
+
+        return enrichAssetAmountWithDecimalValues(assetAmount, desiredDecimals)
+      })
+      .filter((assetAmount) => {
+        const isNotDust =
+          typeof assetAmount.mainCurrencyAmount === "undefined"
+            ? true
+            : assetAmount.mainCurrencyAmount > userValueDustThreshold
+        const isPresent = assetAmount.decimalAmount > 0
+
+        // Hide dust and missing amounts.
+        return hideDust ? isNotDust && isPresent : isPresent
+      })
+
+    return {
+      assetAmounts: accountAssetAmounts,
+      totalMainCurrencyValue: totalMainCurrencyAmount
+        ? formatCurrencyAmount(
+            mainCurrencySymbol,
+            totalMainCurrencyAmount,
+            desiredDecimals
+          )
+        : undefined,
     }
   }
 )

--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -1,0 +1,109 @@
+import { createSelector } from "@reduxjs/toolkit"
+import { selectHideDust } from "../ui"
+import { RootState } from ".."
+import { CompleteAssetAmount } from "../accounts"
+import { selectAssetPricePoint } from "../assets"
+import {
+  enrichAssetAmountWithDecimalValues,
+  enrichAssetAmountWithMainCurrencyValues,
+  formatCurrencyAmount,
+} from "../utils/asset-utils"
+import {
+  assetAmountToDesiredDecimals,
+  convertAssetAmountViaPricePoint,
+} from "../../assets"
+
+// TODO What actual precision do we want here? Probably more than 2
+// TODO decimals? Maybe it's configurable?
+const desiredDecimals = 2
+// TODO Make this a setting.
+const mainCurrencySymbol = "USD"
+// TODO Make this a setting.
+const userValueDustThreshold = 2
+
+const getAccountState = (state: RootState) => state.account
+const getAssetsState = (state: RootState) => state.assets
+
+// eslint-disable-next-line import/prefer-default-export
+export const selectAccountAndTimestampedActivities = createSelector(
+  getAccountState,
+  getAssetsState,
+  selectHideDust,
+  (account, assets, hideDust) => {
+    // Derive activities with timestamps included
+    const activity = account.combinedData.activity.map((activityItem) => {
+      const isSent =
+        activityItem.from.toLowerCase() ===
+        Object.keys(account.accountsData)[0].toLowerCase()
+
+      return {
+        ...activityItem,
+        ...(activityItem.blockHeight && {
+          timestamp: account?.blocks[activityItem.blockHeight]?.timestamp,
+        }),
+        isSent,
+      }
+    })
+
+    // Keep a tally of the total user value; undefined if no main currency data
+    // is available.
+    let totalMainCurrencyAmount: number | undefined
+
+    // Derive account "assets"/assetAmount which include USD values using
+    // data from the assets slice
+    const accountAssets = account.combinedData.assets
+      .map<CompleteAssetAmount>((assetItem) => {
+        const assetPricePoint = selectAssetPricePoint(
+          assets,
+          assetItem.asset.symbol,
+          mainCurrencySymbol
+        )
+
+        if (assetPricePoint) {
+          const enrichedAssetAmount = enrichAssetAmountWithDecimalValues(
+            enrichAssetAmountWithMainCurrencyValues(
+              assetItem,
+              assetPricePoint,
+              desiredDecimals
+            ),
+            desiredDecimals
+          )
+
+          if (typeof enrichedAssetAmount.mainCurrencyAmount !== "undefined") {
+            totalMainCurrencyAmount ??= 0 // initialize if needed
+            totalMainCurrencyAmount += enrichedAssetAmount.mainCurrencyAmount
+          }
+
+          return enrichedAssetAmount
+        }
+
+        return enrichAssetAmountWithDecimalValues(assetItem, desiredDecimals)
+      })
+      .filter((assetItem) => {
+        const isNotDust =
+          typeof assetItem.mainCurrencyAmount === "undefined"
+            ? true
+            : assetItem.mainCurrencyAmount > userValueDustThreshold
+        const isPresent = assetItem.decimalAmount > 0
+
+        // Hide dust and missing amounts.
+        return hideDust ? isNotDust && isPresent : isPresent
+      })
+
+    return {
+      combinedData: {
+        assets: accountAssets,
+        totalMainCurrencyValue: totalMainCurrencyAmount
+          ? formatCurrencyAmount(
+              mainCurrencySymbol,
+              totalMainCurrencyAmount,
+              desiredDecimals
+            )
+          : undefined,
+        activity: account.combinedData.activity,
+      },
+      accountData: account.accountsData,
+      activity,
+    }
+  }
+)

--- a/background/redux-slices/selectors/index.ts
+++ b/background/redux-slices/selectors/index.ts
@@ -1,0 +1,2 @@
+export * from "./activitiesSelectors"
+export * from "./accountsSelectors"

--- a/src/background-ui.ts
+++ b/src/background-ui.ts
@@ -1,4 +1,5 @@
-import { browser, newProxyStore } from "@tallyho/tally-background"
+// TODO This is meant to do UI notifications, but is incomplete.
+/* import { browser, newProxyStore } from "@tallyho/tally-background"
 
 newProxyStore().then((backgroundStore) => {
   // undefined if no account has been resolved, string array with the latest
@@ -39,4 +40,4 @@ newProxyStore().then((backgroundStore) => {
       latestActivityHashes = undefined
     }
   })
-})
+}) */

--- a/ui/components/AccountsNotificationPanel/AccountsNotificationPanel.tsx
+++ b/ui/components/AccountsNotificationPanel/AccountsNotificationPanel.tsx
@@ -11,7 +11,7 @@ export default function TopMenuNotifications(): ReactElement {
       <SharedPanelSwitcher
         setPanelNumber={setPanelNumber}
         panelNumber={panelNumber}
-        panelNames={["Accounts", "Notifications"]}
+        panelNames={["Accounts"]}
       />
       {panelNumber === 1 ? (
         <AccountsNotificationPanelNotifications />

--- a/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccountItem.tsx
+++ b/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccountItem.tsx
@@ -72,6 +72,7 @@ export default function AccountsNotificationPanelAccountItem(
           background-size: cover;
           width: 48px;
           height: 48px;
+          border-radius: 12px;
         }
         .avatar_selected_outline {
           width: 52px;

--- a/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccountItem.tsx
+++ b/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccountItem.tsx
@@ -1,14 +1,24 @@
 import React, { ReactElement } from "react"
 
+import { AccountTotal } from "@tallyho/tally-background/redux-slices/selectors"
+
+import SharedLoadingSpinner from "../Shared/SharedLoadingSpinner"
+
 interface Props {
   isSelected: boolean
-  address: string
+  accountTotal: AccountTotal
 }
 
 export default function AccountsNotificationPanelAccountItem(
   props: Props
 ): ReactElement {
-  const { isSelected, address } = props
+  const { isSelected, accountTotal: account } = props
+  const {
+    shortenedAddress,
+    name,
+    avatarURL,
+    localizedTotalMainCurrencyAmount,
+  } = account
 
   return (
     <li className="standard_width">
@@ -22,15 +32,24 @@ export default function AccountsNotificationPanelAccountItem(
         )}
 
         <div className="info">
-          <div className="address_name">Foxrunner</div>
-          <div className="address">{address}</div>
+          <div className="address_name">
+            {typeof name === "undefined" ? shortenedAddress : name}
+          </div>
+          <div className="address">
+            {typeof name !== "undefined" ? shortenedAddress : ""}
+          </div>
         </div>
       </div>
       <div className="right">
         <div className="balance_status">
-          <div className="balance">
-            <span className="lighter">$</span>4,124.23
-          </div>
+          {typeof localizedTotalMainCurrencyAmount === "undefined" ? (
+            <SharedLoadingSpinner size="small" />
+          ) : (
+            <div className="balance">
+              <span className="lighter">$</span>{" "}
+              {localizedTotalMainCurrencyAmount}
+            </div>
+          )}
           {isSelected ? (
             <div className="connected_status">Connected</div>
           ) : null}
@@ -48,7 +67,8 @@ export default function AccountsNotificationPanelAccountItem(
           height: 52px;
         }
         .avatar {
-          background: url("./images/avatar@2x.png") center no-repeat;
+          background: url("${avatarURL ?? "./images/avatar@2x.png"}") center
+            no-repeat;
           background-size: cover;
           width: 48px;
           height: 48px;

--- a/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
+++ b/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useState } from "react"
+import React, { ReactElement } from "react"
 import { setSelectedAccount } from "@tallyho/tally-background/redux-slices/ui"
 import { selectAccountTotals } from "@tallyho/tally-background/redux-slices/selectors"
 import AccountsNotificationPanelAccountItem from "./AccountsNotificationPanelAccountItem"
@@ -80,15 +80,6 @@ export default function AccountsNotificationPanelAccounts(): ReactElement {
   const selectedAccount = useBackgroundSelector((background) => {
     return background.ui.selectedAccount?.address
   })
-
-  useEffect(() => {
-    function selectFirstAccountIfNoneSelected() {
-      if (selectedAccount === "" && accountTotals[0]) {
-        dispatch(setSelectedAccount(accountTotals[0].address.toLowerCase()))
-      }
-    }
-    selectFirstAccountIfNoneSelected()
-  }, [dispatch, accountTotals, selectedAccount])
 
   return (
     <div>

--- a/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
+++ b/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
@@ -65,7 +65,7 @@ function WalletName() {
         }
         .right {
           align-items: center;
-          display: flex;
+          display: none; // TODO Display when Add address is hooked up.
         }
       `}</style>
     </>

--- a/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
+++ b/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
@@ -73,8 +73,6 @@ function WalletName() {
 }
 
 export default function AccountsNotificationPanelAccounts(): ReactElement {
-  const [selectedWallet, setSelectedWallet] = useState(0)
-
   const dispatch = useBackgroundDispatch()
 
   const accountTotals = useBackgroundSelector(selectAccountTotals)
@@ -103,8 +101,6 @@ export default function AccountsNotificationPanelAccounts(): ReactElement {
               <button
                 type="button"
                 onClick={() => {
-                  setSelectedWallet(0)
-                  setSelectedAccount(index)
                   dispatch(setSelectedAccount(lowerCaseAddress))
                 }}
               >

--- a/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
+++ b/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, useEffect, useState } from "react"
 import { setSelectedAccount } from "@tallyho/tally-background/redux-slices/ui"
+import { selectAccountTotals } from "@tallyho/tally-background/redux-slices/selectors"
 import AccountsNotificationPanelAccountItem from "./AccountsNotificationPanelAccountItem"
 import SharedButton from "../Shared/SharedButton"
 import { useBackgroundDispatch, useBackgroundSelector } from "../../hooks"
@@ -9,9 +10,8 @@ function WalletName() {
     <>
       <div className="wallet_title">
         <div className="left">
-          <div className="icon_wallet" />
-          Trezor
-          <div className="icon_edit" />
+          <div className="icon_eye" />
+          Read-only mode
         </div>
         <div className="right">
           <SharedButton
@@ -37,6 +37,13 @@ function WalletName() {
           align-items: center;
           display: flex;
           justify-content: space-between;
+        }
+        .icon_eye {
+          background: url("./images/eye@2x.png");
+          background-size: cover;
+          width: 24px;
+          height: 24px;
+          margin: 0px 7px 0px 10px;
         }
         .icon_wallet {
           background: url("./images/wallet_kind_icon@2x.png") center no-repeat;
@@ -70,9 +77,7 @@ export default function AccountsNotificationPanelAccounts(): ReactElement {
 
   const dispatch = useBackgroundDispatch()
 
-  const accountAddresses = useBackgroundSelector((background) => {
-    return Object.keys(background.account.accountsData)
-  })
+  const accountTotals = useBackgroundSelector(selectAccountTotals)
 
   const selectedAccount = useBackgroundSelector((background) => {
     return background.ui.selectedAccount?.address
@@ -80,33 +85,33 @@ export default function AccountsNotificationPanelAccounts(): ReactElement {
 
   useEffect(() => {
     function selectFirstAccountIfNoneSelected() {
-      if (selectedAccount === "" && accountAddresses[0]) {
-        dispatch(setSelectedAccount(accountAddresses[0].toLowerCase()))
+      if (selectedAccount === "" && accountTotals[0]) {
+        dispatch(setSelectedAccount(accountTotals[0].address.toLowerCase()))
       }
     }
     selectFirstAccountIfNoneSelected()
-  }, [dispatch, accountAddresses, selectedAccount])
+  }, [dispatch, accountTotals, selectedAccount])
 
   return (
     <div>
       <WalletName />
       <ul>
-        {accountAddresses.map((item, index) => {
-          const lowerCaseItem = item.toLocaleLowerCase()
+        {accountTotals.map((accountTotal, index) => {
+          const lowerCaseAddress = accountTotal.address.toLocaleLowerCase()
           return (
-            <li key={item}>
+            <li key={lowerCaseAddress}>
               <button
                 type="button"
                 onClick={() => {
                   setSelectedWallet(0)
                   setSelectedAccount(index)
-                  dispatch(setSelectedAccount(lowerCaseItem))
+                  dispatch(setSelectedAccount(lowerCaseAddress))
                 }}
               >
                 <AccountsNotificationPanelAccountItem
-                  key={lowerCaseItem}
-                  address={lowerCaseItem.slice(0, 16)}
-                  isSelected={lowerCaseItem === selectedAccount}
+                  key={lowerCaseAddress}
+                  accountTotal={accountTotal}
+                  isSelected={lowerCaseAddress === selectedAccount}
                 />
               </button>
             </li>

--- a/ui/components/Shared/SharedProgressIndicator.tsx
+++ b/ui/components/Shared/SharedProgressIndicator.tsx
@@ -9,7 +9,7 @@ export default function SharedProgressIndicator(props: {
   const { activeStep, numberOfSteps, onProgressStepClicked } = props
 
   return (
-    <div className="indictor_wrap">
+    <div className="indicator_wrap">
       {Array(numberOfSteps)
         .fill(undefined)
         .map((_, index) => {
@@ -17,6 +17,9 @@ export default function SharedProgressIndicator(props: {
             <button
               aria-label="step"
               type="button"
+              // The nature of this is that the key and index are the same.
+              // eslint-disable-next-line react/no-array-index-key
+              key={index}
               className={classNames("step", {
                 active: index === activeStep - 1,
               })}
@@ -42,7 +45,7 @@ export default function SharedProgressIndicator(props: {
             width: 16px;
             background: var(--trophy-gold);
           }
-          .indictor_wrap {
+          .indicator_wrap {
             display: flex;
           }
         `}

--- a/ui/components/TopMenu/TopMenuProfileButton.tsx
+++ b/ui/components/TopMenu/TopMenuProfileButton.tsx
@@ -27,6 +27,7 @@ export default function TopMenuProfileButton(props: {
             background-color: white;
             margin-left: 8px;
             background: url("${avatar ?? "./images/portrait.png"}");
+            background-size: cover;
           }
         `}
       </style>

--- a/ui/components/Wallet/WalletActivityList.tsx
+++ b/ui/components/Wallet/WalletActivityList.tsx
@@ -1,20 +1,22 @@
 import React, { ReactElement, useCallback } from "react"
 import { setShowingActivityDetail } from "@tallyho/tally-background/redux-slices/ui"
-import { selectCurrentAccountActivitiesWithTimestamps } from "@tallyho/tally-background/redux-slices/selectors"
+import { ActivityItem } from "@tallyho/tally-background/redux-slices/activities"
 import { useBackgroundDispatch, useBackgroundSelector } from "../../hooks"
 import SharedSlideUpMenu from "../Shared/SharedSlideUpMenu"
 import SharedLoadingSpinner from "../Shared/SharedLoadingSpinner"
 import WalletActivityDetails from "./WalletActivityDetails"
 import WalletActivityListItem from "./WalletActivityListItem"
 
-export default function WalletActivityList(): ReactElement {
+type Props = {
+  activities: ActivityItem[]
+}
+
+export default function WalletActivityList({
+  activities,
+}: Props): ReactElement {
   const dispatch = useBackgroundDispatch()
   const { showingActivityDetail } = useBackgroundSelector(
     (background) => background.ui
-  )
-
-  const activities = useBackgroundSelector(
-    selectCurrentAccountActivitiesWithTimestamps
   )
 
   const handleOpen = useCallback(

--- a/ui/components/Wallet/WalletActivityList.tsx
+++ b/ui/components/Wallet/WalletActivityList.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useCallback } from "react"
 import { setShowingActivityDetail } from "@tallyho/tally-background/redux-slices/ui"
-import { selectCurrentAccountActivitiesWithTimestamps } from "@tallyho/tally-background/redux-slices/selectors/activitiesSelectors"
+import { selectCurrentAccountActivitiesWithTimestamps } from "@tallyho/tally-background/redux-slices/selectors"
 import { useBackgroundDispatch, useBackgroundSelector } from "../../hooks"
 import SharedSlideUpMenu from "../Shared/SharedSlideUpMenu"
 import SharedLoadingSpinner from "../Shared/SharedLoadingSpinner"

--- a/ui/pages/Onboarding/OnboardingViewOnlyWallet.tsx
+++ b/ui/pages/Onboarding/OnboardingViewOnlyWallet.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement, useCallback, useState } from "react"
 import { Redirect } from "react-router-dom"
 import { addAddressNetwork } from "@tallyho/tally-background/redux-slices/accounts"
 import { getEthereumNetwork } from "@tallyho/tally-background/lib/utils"
+import { setSelectedAccount } from "@tallyho/tally-background/redux-slices/ui"
 import { useBackgroundDispatch } from "../../hooks"
 import SharedInput from "../../components/Shared/SharedInput"
 import SharedButton from "../../components/Shared/SharedButton"
@@ -20,12 +21,13 @@ export default function OnboardingViewOnlyWallet(): ReactElement {
 
   const handleSubmitViewOnlyAddress = useCallback(async () => {
     if (checkIfPlausibleETHAddress(address)) {
-      await dispatch(
+      dispatch(
         addAddressNetwork({
           address,
           network: getEthereumNetwork(),
         })
       )
+      dispatch(setSelectedAccount(address))
       setRedirect(true)
     } else {
       alert("Please enter a valid address")

--- a/ui/pages/Overview.tsx
+++ b/ui/pages/Overview.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from "react"
-import { selectAccountAndTimestampedActivities } from "@tallyho/tally-background/redux-slices/accounts"
+import { selectAccountAndTimestampedActivities } from "@tallyho/tally-background/redux-slices/selectors"
 import { useBackgroundSelector } from "../hooks"
 import CorePage from "../components/Core/CorePage"
 import OverviewAssetsTable from "../components/Overview/OverviewAssetsTable"

--- a/ui/pages/Send.tsx
+++ b/ui/pages/Send.tsx
@@ -1,5 +1,5 @@
 import { isAddress } from "@ethersproject/address"
-import { selectAccountAndTimestampedActivities } from "@tallyho/tally-background/redux-slices/accounts"
+import { selectAccountAndTimestampedActivities } from "@tallyho/tally-background/redux-slices/selectors"
 import {
   selectEstimatedFeesPerGas,
   updateTransactionOptions,

--- a/ui/pages/SingleAsset.tsx
+++ b/ui/pages/SingleAsset.tsx
@@ -1,6 +1,9 @@
 import React, { ReactElement } from "react"
 import { useLocation } from "react-router-dom"
-import { selectCurrentAccountBalances } from "@tallyho/tally-background/redux-slices/selectors"
+import {
+  selectCurrentAccountActivitiesWithTimestamps,
+  selectCurrentAccountBalances,
+} from "@tallyho/tally-background/redux-slices/selectors"
 import { useBackgroundSelector } from "../hooks"
 import CorePage from "../components/Core/CorePage"
 import SharedAssetIcon from "../components/Shared/SharedAssetIcon"
@@ -11,6 +14,12 @@ import BackButton from "../components/Shared/SharedBackButton"
 export default function SingleAsset(): ReactElement {
   const location = useLocation<{ symbol: string }>()
   const { symbol } = location.state
+
+  const filteredActivities = useBackgroundSelector((state) =>
+    selectCurrentAccountActivitiesWithTimestamps(state).filter(
+      ({ token }) => token.symbol === symbol
+    )
+  )
 
   const { asset, localizedMainCurrencyAmount, localizedDecimalAmount } =
     useBackgroundSelector((state) => {
@@ -75,7 +84,7 @@ export default function SingleAsset(): ReactElement {
           <div className="right">Move to Ethereum</div>
         </div>
         <div className="label_light standard_width_padded">Activity</div>
-        <WalletActivityList />
+        <WalletActivityList activities={filteredActivities} />
       </CorePage>
       <style jsx>
         {`

--- a/ui/pages/SingleAsset.tsx
+++ b/ui/pages/SingleAsset.tsx
@@ -79,7 +79,7 @@ export default function SingleAsset(): ReactElement {
             </SharedButton>
           </div>
         </div>
-        <div className="sub_info_seperator_wrap standard_width_padded">
+        <div className="sub_info_separator_wrap standard_width_padded">
           <div className="left">Asset is on: Arbitrum</div>
           <div className="right">Move to Ethereum</div>
         </div>
@@ -88,8 +88,8 @@ export default function SingleAsset(): ReactElement {
       </CorePage>
       <style jsx>
         {`
-          .sub_info_seperator_wrap {
-            display: flex;
+          .sub_info_separator_wrap {
+            display: none; // TODO asset network location and transfer for later
             border: 1px solid var(--green-120);
             border-left: 0px;
             border-right: 0px;

--- a/ui/pages/SingleAsset.tsx
+++ b/ui/pages/SingleAsset.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from "react"
 import { useLocation } from "react-router-dom"
-import { selectAccountAndTimestampedActivities } from "@tallyho/tally-background/redux-slices/accounts"
+import { selectAccountAndTimestampedActivities } from "@tallyho/tally-background/redux-slices/selectors"
 import { useBackgroundSelector } from "../hooks"
 import CorePage from "../components/Core/CorePage"
 import SharedAssetIcon from "../components/Shared/SharedAssetIcon"

--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -6,7 +6,7 @@ import {
   setSwapTrade,
   setSwapAmount,
 } from "@tallyho/tally-background/redux-slices/0x-swap"
-import { selectAccountAndTimestampedActivities } from "@tallyho/tally-background/redux-slices/accounts"
+import { selectAccountAndTimestampedActivities } from "@tallyho/tally-background/redux-slices/selectors"
 import CorePage from "../components/Core/CorePage"
 import SharedAssetInput from "../components/Shared/SharedAssetInput"
 import SharedButton from "../components/Shared/SharedButton"

--- a/ui/pages/Wallet.tsx
+++ b/ui/pages/Wallet.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useState } from "react"
 import { Redirect } from "react-router-dom"
-import { selectAccountAndTimestampedActivities } from "@tallyho/tally-background/redux-slices/selectors"
+import { selectCurrentAccountBalances } from "@tallyho/tally-background/redux-slices/selectors"
 import { useBackgroundSelector } from "../hooks"
 import CorePage from "../components/Core/CorePage"
 import SharedPanelSwitcher from "../components/Shared/SharedPanelSwitcher"
@@ -12,16 +12,19 @@ export default function Wallet(): ReactElement {
   const [panelNumber, setPanelNumber] = useState(0)
 
   //  accountLoading, hasWalletErrorCode
-  const { combinedData, accountData } = useBackgroundSelector(
-    selectAccountAndTimestampedActivities
-  )
+  const accountData = useBackgroundSelector(selectCurrentAccountBalances)
+
+  const { assetAmounts, totalMainCurrencyValue } = accountData ?? {
+    assetAmounts: [],
+    totalMainCurrencyValue: undefined,
+  }
 
   const initializationLoadingTimeExpired = useBackgroundSelector(
     (background) => background.ui?.initializationLoadingTimeExpired
   )
 
   // If an account doesn't exist, display onboarding
-  if (Object.keys(accountData).length === 0) {
+  if (typeof accountData === "undefined") {
     return <Redirect to="/onboarding/infoIntro" />
   }
 
@@ -31,7 +34,7 @@ export default function Wallet(): ReactElement {
         <div className="page_content">
           <div className="section">
             <WalletAccountBalanceControl
-              balance={combinedData.totalMainCurrencyValue}
+              balance={totalMainCurrencyValue}
               initializationLoadingTimeExpired={
                 initializationLoadingTimeExpired
               }
@@ -46,7 +49,7 @@ export default function Wallet(): ReactElement {
             <div className="panel">
               {panelNumber === 0 ? (
                 <WalletAssetList
-                  assetAmounts={combinedData.assets}
+                  assetAmounts={assetAmounts}
                   initializationLoadingTimeExpired={
                     initializationLoadingTimeExpired
                   }

--- a/ui/pages/Wallet.tsx
+++ b/ui/pages/Wallet.tsx
@@ -1,6 +1,9 @@
 import React, { ReactElement, useState } from "react"
 import { Redirect } from "react-router-dom"
-import { selectCurrentAccountBalances } from "@tallyho/tally-background/redux-slices/selectors"
+import {
+  selectCurrentAccountActivitiesWithTimestamps,
+  selectCurrentAccountBalances,
+} from "@tallyho/tally-background/redux-slices/selectors"
 import { useBackgroundSelector } from "../hooks"
 import CorePage from "../components/Core/CorePage"
 import SharedPanelSwitcher from "../components/Shared/SharedPanelSwitcher"
@@ -18,6 +21,9 @@ export default function Wallet(): ReactElement {
     assetAmounts: [],
     totalMainCurrencyValue: undefined,
   }
+  const currentAccountActivities = useBackgroundSelector(
+    selectCurrentAccountActivitiesWithTimestamps
+  )
 
   const initializationLoadingTimeExpired = useBackgroundSelector(
     (background) => background.ui?.initializationLoadingTimeExpired
@@ -55,7 +61,7 @@ export default function Wallet(): ReactElement {
                   }
                 />
               ) : (
-                <WalletActivityList />
+                <WalletActivityList activities={currentAccountActivities} />
               )}
             </div>
           </div>

--- a/ui/pages/Wallet.tsx
+++ b/ui/pages/Wallet.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useState } from "react"
 import { Redirect } from "react-router-dom"
-import { selectAccountAndTimestampedActivities } from "@tallyho/tally-background/redux-slices/accounts"
-import { useBackgroundSelector, useBackgroundDispatch } from "../hooks"
+import { selectAccountAndTimestampedActivities } from "@tallyho/tally-background/redux-slices/selectors"
+import { useBackgroundSelector } from "../hooks"
 import CorePage from "../components/Core/CorePage"
 import SharedPanelSwitcher from "../components/Shared/SharedPanelSwitcher"
 import WalletAssetList from "../components/Wallet/WalletAssetList"
@@ -12,7 +12,7 @@ export default function Wallet(): ReactElement {
   const [panelNumber, setPanelNumber] = useState(0)
 
   //  accountLoading, hasWalletErrorCode
-  const { combinedData, accountData, activity } = useBackgroundSelector(
+  const { combinedData, accountData } = useBackgroundSelector(
     selectAccountAndTimestampedActivities
   )
 

--- a/ui/pages/Wallet.tsx
+++ b/ui/pages/Wallet.tsx
@@ -14,6 +14,10 @@ import WalletAccountBalanceControl from "../components/Wallet/WalletAccountBalan
 export default function Wallet(): ReactElement {
   const [panelNumber, setPanelNumber] = useState(0)
 
+  const hasAccounts = useBackgroundSelector(
+    (state) => Object.keys(state.account.accountsData).length > 0
+  )
+
   //  accountLoading, hasWalletErrorCode
   const accountData = useBackgroundSelector(selectCurrentAccountBalances)
 
@@ -30,7 +34,7 @@ export default function Wallet(): ReactElement {
   )
 
   // If an account doesn't exist, display onboarding
-  if (typeof accountData === "undefined") {
+  if (!hasAccounts) {
     return <Redirect to="/onboarding/infoIntro" />
   }
 


### PR DESCRIPTION
This PR fils in the remaining data in the account selector, as
well as adjusting the wallet and single asset tabs to only display
balances and activity related to the currently-selected account. In
the process, almost all of the combined activity-related code in the
accounts slice is removed, since it was meant to populate this view,
which was never meant to display data across accounts.

The other large refactor here was the introduction of the
`accountsSelectors` file, following @henryboldi's example with the
`activitiesSelectors` file. Both of these are exposed at the top level
via a re-exporting `background/redux-slices/selectors` package that
exposes all internal selectors for the UI to use, which has allowed
some cleanup in typing dependencies to take place (in particular,
allowing the selectors to reference the full state without having to
resort to redeclaring it to avoid circular dependencies).

A few additional tweaks include trying to resolve avatars where
possible, changing the fixed Trezor header to display read-only mode
(for now), and not displaying a name when an account has no associated
ENS name. Also, the single asset page no longer displays placeholder
“this asset is on Arbitrum” language, which was confusing users and is
rooted in unimplemented functionality. These elements are hidden for
now.

<img width="435" alt="Updated account selector" src="https://user-images.githubusercontent.com/8245/144545125-3908a414-55ca-4243-9947-7ad4e1857570.png">