### PR TITLE
⚠️ Add error message for invalid recovery phrase

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -23,12 +23,13 @@
     "watch": "webpack --mode=development --watch"
   },
   "dependencies": {
-    "@ethersproject/web": "^5.5.0",
     "@ethersproject/address": "^5.5.0",
+    "@ethersproject/hdnode": "^5.5.0",
     "@ethersproject/units": "5.4.0",
+    "@ethersproject/web": "^5.5.0",
     "@reduxjs/toolkit": "^1.6.0",
-    "@tallyho/tally-background": "0.0.1",
     "@tallyho/provider-bridge-shared": "0.0.1",
+    "@tallyho/tally-background": "0.0.1",
     "classnames": "^2.3.1",
     "dayjs": "^1.10.6",
     "ethers": "^5.5.1",


### PR DESCRIPTION
Please test this carefully as it interacts with the recovery phrase. Uses Ethers' `isValidMnemonic` until.

Closes #580 