### PR TITLE
⛔ Contracts Not Welcome: Don't show contract interactions per asset

### DIFF
--- a/ui/pages/SingleAsset.tsx
+++ b/ui/pages/SingleAsset.tsx
@@ -33,22 +33,20 @@ export default function SingleAsset(): ReactElement {
         ) {
           return true
         }
-        if (
-          activity.annotation?.type === "asset-transfer" ||
-          activity.annotation?.type === "asset-approval"
-        ) {
-          return activity.annotation.assetAmount.asset.symbol === symbol
+        switch (activity.annotation?.type) {
+          case "asset-transfer":
+          case "asset-approval":
+            return activity.annotation.assetAmount.asset.symbol === symbol
+          case "asset-swap":
+            return (
+              activity.annotation.fromAssetAmount.asset.symbol === symbol ||
+              activity.annotation.toAssetAmount.asset.symbol === symbol
+            )
+          case "contract-interaction":
+          case "contract-deployment":
+          default:
+            return false
         }
-        if (activity.annotation?.type === "asset-swap") {
-          return (
-            activity.annotation.fromAssetAmount.asset.symbol === symbol ||
-            activity.annotation.toAssetAmount.asset.symbol === symbol
-          )
-        }
-        if (activity.annotation?.type === "contract-interaction") {
-          return activity.asset.symbol === symbol
-        }
-        return false
       }
     )
   )


### PR DESCRIPTION
We still show transfers, of course, or anything that interacts directly against an asset contract. Just want to avoid the ETH single asset page becoming a dumping ground for every uncategorized tx.

Closes #676