### PR TITLE
Correct fee value display

### DIFF
--- a/ui/components/NetworkFees/NetworkFeesChooser.tsx
+++ b/ui/components/NetworkFees/NetworkFeesChooser.tsx
@@ -117,8 +117,9 @@ export default function NetworkFeesChooser({
       }
 
       const ethAmount = formatEther(
-        (baseFee * feeOptionData.estimatedMultiplier[confidence] +
-          option.maxPriorityFeePerGas) *
+        ((baseFee * feeOptionData.estimatedMultiplier[confidence] +
+          option.maxPriorityFeePerGas) /
+          10n) *
           (gasLimit ? BigInt(parseInt(gasLimit, 10)) : 21000n)
       )
 


### PR DESCRIPTION
Networks fees were showing too high in $$,because in order to work with bigInts the multipliers were converted into bigInts so 1.3 = 13n but after calculating the value was not divided by 10 so we were actually showing fees x13 not x1.3. This PR fixes that by adding a division by `10n`.