### PR TITLE
v0.8.1: Patch fix to drop notifications permission

### DIFF
--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Tally",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "The community owned and operated Web3 wallet.",
   "homepage_url": "https://tally.cash",
   "author": "https://tally.cash",

--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -33,7 +33,7 @@
     "default_title": "Tally",
     "default_popup": "popup.html"
   },
-  "permissions": ["alarms", "storage", "unlimitedStorage", "notifications"],
+  "permissions": ["alarms", "storage", "unlimitedStorage"],
   "background": {
     "persistent": true,
     "scripts": ["background.js", "background-ui.js"]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tallyho/tally-extension",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Tally, the community owned and operated Web3 wallet.",
   "main": "index.js",
   "repository": "git@github.com:thesis/tally-extension.git",


### PR DESCRIPTION
This permission isn't currently used by the extension, which has
led to rejection in the Chrome store. Drop it since we don't need
it.

Also included: 

* 🎨 New onboarding and settings paint
* 🚧 Improved infrastructure for autolocking and account listing
* 🐛 Firefox scrollbars, buggy button icon, and weird back button positions begone!
* 🛑 Drop notifications permission to enable Chrome store approval