### PR TITLE
Refactor the network fees to be reusable

### DIFF
--- a/background/redux-slices/transaction-construction.ts
+++ b/background/redux-slices/transaction-construction.ts
@@ -19,6 +19,8 @@ export type TransactionConstruction = {
   transactionRequest?: EIP1559TransactionRequest
   estimatedFeesPerGas: EstimatedFeesPerGas | undefined
   lastGasEstimatesRefreshed: number
+  gasLimitSelected: bigint
+  selectedNetworkFee?: BlockEstimate
 }
 
 export type EstimatedFeesPerGas = {
@@ -32,6 +34,7 @@ export const initialState: TransactionConstruction = {
   status: TransactionConstructionStatus.Idle,
   estimatedFeesPerGas: undefined,
   lastGasEstimatesRefreshed: Date.now(),
+  gasLimitSelected: 0n,
 }
 
 export type Events = {
@@ -73,6 +76,18 @@ const transactionSlice = createSlice({
     signed: (immerState) => {
       immerState.status = TransactionConstructionStatus.Signed
     },
+    gasLimitSelected: (
+      immerState,
+      { payload: gasLimitSelected }: { payload: bigint }
+    ) => {
+      immerState.gasLimitSelected = gasLimitSelected
+    },
+    selectedNetworkFee: (
+      immerState,
+      { payload: selectedNetworkFee }: { payload: BlockEstimate }
+    ) => {
+      immerState.selectedNetworkFee = selectedNetworkFee
+    },
     estimatedFeesPerGas: (
       immerState,
       { payload: estimatedFeesPerGas }: { payload: BlockPrices }
@@ -102,8 +117,13 @@ const transactionSlice = createSlice({
   },
 })
 
-export const { transactionRequest, signed, estimatedFeesPerGas } =
-  transactionSlice.actions
+export const {
+  transactionRequest,
+  signed,
+  estimatedFeesPerGas,
+  gasLimitSelected,
+  selectedNetworkFee,
+} = transactionSlice.actions
 
 export default transactionSlice.reducer
 
@@ -117,6 +137,12 @@ export const selectLastGasEstimatesRefreshTime = createSelector(
   (state: { transactionConstruction: TransactionConstruction }) =>
     state.transactionConstruction.lastGasEstimatesRefreshed,
   (updateTime) => updateTime
+)
+
+export const selectSelectedNetworkFee = createSelector(
+  (state: { transactionConstruction: TransactionConstruction }) =>
+    state.transactionConstruction.selectedNetworkFee,
+  (selectedFee) => selectedFee
 )
 
 export const selectTransactionData = createSelector(

--- a/ui/components/NetworkFees/FeeSettingsButton.tsx
+++ b/ui/components/NetworkFees/FeeSettingsButton.tsx
@@ -1,58 +1,118 @@
-import React, { ReactElement } from "react"
+import { formatUnits } from "@ethersproject/units"
+import {
+  selectEstimatedFeesPerGas,
+  selectSelectedNetworkFee,
+} from "@tallyho/tally-background/redux-slices/transaction-construction"
+import React, { ReactElement, useCallback, useState, useEffect } from "react"
+import { useBackgroundSelector } from "../../hooks"
+import SharedSlideUpMenu from "../Shared/SharedSlideUpMenu"
+import NetworkFeesChooser from "./NetworkFeesChooser"
 
 interface FeeSettingsButtonProps {
   openModal: () => void
-  currentFeeSelected: string
-  minFee: number
-  maxFee: number
+  closeModal: () => void
+  open: boolean
 }
 
 export default function FeeSettingsButton({
   openModal,
-  currentFeeSelected,
-  minFee,
-  maxFee,
+  closeModal,
+  open,
 }: FeeSettingsButtonProps): ReactElement {
+  const [minFee, setMinFee] = useState(0)
+  const [maxFee, setMaxFee] = useState(0)
+  const [currentFeeSelected, setCurrentFeeSelected] = useState("")
+
+  const estimatedFeesPerGas = useBackgroundSelector(selectEstimatedFeesPerGas)
+  const currentlySelectedNetworkFee = useBackgroundSelector(
+    selectSelectedNetworkFee
+  )
+  const findMinMaxGas = useCallback(() => {
+    if (
+      estimatedFeesPerGas?.baseFeePerGas &&
+      estimatedFeesPerGas?.regular?.maxPriorityFeePerGas &&
+      estimatedFeesPerGas?.instant?.maxPriorityFeePerGas
+    ) {
+      setMinFee(
+        Number(
+          formatUnits(
+            (estimatedFeesPerGas.baseFeePerGas * BigInt(11)) / 10n +
+              estimatedFeesPerGas.regular?.maxPriorityFeePerGas,
+            "gwei"
+          ).split(".")[0]
+        )
+      )
+      setMaxFee(
+        Number(
+          formatUnits(
+            (estimatedFeesPerGas.baseFeePerGas * BigInt(18)) / 10n +
+              estimatedFeesPerGas.instant?.maxPriorityFeePerGas,
+            "gwei"
+          ).split(".")[0]
+        )
+      )
+    }
+  }, [estimatedFeesPerGas])
+
+  useEffect(() => {
+    findMinMaxGas()
+  }, [findMinMaxGas])
+
   return (
-    <button
-      className="settings"
-      type="button"
-      onClick={openModal}
-      style={{
-        background: `linear-gradient(90deg, var(--green-80) ${(
-          ((Number(currentFeeSelected) || minFee) / maxFee) *
-          100
-        ).toFixed()}%, rgba(0, 0, 0, 0) ${(
-          ((Number(currentFeeSelected) || minFee) / maxFee) *
-          100
-        ).toFixed()}%)`,
-      }}
-    >
-      <div>
-        ~{currentFeeSelected || minFee}
-        Gwei
-      </div>
-      <img className="settings_image" src="./images/cog@2x.png" alt="" />
-      <style jsx>
-        {`
-          .settings {
-            height: 38px;
-            display: flex;
-            align-items: center;
-            color: var(--gold-5);
-            font-size: 16px;
-            line-height: 24px;
-            border-radius: 4px;
-            padding-left: 8px;
-            border: 1px solid #33514e;
-          }
-          .settings_image {
-            width: 14px;
-            height: 14px;
-            padding: 0 8px;
-          }
-        `}
-      </style>
-    </button>
+    <>
+      <button
+        className="settings"
+        type="button"
+        onClick={openModal}
+        style={{
+          background: `linear-gradient(90deg, var(--green-80) ${(
+            ((Number(currentFeeSelected) || minFee) / maxFee) *
+            100
+          ).toFixed()}%, rgba(0, 0, 0, 0) ${(
+            ((Number(currentFeeSelected) || minFee) / maxFee) *
+            100
+          ).toFixed()}%)`,
+        }}
+      >
+        <div>
+          ~{currentFeeSelected || minFee}
+          Gwei
+        </div>
+        <img className="settings_image" src="./images/cog@2x.png" alt="" />
+        <style jsx>
+          {`
+            .settings {
+              height: 38px;
+              display: flex;
+              align-items: center;
+              color: var(--gold-5);
+              font-size: 16px;
+              line-height: 24px;
+              border-radius: 4px;
+              padding-left: 8px;
+              border: 1px solid #33514e;
+            }
+            .settings_image {
+              width: 14px;
+              height: 14px;
+              padding: 0 8px;
+            }
+          `}
+        </style>
+      </button>
+      <SharedSlideUpMenu
+        size="custom"
+        isOpen={open}
+        close={closeModal}
+        customSize={`${3 * 56 + 320}px`}
+      >
+        <NetworkFeesChooser
+          closeModal={closeModal}
+          currentFeeSelectionPrice={setCurrentFeeSelected}
+          estimatedFeesPerGas={estimatedFeesPerGas}
+          currentlyChosenFeeOption={currentlySelectedNetworkFee}
+        />
+      </SharedSlideUpMenu>
+    </>
   )
 }

--- a/ui/pages/SignTransaction.tsx
+++ b/ui/pages/SignTransaction.tsx
@@ -17,6 +17,7 @@ import {
   useBackgroundSelector,
   useAreKeyringsUnlocked,
 } from "../hooks"
+import FeeSettingsButton from "../components/NetworkFees/FeeSettingsButton"
 
 enum SignType {
   Sign = "sign",
@@ -32,6 +33,7 @@ interface SignLocationState {
 
 export default function SignTransaction(): ReactElement {
   const areKeyringsUnlocked = useAreKeyringsUnlocked(true)
+  const [feeSelectModalOpen, setFeeSelectModalOpen] = useState(false)
 
   const history = useHistory()
   const dispatch = useBackgroundDispatch()
@@ -46,6 +48,13 @@ export default function SignTransaction(): ReactElement {
   const txDetails = useBackgroundSelector(selectTransactionData)
 
   const [panelNumber, setPanelNumber] = useState(0)
+
+  const openSelectFeeModal = () => {
+    setFeeSelectModalOpen(true)
+  }
+  const closeSelectFeeModal = () => {
+    setFeeSelectModalOpen(false)
+  }
 
   if (!areKeyringsUnlocked) {
     return <></>
@@ -100,8 +109,12 @@ export default function SignTransaction(): ReactElement {
       {panelNumber === 0 ? (
         <div className="detail_items_wrap standard_width_padded">
           <span className="detail_item">
-            Network Fee/Speed
-            <span className="detail_item_right">{"$24 / <1min"}</span>
+            Estimated network fee
+            <FeeSettingsButton
+              openModal={openSelectFeeModal}
+              closeModal={closeSelectFeeModal}
+              open={feeSelectModalOpen}
+            />
           </span>
         </div>
       ) : null}


### PR DESCRIPTION
My goal here is to be able to update fees from the Sign page, that requires a significant refactor on how do we handle updating and selecting the gas fees. 

In this PR the network fee selection is stored in redux so it can be retrieved on other pages and updated on other pages.