### PR TITLE
Default fee auto-select and sign page redirect

### DIFF
--- a/ui/components/NetworkFees/NetworkFeesChooser.tsx
+++ b/ui/components/NetworkFees/NetworkFeesChooser.tsx
@@ -195,6 +195,17 @@ export default function NetworkFeesChooser({
   }, [updateGasOptions])
 
   useEffect(() => {
+    if (gasOptions.length > 0) {
+      onSelectFeeOption({
+        confidence: Number(gasOptions[activeFeeIndex].confidence),
+        price: gasOptions[activeFeeIndex].price,
+        maxFeePerGas: gasOptions[activeFeeIndex].maxFeePerGas,
+        maxPriorityFeePerGas: gasOptions[activeFeeIndex].maxPriorityFeePerGas,
+      })
+    }
+  }, [activeFeeIndex, onSelectFeeOption, gasOptions])
+
+  useEffect(() => {
     const selectedOptionIndex = gasOptions.findIndex(
       (el) => el.confidence === `${selectedGas?.confidence}`
     )

--- a/ui/pages/SignTransaction.tsx
+++ b/ui/pages/SignTransaction.tsx
@@ -40,8 +40,6 @@ interface SignLocationState {
 }
 
 export default function SignTransaction(): ReactElement {
-  const [signing, setSigning] = useState(false)
-
   const areKeyringsUnlocked = useAreKeyringsUnlocked(true)
 
   const history = useHistory()
@@ -71,17 +69,16 @@ export default function SignTransaction(): ReactElement {
   const [isTransactionSigning, setIsTransactionSigning] = useState(false)
 
   useEffect(() => {
-    if (isTransactionSigning && isTransactionSigned) {
-      history.push("/")
-    }
-  }, [history, isTransactionSigned, isTransactionSigning])
-
-  useEffect(() => {
-    if (areKeyringsUnlocked && isTransactionSigned && signing) {
-      setSigning(false)
+    if (areKeyringsUnlocked && isTransactionSigned && isTransactionSigning) {
       history.push("/singleAsset", { symbol: assetSymbol })
     }
-  }, [areKeyringsUnlocked, isTransactionSigned, signing, history, assetSymbol])
+  }, [
+    areKeyringsUnlocked,
+    isTransactionSigned,
+    isTransactionSigning,
+    history,
+    assetSymbol,
+  ])
 
   if (!areKeyringsUnlocked) {
     return <></>
@@ -176,9 +173,10 @@ export default function SignTransaction(): ReactElement {
               setGasLimit={setGasLimit}
             />
           ) : (
-            <span className="detail_item_right">
-              <span className="detail_item">
-                Estimated network fee ~$
+            <span className="detail_item">
+              Estimated network fee
+              <span className="detail_item_right">
+                ~
                 {
                   formatUnits(transactionDetails.maxFeePerGas, "gwei").split(
                     "."


### PR DESCRIPTION
Fix: When user navigates to a component with `NetworkFeesChooser` the `Regular` fee option will be auto-selected.

Example:
 * When user on the Send page selects `Express` as the fee option and goes to Sign and then rejects the signing he is returned to the Send page, but the fee option will be reverted back to `Regular`.
 
 FIx: Sign page should now show the maxFeePerGas from the transaction details.
 
 Fix: After signing the transaction users are redirected to the respective `SingleAsset` page.