### PR TITLE
ARCHIVED: 🐝  the change: let's give our beloved OGs some dApp goodies

### DIFF
--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -387,7 +387,8 @@ export default class ChainService extends BaseService<Events> {
   }
 
   async send(method: string, params: unknown[]) {
-    return this.pollingProviders.ethereum.send(method, params)
+    return this.websocketProviders.ethereum.send(method, params)
+    // return this.pollingProviders.ethereum.send(method, params)
   }
 
   /* *****************

--- a/env.d.ts
+++ b/env.d.ts
@@ -4,3 +4,29 @@
 // result in a handful of type errors. See PR #196.
 
 declare module "styled-jsx/style"
+interface Window {
+  tally?: {
+    isTally?: boolean
+    on?: (
+      eventName: string | symbol,
+      listener: (...args: any[]) => void
+    ) => unknown
+    removeListener?: (
+      eventName: string | symbol,
+      listener: (...args: any[]) => void
+    ) => unknown
+  }
+  ethereum?: {
+    isMetaMask?: boolean
+    isTally?: boolean
+    on?: (
+      eventName: string | symbol,
+      listener: (...args: any[]) => void
+    ) => unknown
+    removeListener?: (
+      eventName: string | symbol,
+      listener: (...args: any[]) => void
+    ) => unknown
+    autoRefreshOnNetworkChange?: boolean
+  }
+}

--- a/manifest/manifest.development.json
+++ b/manifest/manifest.development.json
@@ -1,13 +1,5 @@
 {
   "background": {
     "scripts": ["dev-utils/extension-reload.js"]
-  },
-  "content_scripts": [
-    {
-      "matches": ["file://*/*", "http://localhost/*", "https://*/*"],
-      "js": ["provider-bridge.js"],
-      "run_at": "document_start",
-      "all_frames": true
-    }
-  ]
+  }
 }

--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -9,6 +9,15 @@
   "content_security_policy": "object-src 'self'; script-src 'self' blob: filesystem: 'unsafe-eval';",
   "web_accessible_resources": ["*.js", "*.json"],
 
+  "content_scripts": [
+    {
+      "matches": ["file://*/*", "http://localhost/*", "https://*/*"],
+      "js": ["provider-bridge.js"],
+      "run_at": "document_start",
+      "all_frames": true
+    }
+  ],
+
   "commands": {
     "_execute_browser_action": {
       "suggested_key": {

--- a/src/window-provider.ts
+++ b/src/window-provider.ts
@@ -116,6 +116,6 @@ class TallyWindowProvider extends EventEmitter {
 }
 
 if (enabled === "true") {
-  // @ts-expect-error I don't really have any way to know the exact type of window.ethereum so it's better to expect error than lie
-  window.ethereum = new TallyWindowProvider()
+  window.tally = new TallyWindowProvider()
+  window.ethereum = window.tally
 }


### PR DESCRIPTION
This PR will integrate the window-provider and provider-bridge into the published extension. 
The `window-provider` is still behind a feature flag so it does not introduce issues until the integration is ready. 
To enable the integration the `isTallyWindowProviderEnabled` has to be set to `true` in the local storage of the given page.

* moved the content script into the main manifest.json — solving the CORS issues as well
* added typing for the window provider because that's always a cosy feeling
* added window.tally
* switched to the websocket provider so subscriptions can also work