### PR TITLE
Reverse Safety: Fix autolock clearing keyring metadata for good

### DIFF
--- a/background/redux-slices/keyrings.ts
+++ b/background/redux-slices/keyrings.ts
@@ -66,7 +66,7 @@ const keyringsSlice = createSlice({
       // list as the keyring service clears the in-memory keyrings. For UI
       // purposes, however, we want to continue tracking the keyring metadata,
       // so we ignore an empty list if the keyrings are locked.
-      if (keyrings.length === 0 && state.status !== "locked") {
+      if (keyrings.length === 0 && state.status === "locked") {
         return state
       }
 

--- a/background/redux-slices/selectors/activitiesSelectors.ts
+++ b/background/redux-slices/selectors/activitiesSelectors.ts
@@ -1,27 +1,23 @@
 import { createSelector, EntityId } from "@reduxjs/toolkit"
-import { AccountState } from "../accounts"
-import { UIState } from "../ui"
-import { ActivitiesState, ActivityItem } from "../activities"
+import { RootState } from ".."
+import { ActivityItem } from "../activities"
 
 export const selectCurrentAccountActivitiesWithTimestamps = createSelector(
-  (state: {
-    ui: UIState
-    activities: ActivitiesState
-    account: AccountState
-  }) => state,
-  ({ activities, ui, account }) => {
-    const currentAccountActivities = ui.currentAccount
-      ? activities[ui.currentAccount.address]
+  (state: RootState) => state.ui.currentAccount?.address,
+  (state: RootState) => state.activities,
+  (state: RootState) => state.account.blocks,
+  (currentAddress, activities, blocks) => {
+    const currentAccountActivities = currentAddress
+      ? activities[currentAddress]
       : undefined
     return currentAccountActivities?.ids.map((id: EntityId): ActivityItem => {
       const activityItem = currentAccountActivities.entities[id] as ActivityItem
-      const isSent =
-        activityItem.from.toLowerCase() === ui.currentAccount?.address
+      const isSent = activityItem.from.toLowerCase() === currentAddress
       return {
         ...activityItem,
         timestamp:
           activityItem?.blockHeight &&
-          account.blocks[activityItem?.blockHeight]?.timestamp,
+          blocks[activityItem?.blockHeight]?.timestamp,
         isSent,
       }
     })

--- a/background/redux-slices/selectors/keyringsSelectors.ts
+++ b/background/redux-slices/selectors/keyringsSelectors.ts
@@ -1,20 +1,19 @@
 import { createSelector } from "@reduxjs/toolkit"
 import { RootState } from ".."
 
-export const selectIsCurrentAccountSigner = createSelector(
-  (state: RootState) =>
-    state.keyrings.keyrings.flatMap((keyring) => keyring.addresses),
-  (state: RootState) => state.ui.currentAccount,
-  (addresses, selectedAccount) => addresses.includes(selectedAccount.address)
-)
-
 export const selectKeyringStatus = createSelector(
   (state: RootState) => state.keyrings.status,
   (status) => status
 )
 
 export const selectSigningAddresses = createSelector(
-  (state: RootState) =>
-    state.keyrings.keyrings.flatMap((keyring) => keyring.addresses),
-  (addresses) => addresses
+  (state: RootState) => state.keyrings.keyrings,
+  (keyrings) => keyrings.flatMap((keyring) => keyring.addresses)
+)
+
+export const selectIsCurrentAccountSigner = createSelector(
+  selectSigningAddresses,
+  (state: RootState) => state.ui.currentAccount,
+  (signingAddresses, selectedAccount) =>
+    signingAddresses.includes(selectedAccount.address)
 )

--- a/ui/pages/Send.tsx
+++ b/ui/pages/Send.tsx
@@ -39,9 +39,7 @@ export default function Send(): ReactElement {
 
   const dispatch = useBackgroundDispatch()
 
-  const { accountData } = useBackgroundSelector(
-    selectAccountAndTimestampedActivities
-  )
+  const currentAccount = useBackgroundSelector(({ ui }) => ui.currentAccount)
 
   const openSelectFeeModal = () => {
     setFeeModalOpen(true)
@@ -52,7 +50,7 @@ export default function Send(): ReactElement {
 
   const sendTransactionRequest = async () => {
     const transaction = {
-      from: Object.keys(accountData)[0],
+      from: currentAccount.address,
       to: destinationAddress,
       // eslint-disable-next-line no-underscore-dangle
       value: BigInt(utils.parseEther(amount)._hex),


### PR DESCRIPTION
Had a reversed condition here. While poking around, also found
some quick wins on optimizing selectors, and while looking at that
also found an issue with how we were setting the `from` on send
transactions.