### PR TITLE
👻 Ghostbuster: Only store the latest dApp request in store

### DIFF
--- a/background/redux-slices/dapp-permission.ts
+++ b/background/redux-slices/dapp-permission.ts
@@ -60,7 +60,9 @@ const dappPermissionSlice = createSlice({
         return {
           ...state,
           permissionRequests: {
-            ...state.permissionRequests,
+            // Quick fix: store only the latest permission request.
+            // TODO: put this back when we fixed the performance issues and/or updated our UI to handle multiple requests
+            // ...state.permissionRequests,
             [request.origin]: { ...request },
           },
         }
@@ -97,7 +99,7 @@ const dappPermissionSlice = createSlice({
           delete updatedAllowedPages[permission.origin]
 
           return {
-            permissionRequests: { ...updatedPermissionRequests },
+            permissionRequests: updatedPermissionRequests,
             allowedPages: updatedAllowedPages,
           }
         }

--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -92,7 +92,7 @@ export default class ProviderBridgeService extends BaseService<Events> {
 
     // a port: browser.Runtime.Port is passed into this function as a 2nd argument by the port.onMessage.addEventListener.
     // This contradicts the MDN documentation so better not to rely on it.
-    logger.log(`background: request payload: ${JSON.stringify(event.request)}`)
+    // logger.log(`background: request payload: ${JSON.stringify(event.request)}`)
 
     const response: PortResponseEvent = { id: event.id, result: [] }
 
@@ -123,7 +123,7 @@ export default class ProviderBridgeService extends BaseService<Events> {
       response.result = new EIP1193Error(EIP1193_ERROR.unauthorized)
     }
 
-    logger.log("background response:", response)
+    // logger.log("background response:", response)
 
     port.postMessage(response)
   }

--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -90,10 +90,6 @@ export default class ProviderBridgeService extends BaseService<Events> {
     const faviconUrl = tab?.favIconUrl ?? ""
     const title = tab?.title ?? ""
 
-    // a port: browser.Runtime.Port is passed into this function as a 2nd argument by the port.onMessage.addEventListener.
-    // This contradicts the MDN documentation so better not to rely on it.
-    // logger.log(`background: request payload: ${JSON.stringify(event.request)}`)
-
     const response: PortResponseEvent = { id: event.id, result: [] }
 
     if (await this.checkPermission(origin)) {
@@ -122,8 +118,6 @@ export default class ProviderBridgeService extends BaseService<Events> {
     } else {
       response.result = new EIP1193Error(EIP1193_ERROR.unauthorized)
     }
-
-    // logger.log("background response:", response)
 
     port.postMessage(response)
   }


### PR DESCRIPTION
I have set up the store in a way to be able to handle multiple dApp requests, but we are just showing the latest in the UI. 
This change overwrites the whole `permissionRequests` object with the incoming request, so we keep track only the latest request.  

The source of the problem seems to be that the store was really busy and user interaction come quicker then it could remove the previous request from the queue. The remove reducer is ran on the fulfillment of an async thunk. It's more than possible that something keeps that from finishing.

Closes #606, closes #613