### PR TITLE
Alarming Balances: Update balances when transactions are confirmed

### DIFF
--- a/background/services/chain/utils.ts
+++ b/background/services/chain/utils.ts
@@ -12,6 +12,7 @@ import {
   SignedEVMTransaction,
   AnyEVMBlock,
   EIP1559TransactionRequest,
+  ConfirmedEVMTransaction,
 } from "../../networks"
 import { FungibleAsset } from "../../assets"
 import { getEthereumNetwork } from "../../lib/utils"
@@ -147,11 +148,16 @@ export function ethersTransactionFromSignedTransaction(
 export function enrichTransactionWithReceipt(
   transaction: AnyEVMTransaction,
   receipt: EthersTransactionReceipt
-): AnyEVMTransaction {
+): ConfirmedEVMTransaction {
+  const gasUsed = receipt.gasUsed.toBigInt()
   return {
     ...transaction,
-    gasUsed: receipt.gasUsed.toBigInt(),
-    status: receipt.status,
+    gasUsed,
+    status:
+      receipt.status ??
+      // Pre-Byzantium transactions require a guesswork approach or an
+      // eth_call; we go for guesswork.
+      (gasUsed === transaction.gasLimit ? 0 : 1),
     blockHash: receipt.blockHash,
     blockHeight: receipt.blockNumber,
   }


### PR DESCRIPTION
When transactions near the chain tip with a successful status are
seen, the indexing service now schedules a token balance lookup to
occur within 1 minute. This should ensure that any transactions that
affect balances update the balance in relatively short order, even if
we don't have enough insight into the transaction itself to locally
handle those updates.

~~Fixes~~ Refs #707 .