### PR TITLE
Rejectamundo: Proper support for transaction signing rejection

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -511,16 +511,37 @@ export default class Main extends BaseService<never> {
   async connectInternalEthereumProviderService(): Promise<void> {
     this.internalEthereumProviderService.emitter.on(
       "transactionSignatureRequest",
-      async ({ payload, resolver }) => {
+      async ({ payload, resolver, rejecter }) => {
         this.store.dispatch(updateTransactionOptions(payload))
         // TODO force route?
 
         this.store.dispatch(broadcastOnSign(false))
-        const signedTransaction = await this.keyringService.emitter.once(
-          "signedTx"
-        )
 
-        resolver(signedTransaction)
+        const resolveAndClear = (signedTransaction: SignedEVMTransaction) => {
+          this.keyringService.emitter.off("signedTx", resolveAndClear)
+          transactionConstructionSliceEmitter.off(
+            "signatureRejected",
+            // Ye olde mutual dependency.
+            // eslint-disable-next-line @typescript-eslint/no-use-before-define
+            rejectAndClear
+          )
+          resolver(signedTransaction)
+        }
+
+        const rejectAndClear = () => {
+          this.keyringService.emitter.off("signedTx", resolveAndClear)
+          transactionConstructionSliceEmitter.off(
+            "signatureRejected",
+            rejectAndClear
+          )
+          rejecter()
+        }
+
+        this.keyringService.emitter.on("signedTx", resolveAndClear)
+        transactionConstructionSliceEmitter.on(
+          "signatureRejected",
+          rejectAndClear
+        )
       }
     )
   }

--- a/background/services/internal-ethereum-provider/index.ts
+++ b/background/services/internal-ethereum-provider/index.ts
@@ -22,6 +22,7 @@ import {
 type DAppRequestEvent<T, E> = {
   payload: T
   resolver: (result: E | PromiseLike<E>) => void
+  rejecter: () => void
 }
 
 type Events = ServiceLifecycleEvents & {
@@ -190,13 +191,14 @@ export default class InternalEthereumProviderService extends BaseService<Events>
       throw new Error("Transactions must have a from address for signing.")
     }
 
-    return new Promise<SignedEVMTransaction>((resolve) => {
+    return new Promise<SignedEVMTransaction>((resolve, reject) => {
       this.emitter.emit("transactionSignatureRequest", {
         payload: {
           ...convertedRequest,
           from,
         },
         resolver: resolve,
+        rejecter: reject,
       })
     })
   }

--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -156,11 +156,13 @@ export default class ProviderBridgeService extends BaseService<Events> {
 
         response.result = new EIP1193Error(
           EIP1193_ERROR_CODES.userRejectedRequest
-        )
+        ).toJSON()
       }
     } else {
       // sorry dear dApp, there is no love for you here
-      response.result = new EIP1193Error(EIP1193_ERROR_CODES.unauthorized)
+      response.result = new EIP1193Error(
+        EIP1193_ERROR_CODES.unauthorized
+      ).toJSON()
     }
 
     port.postMessage(response)

--- a/ui/pages/SignTransaction.tsx
+++ b/ui/pages/SignTransaction.tsx
@@ -3,6 +3,7 @@ import { useHistory, useLocation } from "react-router-dom"
 import { formatUnits } from "@ethersproject/units"
 import {
   broadcastSignedTransaction,
+  rejectTransactionSignature,
   selectEstimatedFeesPerGas,
   selectIsTransactionLoaded,
   selectIsTransactionSigned,
@@ -169,6 +170,10 @@ export default function SignTransaction(): ReactElement {
     },
   }
 
+  const handleReject = async () => {
+    await dispatch(rejectTransactionSignature())
+    history.goBack()
+  }
   const handleConfirm = async () => {
     if (isTransactionDataReady && transactionDetails) {
       dispatch(signTransaction(transactionDetails))
@@ -219,7 +224,7 @@ export default function SignTransaction(): ReactElement {
           iconSize="large"
           size="large"
           type="secondary"
-          onClick={() => history.goBack()}
+          onClick={handleReject}
         >
           Reject
         </SharedButton>


### PR DESCRIPTION
Also fixes some corner cases where an RPC request could fail
but the calling dApp would never find out about it.

Fixes #690.