### PR TITLE
More Bags to Grab Redux: A fix for a keyring status change and an enrichment approval parameter, oh and also a showstopper fix

### DIFF
--- a/background/services/enrichment/index.ts
+++ b/background/services/enrichment/index.ts
@@ -224,7 +224,7 @@ export default class EnrichmentService extends BaseService<Events> {
           assetAmount: enrichAssetAmountWithDecimalValues(
             {
               asset: matchingFungibleAsset,
-              amount: BigInt(erc20Tx.args.amount),
+              amount: BigInt(erc20Tx.args.value),
             },
             desiredDecimals
           ),

--- a/background/services/keyring/index.ts
+++ b/background/services/keyring/index.ts
@@ -85,8 +85,10 @@ export default class KeyringService extends BaseService<Events> {
   async internalStartService(): Promise<void> {
     // Emit locked status on startup. Should always be locked, but the main
     // goal is to have external viewers synced to internal state no matter what
-    // it is.
-    this.emitter.emit("locked", this.locked())
+    // it is. Don't emit if there are no keyrings to unlock.
+    if ((await getEncryptedVaults()).vaults.length > 0) {
+      this.emitter.emit("locked", this.locked())
+    }
   }
 
   async internalStopService(): Promise<void> {

--- a/ui/pages/Send.tsx
+++ b/ui/pages/Send.tsx
@@ -6,6 +6,7 @@ import {
   selectCurrentAccountBalances,
 } from "@tallyho/tally-background/redux-slices/selectors"
 import {
+  broadcastOnSign,
   selectEstimatedFeesPerGas,
   updateTransactionOptions,
 } from "@tallyho/tally-background/redux-slices/transaction-construction"
@@ -76,6 +77,7 @@ export default function Send(): ReactElement {
   }
 
   const sendTransactionRequest = async () => {
+    dispatch(broadcastOnSign(true))
     // FIXME Hackily handle the user not interacting with the fee selector for now.
     if (selectedEstimatedFeePerGas.maxFeePerGas === 0n) {
       const transaction = {


### PR DESCRIPTION
Fixes an issue introduced in #694 where the keyring status in a fresh extension install was unlocked rather than uninitialized. Also fixes an issue where transaction enrichment would fail for token approvals due to a misnamed parameter.

Finally, fixes #692.