### PR TITLE
🔐 Update create password page copy

### DIFF
--- a/ui/components/Keyring/KeyringSetPassword.tsx
+++ b/ui/components/Keyring/KeyringSetPassword.tsx
@@ -53,8 +53,10 @@ export default function KeyringSetPassword(): ReactElement {
   return (
     <section>
       <div className="full_logo" />
-      <h1 className="serif_header">Good hunting.</h1>
-      <div className="subtitle">The decentralized web awaits.</div>
+      <h1 className="serif_header">Create a password</h1>
+      <div className="subtitle">
+        You will NOT be able to change this password for now.
+      </div>
       <div className="input_wrap">
         <SharedInput
           type="password"
@@ -77,7 +79,7 @@ export default function KeyringSetPassword(): ReactElement {
         onClick={dispatchCreatePassword}
         showLoadingOnClick={!passwordErrorMessage}
       >
-        Begin the hunt
+        Continue
       </SharedButton>
       <div className="restore">
         <SharedButton type="tertiary" size="medium">
@@ -105,6 +107,13 @@ export default function KeyringSetPassword(): ReactElement {
             display: none; // TODO Implement account restoration.
             position: fixed;
             bottom: 26px;
+          }
+          .subtitle {
+            color: var(--green-40);
+            width: 307px;
+            text-align: center;
+            line-height: 24px;
+            margin-top: 4px;
           }
         `}
       </style>


### PR DESCRIPTION
This doesn't exactly match the updated design in Figma, and I've deviated on the copy a bit (see #577). But I think these copy changes make sense given that this screen isn't first in the flow.

<img width="340" alt="Password page copy" src="https://user-images.githubusercontent.com/1918798/145869973-a8b8f3eb-44e2-4068-bbf0-022c18ba82a5.png">

Closes #577
