### PR TITLE
Custodian: Add keyring service autolock and track status in keyrings slice

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -35,6 +35,8 @@ import { activityEncountered } from "./redux-slices/activities"
 import { assetsLoaded, newPricePoint } from "./redux-slices/assets"
 import {
   emitter as keyringSliceEmitter,
+  keyringLocked,
+  keyringUnlocked,
   updateKeyrings,
 } from "./redux-slices/keyrings"
 import { initializationLoadingTimeHitLimit } from "./redux-slices/ui"
@@ -440,6 +442,13 @@ export default class Main extends BaseService<never> {
       }
     )
 
+    this.keyringService.emitter.on("locked", async (isLocked) => {
+      if (isLocked) {
+        this.store.dispatch(keyringLocked())
+      } else {
+        this.store.dispatch(keyringUnlocked())
+      }
+    })
     keyringSliceEmitter.on("unlockKeyring", async (password) => {
       await this.keyringService.unlock(password)
     })

--- a/background/redux-slices/keyrings.ts
+++ b/background/redux-slices/keyrings.ts
@@ -16,11 +16,13 @@ type Keyring = {
 type KeyringsState = {
   keyrings: Keyring[]
   importing: false | "pending" | "done"
+  status: "locked" | "unlocked" | "uninitialized"
 }
 
 export const initialState: KeyringsState = {
   keyrings: [],
   importing: false,
+  status: "uninitialized",
 }
 
 export type Events = {
@@ -47,6 +49,8 @@ const keyringsSlice = createSlice({
   name: "keyrings",
   initialState,
   reducers: {
+    keyringLocked: (state) => ({ ...state, status: "locked" }),
+    keyringUnlocked: (state) => ({ ...state, status: "unlocked" }),
     updateKeyrings: (state, { payload: keyrings }: { payload: Keyring[] }) => ({
       ...state,
       keyrings,
@@ -69,7 +73,8 @@ const keyringsSlice = createSlice({
   },
 })
 
-export const { updateKeyrings } = keyringsSlice.actions
+export const { updateKeyrings, keyringLocked, keyringUnlocked } =
+  keyringsSlice.actions
 
 export default keyringsSlice.reducer
 

--- a/background/services/keyring/encryption.ts
+++ b/background/services/keyring/encryption.ts
@@ -86,7 +86,7 @@ export async function deriveSymmetricKeyFromPassword(
     {
       name: "PBKDF2",
       salt: encoder.encode(salt),
-      iterations: 10000,
+      iterations: 1000000,
       hash: "SHA-256",
     },
     derivationKey,

--- a/background/tests/keyring-integration.test.ts
+++ b/background/tests/keyring-integration.test.ts
@@ -87,8 +87,6 @@ describe("KeyringService when uninitialized", () => {
     mockAlarms(mockBrowser)
 
     service = await startKeyringService()
-
-    jest.spyOn(Date, "now").mockReturnValue(dateNowValue)
   })
 
   describe("and locked", () => {
@@ -293,7 +291,7 @@ describe("KeyringService when saving keyrings", () => {
     })
   })
 
-  it("loads encrypted data at instantiation time", async () => {
+  it.only("loads encrypted data at instantiation time", async () => {
     localStorage = {
       tallyVaults: {
         version: 1,
@@ -302,9 +300,9 @@ describe("KeyringService when saving keyrings", () => {
             timeSaved: 1635201991098,
             vault: {
               salt: "XeQ9825jVp7rCq6f2vRySunT/G7Q4rbCcrWxKc/o6KiRCx27eyrQYHciGz4YB3wYCh6Po1liuffN7GIYqkxWJw==",
-              initializationVector: "K5/+ECJ2ei6Fy+x10TutgQ==",
+              initializationVector: "7MJ1ur79CzKwgVAXXcJmQA==",
               cipherText:
-                "9tmTazKJT4tai1HdhT4pVD/o97QJG4KspsCqIp2Gpk0CsWxEIQ4FFJ4ecOOmW6+Gpojgh77N0sQsCU8LL4S43zK/XS5LzTtLNlPq9CQ9IRDt0SZQN4tD7/0/rO5H4wDRCaHxj0g49O5/n87ezlHvijYB+gr0d64OE96TyDkTuZZgrZg4jB4DL3aEebhZp+zKidofi0GCHqqKClzw2nwq7teasRYV6h69KcYibpITB0+FN1QSqP4c9Oblio3VTjfIubC8uINXhnKO5b1Pj6md4N6wj3RyFQVober45vRfl/WAGQF4pHM2KyvWFytZ+tQJ+QgBhTPwrJjMMmabnCok6MWLUApLOdddDHYyUfrUZuxp2xvw/A==",
+                "0bi2msjv2+3zVt2Tjd40i7BNfAuMgbomzCOuce2/l5oiyxsTcqOb871xdDYIvh2g7uHnRXC+BSbopA4xoXpRn/uh4Tjcu8R0dZxsCxCBRAiXVu1RLFojAdhsUwuUZuHn7nhGmu9mrLNKrVh8lFmshYfjtFMgiUFjAIkzEwWvVDvVT0PWVZghg+KXrUd+i3ymVRHYnvz2nZ91fYa3TBIP27ohTxSrNGyccz63Njqk7fCVNACSEXMC7Uqment1h/YpIYG8IGDTfo7/7kz8dSvBQlPlTSgOnC4O9Bey0UEj0LAZXur/i6EyJUxQWlWIXN6is5tEDfWFunrjRmbeqpQBMrPhlhUbGNfbvid5bTGHsgO2Kz9d3w==",
             },
           },
         ],


### PR DESCRIPTION
From the first commit message:

The service supports autolocking depending on internal and external
idle times. Currently both are set to 30 minutes, but although the
markOutsideActivity method exists on the service, it is not yet being
called by any external caller, so the keyring is locked for max 30
minutes no matter what.

This PR also bumps our PBKDF2 iterations per the Least Authority audit.

See #423 .