### PR TITLE
Network fees ranges and gas limit handling

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -342,8 +342,8 @@ export default class Main extends BaseService<never> {
           chainID: "1",
           nonce: resolvedNonce,
         }
-        // We use estimateGasLimit only if user did not specify the gas explicitly
-        if (options.gasLimit === 0n) {
+        // We use estimateGasLimit only if user did not specify the gas explicitly or it was set below minimum
+        if (options.gasLimit === 0n || options.gasLimit < 21000n) {
           transaction.gasLimit = await this.chainService.estimateGasLimit(
             getEthereumNetwork(),
             transaction

--- a/background/main.ts
+++ b/background/main.ts
@@ -342,11 +342,13 @@ export default class Main extends BaseService<never> {
           chainID: "1",
           nonce: resolvedNonce,
         }
-
-        transaction.gasLimit = await this.chainService.estimateGasLimit(
-          getEthereumNetwork(),
-          transaction
-        )
+        // We use estimateGasLimit only if user did not specify the gas explicitly
+        if (options.gasLimit === 0n) {
+          transaction.gasLimit = await this.chainService.estimateGasLimit(
+            getEthereumNetwork(),
+            transaction
+          )
+        }
         this.store.dispatch(transactionRequest(transaction))
       }
     })

--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -11,6 +11,9 @@ import {
 import {
   assetAmountToDesiredDecimals,
   convertAssetAmountViaPricePoint,
+  FungibleAssetAmount,
+  UnitPricePoint,
+  unitPricePointForPricePoint,
 } from "../../assets"
 import { selectSigningAddresses } from "./keyringsSelectors"
 
@@ -91,6 +94,29 @@ export const selectAccountAndTimestampedActivities = createSelector(
       },
       accountData: account.accountsData,
     }
+  }
+)
+
+export const selectMainCurrencyUnitPrice = createSelector(
+  getAssetsState,
+  (assets) => {
+    const pricePoint = selectAssetPricePoint(assets, "ETH", mainCurrencySymbol)
+    if (pricePoint) {
+      const {
+        unitPrice,
+      }:
+        | (UnitPricePoint & { unitPrice: FungibleAssetAmount })
+        | { unitPrice: undefined } = unitPricePointForPricePoint(
+        pricePoint
+      ) ?? {
+        unitPrice: undefined,
+      }
+      if (unitPrice) {
+        const decimalValue = assetAmountToDesiredDecimals(unitPrice, 2)
+        return decimalValue
+      }
+    }
+    return undefined
   }
 )
 

--- a/ui/components/NetworkFees/FeeSettingsButton.tsx
+++ b/ui/components/NetworkFees/FeeSettingsButton.tsx
@@ -1,0 +1,58 @@
+import React, { ReactElement } from "react"
+
+interface FeeSettingsButtonProps {
+  openModal: () => void
+  currentFeeSelected: string
+  minFee: number
+  maxFee: number
+}
+
+export default function FeeSettingsButton({
+  openModal,
+  currentFeeSelected,
+  minFee,
+  maxFee,
+}: FeeSettingsButtonProps): ReactElement {
+  return (
+    <button
+      className="settings"
+      type="button"
+      onClick={openModal}
+      style={{
+        background: `linear-gradient(90deg, var(--green-80) ${(
+          ((Number(currentFeeSelected) || minFee) / maxFee) *
+          100
+        ).toFixed()}%, rgba(0, 0, 0, 0) ${(
+          ((Number(currentFeeSelected) || minFee) / maxFee) *
+          100
+        ).toFixed()}%)`,
+      }}
+    >
+      <div>
+        ~{currentFeeSelected || minFee}
+        Gwei
+      </div>
+      <img className="settings_image" src="./images/cog@2x.png" alt="" />
+      <style jsx>
+        {`
+          .settings {
+            height: 38px;
+            display: flex;
+            align-items: center;
+            color: var(--gold-5);
+            font-size: 16px;
+            line-height: 24px;
+            border-radius: 4px;
+            padding-left: 8px;
+            border: 1px solid #33514e;
+          }
+          .settings_image {
+            width: 14px;
+            height: 14px;
+            padding: 0 8px;
+          }
+        `}
+      </style>
+    </button>
+  )
+}

--- a/ui/components/NetworkFees/NetworkFeesChooser.tsx
+++ b/ui/components/NetworkFees/NetworkFeesChooser.tsx
@@ -21,7 +21,7 @@ type GasOption = {
 
 interface NetworkFeesChooserProps {
   setFeeModalOpen: React.Dispatch<React.SetStateAction<boolean>>
-  onSaveGasChoice: React.Dispatch<React.SetStateAction<BlockEstimate>>
+  onSelectFeeOption: (arg0: BlockEstimate) => void
   selectedGas?: BlockEstimate
   gasLimit: string | number
   setGasLimit: React.Dispatch<React.SetStateAction<string>>
@@ -30,7 +30,7 @@ interface NetworkFeesChooserProps {
 
 export default function NetworkFeesChooser({
   setFeeModalOpen,
-  onSaveGasChoice,
+  onSelectFeeOption,
   selectedGas,
   gasLimit,
   setGasLimit,
@@ -45,7 +45,7 @@ export default function NetworkFeesChooser({
   }
 
   const saveUserGasChoice = () => {
-    onSaveGasChoice({
+    onSelectFeeOption({
       confidence: Number(gasOptions[activeFeeIndex].confidence),
       price: gasOptions[activeFeeIndex].price,
       maxFeePerGas: gasOptions[activeFeeIndex].maxFeePerGas,
@@ -68,7 +68,7 @@ export default function NetworkFeesChooser({
     }
   })
 
-  const getGasOptionFormatted = (option: BlockEstimate) => {
+  const formatBlockEstimate = (option: BlockEstimate) => {
     const { confidence } = option
     const names: { [key: number]: string } = {
       70: "Regular",
@@ -78,9 +78,10 @@ export default function NetworkFeesChooser({
     return {
       name: names[confidence],
       confidence: `${confidence}`,
-      gwei: Number(
-        formatUnits(option.maxFeePerGas + option.maxPriorityFeePerGas, "gwei")
-      ).toFixed(),
+      gwei: formatUnits(
+        option.maxFeePerGas + option.maxPriorityFeePerGas,
+        "gwei"
+      ).split(".")[0],
       dollarValue: "$??",
       price: option.price,
       maxFeePerGas: option.maxFeePerGas,
@@ -93,15 +94,19 @@ export default function NetworkFeesChooser({
       const instant = estimatedFeesPerGas?.instant
       const express = estimatedFeesPerGas?.express
       const regular = estimatedFeesPerGas?.regular
-      if (!!instant && !!express && !!regular) {
+      if (
+        instant !== undefined &&
+        express !== undefined &&
+        regular !== undefined
+      ) {
         const updatedGasOptions = [regular, express, instant].map((option) =>
-          getGasOptionFormatted(option)
+          formatBlockEstimate(option)
         )
         setGasOptions(updatedGasOptions)
-        onSaveGasChoice(regular)
+        onSelectFeeOption(regular)
       }
     }
-  }, [estimatedFeesPerGas, onSaveGasChoice])
+  }, [estimatedFeesPerGas, onSelectFeeOption])
 
   useEffect(() => {
     updateGasOptions()

--- a/ui/components/NetworkFees/NetworkFeesChooser.tsx
+++ b/ui/components/NetworkFees/NetworkFeesChooser.tsx
@@ -113,7 +113,7 @@ export default function NetworkFeesChooser({
 
       const feeFiatPrice =
         ethUnitPrice !== undefined
-          ? `$${(+ethAmount * ethUnitPrice).toFixed(2)}`
+          ? `${(+ethAmount * ethUnitPrice).toFixed(2)}`
           : "N/A"
 
       return {
@@ -201,7 +201,7 @@ export default function NetworkFeesChooser({
               </div>
               <div className="option_right">
                 <div className="price">{`~${option.gwei} Gwei`}</div>
-                <div className="subtext">{option.dollarValue}</div>
+                <div className="subtext">${option.dollarValue}</div>
               </div>
             </button>
           )

--- a/ui/components/NetworkFees/NetworkFeesChooser.tsx
+++ b/ui/components/NetworkFees/NetworkFeesChooser.tsx
@@ -13,9 +13,11 @@ import SharedInput from "../Shared/SharedInput"
 type GasOption = {
   name: string
   confidence: string
-  gwei: string
+  estimatedGwei: string
+  maxGwei: string
   dollarValue: string
   price: bigint
+  estimatedFeePerGas: bigint
   maxFeePerGas: bigint
   maxPriorityFeePerGas: bigint
 }
@@ -25,7 +27,7 @@ interface NetworkFeesChooserProps {
   onSelectFeeOption: (arg0: BlockEstimate) => void
   currentFeeSelectionPrice: (arg0: { gwei: string; fiat: string }) => void
   selectedGas?: BlockEstimate
-  gasLimit: string | number
+  gasLimit: string
   setGasLimit: React.Dispatch<React.SetStateAction<string>>
   estimatedFeesPerGas: EstimatedFeesPerGas | undefined
 }
@@ -56,7 +58,7 @@ export default function NetworkFeesChooser({
     })
     setFeeModalOpen(false)
     currentFeeSelectionPrice({
-      gwei: gasOptions[activeFeeIndex].gwei,
+      gwei: gasOptions[activeFeeIndex].estimatedGwei,
       fiat: gasOptions[activeFeeIndex].dollarValue,
     })
   }
@@ -83,32 +85,37 @@ export default function NetworkFeesChooser({
       const baseFee = estimatedFeesPerGas?.baseFeePerGas || 0n
       const feeOptionData: {
         name: { [key: number]: string }
-        multiplier: { [key: number]: bigint }
+        estimatedMultiplier: { [key: number]: bigint }
+        maxMultiplier: { [key: number]: bigint }
       } = {
         name: {
           70: "Regular",
           95: "Express",
           99: "Instant",
         },
-        multiplier: {
-          70: 13n,
-          95: 15n,
+        estimatedMultiplier: {
+          70: 11n,
+          95: 13n,
           99: 18n,
         },
+        maxMultiplier: {
+          70: 13n,
+          95: 15n,
+          99: 20n,
+        },
       }
-      const gweiAmount = formatUnits(
-        BigInt(
-          Number(
-            (baseFee * feeOptionData.multiplier[confidence]) / 10n
-          ).toFixed()
-        ) + option.maxPriorityFeePerGas,
-        "gwei"
-      ).split(".")[0]
+      const formatToGwei = (multiplier: bigint) => {
+        return formatUnits(
+          BigInt(Number((baseFee * multiplier) / 10n).toFixed()) +
+            option.maxPriorityFeePerGas,
+          "gwei"
+        ).split(".")[0]
+      }
 
       const ethAmount = formatEther(
-        (baseFee * feeOptionData.multiplier[confidence] +
+        (baseFee * feeOptionData.estimatedMultiplier[confidence] +
           option.maxPriorityFeePerGas) *
-          (BigInt(gasLimit) > 0 ? BigInt(gasLimit) : 21000n)
+          (gasLimit ? BigInt(parseInt(gasLimit, 10)) : 21000n)
       )
 
       const feeFiatPrice =
@@ -119,10 +126,15 @@ export default function NetworkFeesChooser({
       return {
         name: feeOptionData.name[confidence],
         confidence: `${confidence}`,
-        gwei: gweiAmount,
+        estimatedGwei: formatToGwei(
+          feeOptionData.estimatedMultiplier[confidence]
+        ),
+        maxGwei: formatToGwei(feeOptionData.maxMultiplier[confidence]),
         dollarValue: feeFiatPrice,
         price: option.price,
-        maxFeePerGas: (baseFee * feeOptionData.multiplier[confidence]) / 10n,
+        estimatedFeePerGas:
+          (baseFee * feeOptionData.estimatedMultiplier[confidence]) / 10n,
+        maxFeePerGas: (baseFee * feeOptionData.maxMultiplier[confidence]) / 10n,
         maxPriorityFeePerGas: option.maxPriorityFeePerGas,
       }
     }
@@ -150,7 +162,7 @@ export default function NetworkFeesChooser({
             price: currentlySelectedFee.price,
           })
           currentFeeSelectionPrice({
-            gwei: currentlySelectedFee.gwei,
+            gwei: currentlySelectedFee.estimatedGwei,
             fiat: currentlySelectedFee.dollarValue,
           })
         }
@@ -185,7 +197,7 @@ export default function NetworkFeesChooser({
           <div className="divider-background" />
           <div
             className="divider-cover"
-            style={{ left: (120 - timeRemaining) * (-384 / 120) }}
+            style={{ left: -384 + (384 - timeRemaining * (384 / 120)) }}
           />
         </div>
         {gasOptions.map((option, i) => {
@@ -200,23 +212,31 @@ export default function NetworkFeesChooser({
                 <div className="subtext">Probability: {option.confidence}%</div>
               </div>
               <div className="option_right">
-                <div className="price">{`~${option.gwei} Gwei`}</div>
+                <div className="price">{`~${option.estimatedGwei} Gwei`}</div>
                 <div className="subtext">${option.dollarValue}</div>
               </div>
             </button>
           )
         })}
-        <div className="limit">
-          <label className="limit_label" htmlFor="gasLimit">
-            Gas limit
-          </label>
-          <SharedInput
-            id="gasLimit"
-            value={gasLimit}
-            onChange={(val) => setGasLimit(val)}
-            placeholder="Auto"
-            type="number"
-          />
+        <div className="info">
+          <div className="limit">
+            <label className="limit_label" htmlFor="gasLimit">
+              Gas limit
+            </label>
+            <SharedInput
+              id="gasLimit"
+              value={gasLimit}
+              onChange={(val) => setGasLimit(val)}
+              placeholder="21000"
+              type="number"
+            />
+          </div>
+          <div className="max_fee">
+            <span className="max_label">Max Fee</span>
+            <div className="price">
+              {gasOptions?.[activeFeeIndex]?.maxGwei} Gwei
+            </div>
+          </div>
         </div>
       </div>
       <div className="confirm">
@@ -331,6 +351,21 @@ export default function NetworkFeesChooser({
             box-sizing: border-box;
             justify-content: flex-end;
             padding: 20px 16px;
+          }
+          .info {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+          }
+          .max_fee {
+            display: flex;
+            flex-flow: column;
+            margin-right: 16px;
+            align-items: flex-end;
+          }
+          .max_label {
+            font-size: 14px;
+            color: var(--green-40);
           }
         `}
       </style>

--- a/ui/components/NetworkFees/NetworkFeesChooser.tsx
+++ b/ui/components/NetworkFees/NetworkFeesChooser.tsx
@@ -81,7 +81,6 @@ export default function NetworkFeesChooser({
     const formatBlockEstimate = (option: BlockEstimate) => {
       const { confidence } = option
       const baseFee = estimatedFeesPerGas?.baseFeePerGas || 0n
-
       const feeOptionData: {
         name: { [key: number]: string }
         multiplier: { [key: number]: bigint }
@@ -140,10 +139,31 @@ export default function NetworkFeesChooser({
           formatBlockEstimate(option)
         )
         setGasOptions(updatedGasOptions)
-        onSelectFeeOption(regular)
+        const currentlySelectedFee = updatedGasOptions.find(
+          (el, index) => index === activeFeeIndex
+        )
+        if (currentlySelectedFee) {
+          onSelectFeeOption({
+            confidence: Number(currentlySelectedFee?.confidence),
+            maxFeePerGas: currentlySelectedFee?.maxFeePerGas,
+            maxPriorityFeePerGas: currentlySelectedFee?.maxPriorityFeePerGas,
+            price: currentlySelectedFee.price,
+          })
+          currentFeeSelectionPrice({
+            gwei: currentlySelectedFee.gwei,
+            fiat: currentlySelectedFee.dollarValue,
+          })
+        }
       }
     }
-  }, [estimatedFeesPerGas, onSelectFeeOption, gasLimit, ethUnitPrice])
+  }, [
+    estimatedFeesPerGas,
+    gasLimit,
+    ethUnitPrice,
+    onSelectFeeOption,
+    activeFeeIndex,
+    currentFeeSelectionPrice,
+  ])
 
   useEffect(() => {
     updateGasOptions()

--- a/ui/components/Shared/SharedAssetInput.tsx
+++ b/ui/components/Shared/SharedAssetInput.tsx
@@ -225,6 +225,7 @@ export default function SharedAssetInput(
               className="input_amount"
               type="number"
               step="any"
+              lang="en-US"
               placeholder="0.0"
               value={amount}
               onChange={(e) => onAmountChange(e.target.value)}

--- a/ui/components/Shared/SharedAssetInput.tsx
+++ b/ui/components/Shared/SharedAssetInput.tsx
@@ -223,9 +223,7 @@ export default function SharedAssetInput(
             )}
             <input
               className="input_amount"
-              type="number"
-              step="any"
-              lang="en-US"
+              type="text"
               placeholder="0.0"
               value={amount}
               onChange={(e) => onAmountChange(e.target.value)}

--- a/ui/components/Shared/SharedInput.tsx
+++ b/ui/components/Shared/SharedInput.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement } from "react"
 interface Props {
   id?: string
   placeholder: string
-  type: "password" | "text"
+  type: "password" | "text" | "number"
   value?: string | number | undefined
   onChange?: (value: string) => void
 }
@@ -35,6 +35,9 @@ export default function SharedInput(props: Props): ReactElement {
           }
           input:focus {
             border: 2px solid var(--green-40);
+          }
+          input[type="number"] {
+            -moz-appearance: textfield;
           }
         `}
       </style>

--- a/ui/pages/Send.tsx
+++ b/ui/pages/Send.tsx
@@ -27,6 +27,8 @@ export default function Send(): ReactElement {
   const [feeModalOpen, setFeeModalOpen] = useState(false)
   const [minFee, setMinFee] = useState(0)
   const [maxFee, setMaxFee] = useState(0)
+  const [currentBalance, setCurrentBalance] = useState("")
+  const [gasLimit, setGasLimit] = useState("")
   const [currentFeeValues, setCurrentFeeValues] = useState({
     gwei: "",
     fiat: "",
@@ -38,7 +40,6 @@ export default function Send(): ReactElement {
       maxPriorityFeePerGas: 0n,
       price: 0n,
     })
-  const [gasLimit, setGasLimit] = useState("")
 
   const estimatedFeesPerGas = useBackgroundSelector(selectEstimatedFeesPerGas)
 
@@ -61,17 +62,16 @@ export default function Send(): ReactElement {
     }
     return 0
   }
-  const findBalance = () => {
-    return formatEther(
+  const findBalance = useCallback(() => {
+    const balance = formatEther(
       assetAmounts.find((el) => el.asset.symbol === assetSymbol)?.amount || "0"
     )
-  }
+    setCurrentBalance(balance)
+  }, [assetAmounts, assetSymbol])
 
-  // TODO sets the value of the balance using comma and it should display decimal point for consistency
   const setMaxBalance = () => {
-    const balance = findBalance()
-    if (balance) {
-      setAmount(balance)
+    if (currentBalance) {
+      setAmount(currentBalance)
     }
   }
 
@@ -124,7 +124,8 @@ export default function Send(): ReactElement {
 
   useEffect(() => {
     findMinMaxGas()
-  }, [findMinMaxGas])
+    findBalance()
+  }, [findMinMaxGas, findBalance])
 
   useEffect(() => {
     if (assetSymbol) {
@@ -159,7 +160,7 @@ export default function Send(): ReactElement {
           <div className="form">
             <div className="form_input">
               <div className="balance">
-                Balance: {findBalance()}{" "}
+                Balance: {`${currentBalance.substr(0, 8)}\u2026 `}
                 <span
                   className="max"
                   onClick={setMaxBalance}
@@ -204,7 +205,7 @@ export default function Send(): ReactElement {
               />
             </div>
             <div className="divider" />
-            <div className="total_footer standard_width_padded">
+            <div className="send_footer standard_width_padded">
               <SharedButton
                 type="primary"
                 size="large"
@@ -297,6 +298,12 @@ export default function Send(): ReactElement {
             color: var(--green-60);
             font-size: 12px;
             line-height: 16px;
+          }
+          .send_footer {
+            display: flex;
+            justify-content: flex-end;
+            margin-top: 21px;
+            padding-bottom: 20px;
           }
         `}
       </style>

--- a/ui/pages/Send.tsx
+++ b/ui/pages/Send.tsx
@@ -1,5 +1,5 @@
 import { isAddress } from "@ethersproject/address"
-import { formatUnits } from "@ethersproject/units"
+import { formatEther, formatUnits } from "@ethersproject/units"
 import { BlockEstimate } from "@tallyho/tally-background/networks"
 import { selectCurrentAccountBalances } from "@tallyho/tally-background/redux-slices/selectors"
 import {
@@ -62,8 +62,9 @@ export default function Send(): ReactElement {
     return 0
   }
   const findBalance = () => {
-    return assetAmounts.find((el) => el.asset.symbol === assetSymbol)
-      ?.localizedDecimalAmount
+    return formatEther(
+      assetAmounts.find((el) => el.asset.symbol === assetSymbol)?.amount || "0"
+    )
   }
 
   // TODO sets the value of the balance using comma and it should display decimal point for consistency
@@ -184,6 +185,7 @@ export default function Send(): ReactElement {
                 defaultToken={{ symbol: assetSymbol, name: assetSymbol }}
                 amount={amount}
               />
+              <div className="value">${getTotalLocalizedValue()}</div>
             </div>
             <div className="form_input">
               <SharedAssetInput
@@ -203,19 +205,6 @@ export default function Send(): ReactElement {
             </div>
             <div className="divider" />
             <div className="total_footer standard_width_padded">
-              <div className="total_amount">
-                <div className="total_label">Total</div>
-                <div className="total_amount_number">
-                  {`${amount || 0} ${assetSymbol ?? ""} `}
-                  <div className="total_localized">
-                    {amount
-                      ? `$${getTotalLocalizedValue()} + ${
-                          currentFeeValues.fiat
-                        } network fee`
-                      : ""}
-                  </div>
-                </div>
-              </div>
               <SharedButton
                 type="primary"
                 size="large"
@@ -279,30 +268,6 @@ export default function Send(): ReactElement {
           .label_right {
             margin-right: 6px;
           }
-          .total_amount_number {
-            width: 150px;
-            height: 32px;
-            color: #ffffff;
-            font-size: 22px;
-            font-weight: 500;
-            line-height: 32px;
-          }
-          .total_footer {
-            display: flex;
-            justify-content: space-between;
-            margin-top: 21px;
-            padding-bottom: 20px;
-          }
-          .total_label {
-            width: 33px;
-            height: 17px;
-            color: var(--green-60);
-            font-family: Segment;
-            font-size: 14px;
-            font-weight: 400;
-            letter-spacing: 0.42px;
-            line-height: 16px;
-          }
           .divider {
             width: 384px;
             border-bottom: 1px solid #000000;
@@ -323,7 +288,12 @@ export default function Send(): ReactElement {
             color: #d08e39;
             cursor: pointer;
           }
-          .total_localized {
+          .value {
+            display: flex;
+            justify-content: flex-end;
+            position: relative;
+            top: -24px;
+            right: 16px;
             color: var(--green-60);
             font-size: 12px;
             line-height: 16px;

--- a/ui/pages/Send.tsx
+++ b/ui/pages/Send.tsx
@@ -128,7 +128,7 @@ export default function Send(): ReactElement {
         >
           <NetworkFeesChooser
             setFeeModalOpen={setFeeModalOpen}
-            onSaveGasChoice={setSelectedEstimatedFeePerGas}
+            onSelectFeeOption={setSelectedEstimatedFeePerGas}
             selectedGas={selectedEstimatedFeePerGas}
             gasLimit={gasLimit}
             setGasLimit={setGasLimit}

--- a/ui/pages/SignTransaction.tsx
+++ b/ui/pages/SignTransaction.tsx
@@ -40,6 +40,8 @@ export default function SignTransaction(): ReactElement {
   const isTransactionDataReady = useBackgroundSelector(
     selectIsTransactionLoaded
   )
+
+  // TODO the below should return a promise that resolves once tx is signed
   const isTransactionSigned = useBackgroundSelector(selectIsTransactionSigned)
   const txDetails = useBackgroundSelector(selectTransactionData)
 
@@ -78,6 +80,7 @@ export default function SignTransaction(): ReactElement {
   const handleConfirm = async () => {
     if (SignType.Sign === signType && isTransactionDataReady && txDetails) {
       dispatch(signTransaction(txDetails))
+      await isTransactionSigned
       history.push("/")
     }
   }
@@ -116,6 +119,7 @@ export default function SignTransaction(): ReactElement {
           iconSize="large"
           size="large"
           onClick={handleConfirm}
+          showLoadingOnClick
         >
           {signContent[signType].confirmButtonText}
         </SharedButton>

--- a/ui/pages/SingleAsset.tsx
+++ b/ui/pages/SingleAsset.tsx
@@ -66,19 +66,24 @@ export default function SingleAsset(): ReactElement {
           </div>
           {!HIDE_SEND_BUTTON && isCurrentAccountSigner ? (
             <div className="right">
-              <SharedButton
-                type="primary"
-                size="medium"
-                icon="send"
-                linkTo={{
-                  pathname: "/send",
-                  state: {
-                    symbol,
-                  },
-                }}
-              >
-                Send
-              </SharedButton>
+              {/* TEMP HIDE SEND FOR NON-ETH ASSETS */}
+              {symbol === "ETH" ? (
+                <SharedButton
+                  type="primary"
+                  size="medium"
+                  icon="send"
+                  linkTo={{
+                    pathname: "/send",
+                    state: {
+                      symbol,
+                    },
+                  }}
+                >
+                  Send
+                </SharedButton>
+              ) : (
+                <></>
+              )}
               <SharedButton type="primary" size="medium" icon="swap">
                 Swap
               </SharedButton>

--- a/ui/public/index.css
+++ b/ui/public/index.css
@@ -110,7 +110,7 @@ label {
 }
 
 .label {
-  color: var(--green-60);
+  color: var(--green-40);
   font-size: 14px;
   font-weight: 400;
   letter-spacing: 0.42px;


### PR DESCRIPTION
This PR updates the fee selection logic with updated multipliers, we now show the estimated amount along with a maximum that can be charged.

The animation of fees timeout has been reversed to be as per the design.

Users can now specify their custom gasLimit to be set in the transaction provided it's more than `21000`. If the user mistakenly sets lower amount, we will estimate the needed gas and update.

![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/61434499/145809936-70ac6051-b6e3-4492-a68f-69748e79af26.gif)

To be merged after #534