### PR TITLE
🏀 Buzzer beaters

### DIFF
--- a/ui/components/Shared/SharedCurrentAccountInformation.tsx
+++ b/ui/components/Shared/SharedCurrentAccountInformation.tsx
@@ -22,9 +22,9 @@ export default function SharedCurrentAccountInformation(): ReactElement {
             border-radius: 12px;
             width: 32px;
             height: 32px;
-            background-color: white;
             margin-left: 8px;
             background: url("${avatarURL ?? "./images/portrait.png"}");
+            background-color: var(--green-40);
             background-size: cover;
           }
         `}

--- a/ui/components/Shared/SharedPanelAccountItem.tsx
+++ b/ui/components/Shared/SharedPanelAccountItem.tsx
@@ -67,6 +67,7 @@ export default function SharedPanelAccountItem(props: Props): ReactElement {
         .avatar {
           background: url("${avatarURL ?? "./images/avatar@2x.png"}") center
             no-repeat;
+          background-color: var(--green-40);
           background-size: cover;
           width: 48px;
           height: 48px;

--- a/ui/components/Snackbar/Snackbar.tsx
+++ b/ui/components/Snackbar/Snackbar.tsx
@@ -10,7 +10,7 @@ import { useBackgroundSelector } from "../../hooks"
 export default function Snackbar(): ReactElement {
   const dispatch = useDispatch()
   const snackbarMessage = useBackgroundSelector(selectSnackbarMessage)
-  const msTillDismiss = 5000
+  const msTillDismiss = 2500
 
   const snackbarTimeout = useRef<ReturnType<typeof setTimeout>>()
 

--- a/ui/components/Wallet/WalletAccountBalanceControl.tsx
+++ b/ui/components/Wallet/WalletAccountBalanceControl.tsx
@@ -82,7 +82,7 @@ export default function WalletAccountBalanceControl(
             })}
           >
             <span className="dollar_sign">$</span>
-            {balance}
+            {balance ?? 0}
           </span>
         </span>
         {isCurrentAccountSigner && !HIDE_SEND_BUTTON ? (

--- a/ui/components/Wallet/WalletActivityList.tsx
+++ b/ui/components/Wallet/WalletActivityList.tsx
@@ -49,24 +49,25 @@ export default function WalletActivityList({
 
   if (!activities || activities.length === 0)
     return (
-      <div className="loading">
-        <SharedLoadingSpinner />
-        <span>This may initially take awhile.</span>
+      <span>
+        Tally will populate your historical activity over time; this may take an
+        hour or more for accounts that have been active for a long time. For new
+        accounts, new activity will show up here.
         <style jsx>{`
-          .loading {
-            width: 100%;
+          span {
+            width: 316px;
             display: flex;
             flex-direction: column;
             align-items: center;
-            margin-top: 20px;
-          }
-          .loading span {
-            color: var(--green-60);
-            margin-top: 12px;
-            font-size: 14px;
+            color: var(--green-40);
+            font-size: 16px;
+            text-align: center;
+            line-height: 22px;
+            margin: 0 auto;
+            margin-top: 15px;
           }
         `}</style>
-      </div>
+      </span>
     )
 
   return (

--- a/ui/pages/Onboarding/OnboardingImportMetamask.tsx
+++ b/ui/pages/Onboarding/OnboardingImportMetamask.tsx
@@ -108,7 +108,8 @@ export default function OnboardingImportMetamask(props: Props): ReactElement {
           <div className="metamask_onboarding_image" />
           <h1 className="serif_header">Import account</h1>
           <div className="info">
-            Enter or copy paste the recovery phrase from your MetaMask account.
+            Enter or copy & paste the recovery phrase from your MetaMask
+            account.
           </div>
           <TextArea
             value={recoveryPhrase}

--- a/ui/pages/Onboarding/OnboardingImportMetamask.tsx
+++ b/ui/pages/Onboarding/OnboardingImportMetamask.tsx
@@ -84,9 +84,10 @@ export default function OnboardingImportMetamask(props: Props): ReactElement {
   }, [history, areKeyringsUnlocked, keyringImport, nextPage, isImporting])
 
   const importWallet = useCallback(async () => {
-    if (isValidMnemonic(recoveryPhrase)) {
+    const trimmedRecoveryPhrase = recoveryPhrase.trim()
+    if (isValidMnemonic(trimmedRecoveryPhrase)) {
       setIsImporting(true)
-      dispatch(importLegacyKeyring({ mnemonic: recoveryPhrase.trim() }))
+      dispatch(importLegacyKeyring({ mnemonic: trimmedRecoveryPhrase }))
     } else {
       setErrorMessage("Invalid recovery phrase")
     }

--- a/ui/pages/SignTransaction.tsx
+++ b/ui/pages/SignTransaction.tsx
@@ -219,7 +219,7 @@ export default function SignTransaction(): ReactElement {
           iconSize="large"
           size="large"
           type="secondary"
-          onClick={() => window.close()}
+          onClick={() => history.goBack()}
         >
           Reject
         </SharedButton>

--- a/ui/pages/SignTransaction.tsx
+++ b/ui/pages/SignTransaction.tsx
@@ -219,7 +219,7 @@ export default function SignTransaction(): ReactElement {
           iconSize="large"
           size="large"
           type="secondary"
-          onClick={() => history.goBack()}
+          onClick={() => window.close()}
         >
           Reject
         </SharedButton>


### PR DESCRIPTION
- [x] Tiny tweak to show 0 balance if none exist
- [x] Trim recovery phrase before testing if valid
- [x] Fixes #709
- [x] Fixes #708
- [x] Adds a background color fallback for if an ENS profile avatar URL doesn't load
- [x] Add explanation on activity loading, remove spinner

<img width="398" alt="activity loading 1" src="https://user-images.githubusercontent.com/1918798/146571970-72a6da12-f237-4199-92cf-6831915f0b95.png">

<img width="398" alt="activity loading 2" src="https://user-images.githubusercontent.com/1918798/146571985-2880a4b3-155c-462c-9a43-8ed73008b534.png">

