### PR TITLE
👻 Fix back button gore

### DIFF
--- a/ui/components/Shared/SharedBackButton.tsx
+++ b/ui/components/Shared/SharedBackButton.tsx
@@ -14,6 +14,7 @@ export default function SharedBackButton(): ReactElement {
       onClick={() => history.goBack()}
     >
       <div className="icon_chevron_left" />
+      Back
       <style jsx>{`
         button {
           color: var(--green-40);
@@ -23,8 +24,6 @@ export default function SharedBackButton(): ReactElement {
           display: flex;
           margin-bottom: 10px;
           margin-top: 2px;
-          position: fixed;
-          top: 25px;
         }
         button:hover {
           color: #fff;

--- a/ui/pages/Onboarding/OnboardingAddWallet.tsx
+++ b/ui/pages/Onboarding/OnboardingAddWallet.tsx
@@ -1,12 +1,14 @@
 import React, { ReactElement } from "react"
-import BackButton from "../../components/Shared/SharedBackButton"
+import SharedBackButton from "../../components/Shared/SharedBackButton"
 import SharedButton from "../../components/Shared/SharedButton"
 
 export default function OnboardingAddWallet(): ReactElement {
   return (
     <section>
       <div className="wordmark" />
-      <BackButton />
+      <div className="back_button_wrap">
+        <SharedBackButton />
+      </div>
       <div className="primary_wrap">
         <div className="choice_wrap">
           <h1 className="serif_header">Explore Tally</h1>
@@ -45,6 +47,10 @@ export default function OnboardingAddWallet(): ReactElement {
             background-size: cover;
             width: 52px;
             height: 25px;
+          }
+          .back_button_wrap {
+            position: fixed;
+            top: 25px;
           }
           .choice_wrap {
             display: flex;

--- a/ui/pages/Onboarding/OnboardingImportMetamask.tsx
+++ b/ui/pages/Onboarding/OnboardingImportMetamask.tsx
@@ -58,7 +58,9 @@ export default function OnboardingImportMetamask(props: Props): ReactElement {
 
   return (
     <section className="center_horizontal">
-      <SharedBackButton />
+      <div className="back_button_wrap">
+        <SharedBackButton />
+      </div>
       <div className="portion top">
         <div className="metamask_onboarding_image" />
         <h1 className="serif_header">Import account</h1>
@@ -82,6 +84,10 @@ export default function OnboardingImportMetamask(props: Props): ReactElement {
           flex-direction: column;
           justify-content: space-between;
           height: 100%;
+        }
+        .back_button_wrap {
+          position: fixed;
+          top: 25px;
         }
         h1 {
           margin: unset;


### PR DESCRIPTION
I had committed the sin of using a fixed position in a shared component. This ended up breaking its display on the single asset page. No longer must we suffer after PR!

For now, it leaves the "back" button text in for all uses. We could add a prop to turn this on and off.