### PR TITLE
Quicksand Accounting: Improve handling of dApp connections with multiple accounts

### DIFF
--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -278,14 +278,26 @@ export const selectAccountTotalsByCategory = createSelector(
   }
 )
 
+function findAccountTotal(
+  categorizedAccountTotals: CategorizedAccountTotals,
+  accountAddress: string
+): AccountTotal | undefined {
+  return Object.values(categorizedAccountTotals)
+    .flat()
+    .find(
+      ({ address }) => address.toLowerCase() === accountAddress.toLowerCase()
+    )
+}
+
+export const getAccountTotal = (
+  state: RootState,
+  accountAddress: string
+): AccountTotal | undefined =>
+  findAccountTotal(selectAccountTotalsByCategory(state), accountAddress)
+
 export const selectCurrentAccountTotal = createSelector(
-  selectCurrentAccount,
   selectAccountTotalsByCategory,
-  (currentAccount, categorizedAccountTotals): AccountTotal | undefined =>
-    Object.values(categorizedAccountTotals)
-      .flat()
-      .find(
-        ({ address }) =>
-          address.toLowerCase() === currentAccount?.address?.toLowerCase()
-      )
+  selectCurrentAccount,
+  (categorizedAccountTotals, currentAccount): AccountTotal | undefined =>
+    findAccountTotal(categorizedAccountTotals, currentAccount.address)
 )

--- a/background/redux-slices/selectors/dappPermissionSelectors.ts
+++ b/background/redux-slices/selectors/dappPermissionSelectors.ts
@@ -1,6 +1,7 @@
 import { createSelector } from "@reduxjs/toolkit"
 import { RootState } from ".."
 import { DAppPermissionState } from "../dapp-permission"
+import { selectCurrentAccount } from "./uiSelectors"
 
 export const getProviderBridgeState = (state: RootState): DAppPermissionState =>
   state.dappPermission
@@ -26,5 +27,12 @@ export const selectCurrentPendingPermission = createSelector(
 
 export const selectAllowedPages = createSelector(
   getProviderBridgeState,
-  (slice: DAppPermissionState) => slice.allowedPages
+  selectCurrentAccount,
+  (slice, currentAccount) =>
+    Object.fromEntries(
+      Object.entries(slice.allowedPages).filter(
+        ([_, { accountAddress }]) =>
+          accountAddress.toLowerCase() === currentAccount.address.toLowerCase()
+      )
+    )
 )

--- a/background/redux-slices/selectors/dappPermissionSelectors.ts
+++ b/background/redux-slices/selectors/dappPermissionSelectors.ts
@@ -26,12 +26,14 @@ export const selectCurrentPendingPermission = createSelector(
 )
 
 export const selectAllowedPages = createSelector(
-  getProviderBridgeState,
+  (state: RootState) => getProviderBridgeState(state).allowedPages,
   selectCurrentAccount,
-  (slice, currentAccount) =>
+  (allowedPages, currentAccount) =>
+    // Decompose the origin -> permission mapping and leave only the origin ->
+    // permissions that reference the current account address.
     Object.fromEntries(
-      Object.entries(slice.allowedPages).filter(
-        ([_, { accountAddress }]) =>
+      Object.entries(allowedPages).filter(
+        ([, { accountAddress }]) =>
           accountAddress.toLowerCase() === currentAccount.address.toLowerCase()
       )
     )

--- a/background/redux-slices/utils/activity-utils.ts
+++ b/background/redux-slices/utils/activity-utils.ts
@@ -1,6 +1,4 @@
-import dayjs from "dayjs"
 import { convertToEth, weiToGwei } from "../../lib/utils"
-import { AnyEVMTransaction } from "../../networks"
 import { EnrichedEVMTransaction } from "../../services/enrichment"
 
 function ethTransformer(

--- a/background/redux-slices/utils/activity-utils.ts
+++ b/background/redux-slices/utils/activity-utils.ts
@@ -108,11 +108,6 @@ export const keysMap: UIAdaptationMap<ActivityItem> = {
     transformer: ethTransformer,
     detailTransformer: ethTransformer,
   },
-  gasUsed: {
-    readableName: "Gas",
-    transformer: (val) => val.toString(),
-    detailTransformer: (val) => val.toString(),
-  },
   maxFeePerGas: {
     readableName: "Max Fee/Gas",
     transformer: gweiTransformer,
@@ -122,5 +117,10 @@ export const keysMap: UIAdaptationMap<ActivityItem> = {
     readableName: "Gas Price",
     transformer: gweiTransformer,
     detailTransformer: gweiTransformer,
+  },
+  gasUsed: {
+    readableName: "Gas",
+    transformer: (val) => val?.toString(),
+    detailTransformer: (val) => val?.toString(),
   },
 }

--- a/background/services/provider-bridge/db.ts
+++ b/background/services/provider-bridge/db.ts
@@ -46,7 +46,9 @@ export class ProviderBridgeServiceDatabase extends Dexie {
     return this.dAppPermissions.delete(origin)
   }
 
-  async checkPermission(origin: string) {
+  async checkPermission(
+    origin: string
+  ): Promise<PermissionRequest | undefined> {
     return this.dAppPermissions.get(origin)
   }
 

--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -113,6 +113,8 @@ export default class ProviderBridgeService extends BaseService<Events> {
 
     const response: PortResponseEvent = { id: event.id, result: [] }
 
+    const originPermission = await this.checkPermission(origin)
+
     if (isTallyInternalCommunication(event.request)) {
       // let's start with the internal communication
       response.id = "tallyHo"
@@ -120,10 +122,11 @@ export default class ProviderBridgeService extends BaseService<Events> {
         method: event.request.method,
         defaultWallet: await this.preferenceService.getDefaultWallet(),
       }
-    } else if (await this.checkPermission(origin)) {
+    } else if (typeof originPermission !== "undefined") {
       // if it's not internal but dapp has permission to communicate we proxy the request
       // TODO: here comes format validation
       response.result = await this.routeContentScriptRPCRequest(
+        originPermission,
         event.request.method,
         event.request.params
       )
@@ -145,10 +148,12 @@ export default class ProviderBridgeService extends BaseService<Events> {
 
       await blockUntilUserAction
 
-      if (await this.checkPermission(origin)) {
+      const persistedPermission = await this.checkPermission(origin)
+      if (typeof persistedPermission !== "undefined") {
         // if agrees then let's return the account data
 
         response.result = await this.routeContentScriptRPCRequest(
+          persistedPermission,
           "eth_accounts",
           event.request.params
         )
@@ -218,21 +223,23 @@ export default class ProviderBridgeService extends BaseService<Events> {
     }
   }
 
-  async checkPermission(origin: string): Promise<boolean> {
-    return this.db.checkPermission(origin).then((r) => !!r)
+  async checkPermission(
+    origin: string
+  ): Promise<PermissionRequest | undefined> {
+    return this.db.checkPermission(origin)
   }
 
   async routeContentScriptRPCRequest(
+    enablingPermission: PermissionRequest,
     method: string,
     params: RPCRequest["params"]
   ): Promise<unknown> {
     try {
       switch (method) {
         case "eth_requestAccounts":
-          return await this.internalEthereumProviderService.routeSafeRPCRequest(
-            "eth_accounts",
-            params
-          )
+        case "eth_accounts":
+          return [enablingPermission.accountAddress]
+
         case "eth_signTransaction":
         case "eth_sendTransaction":
           // We are monsters.

--- a/ui/components/Shared/SharedCurrentAccountInformation.tsx
+++ b/ui/components/Shared/SharedCurrentAccountInformation.tsx
@@ -1,17 +1,16 @@
 import React, { ReactElement } from "react"
 
-import { selectCurrentAccountTotal } from "@tallyho/tally-background/redux-slices/selectors"
-import { useBackgroundSelector } from "../../hooks"
+type Props = {
+  shortenedAddress: string
+  name: string | undefined
+  avatarURL: string | undefined
+}
 
-export default function SharedCurrentAccountInformation(): ReactElement {
-  const currentAccountTotal = useBackgroundSelector(selectCurrentAccountTotal)
-
-  if (typeof currentAccountTotal === "undefined") {
-    return <></>
-  }
-
-  const { shortenedAddress, name, avatarURL } = currentAccountTotal
-
+export default function SharedCurrentAccountInformation({
+  shortenedAddress,
+  name,
+  avatarURL,
+}: Props): ReactElement {
   return (
     <>
       {name ?? shortenedAddress}

--- a/ui/components/SignTransaction/SignTransactionNetworkAccountInfoTopBar.tsx
+++ b/ui/components/SignTransaction/SignTransactionNetworkAccountInfoTopBar.tsx
@@ -1,7 +1,26 @@
+import { HexString } from "@tallyho/tally-background/types"
+import { getAccountTotal } from "@tallyho/tally-background/redux-slices/selectors"
 import React, { ReactElement } from "react"
+import { useBackgroundSelector } from "../../hooks"
 import SharedCurrentAccountInformation from "../Shared/SharedCurrentAccountInformation"
 
-export default function SignTransactionNetworkAccountInfoTopBar(): ReactElement {
+type Props = {
+  transactionSenderAddress: HexString
+}
+
+export default function SignTransactionNetworkAccountInfoTopBar({
+  transactionSenderAddress,
+}: Props): ReactElement {
+  const accountTotal = useBackgroundSelector((state) =>
+    getAccountTotal(state, transactionSenderAddress)
+  )
+
+  if (typeof accountTotal === "undefined") {
+    return <></>
+  }
+
+  const { shortenedAddress, name, avatarURL } = accountTotal
+
   return (
     <div className="top_bar_wrap standard_width">
       <div className="row_part">
@@ -9,7 +28,11 @@ export default function SignTransactionNetworkAccountInfoTopBar(): ReactElement 
         <span className="network_name">Arbitrum</span>
       </div>
       <div className="row_part">
-        <SharedCurrentAccountInformation />
+        <SharedCurrentAccountInformation
+          shortenedAddress={shortenedAddress}
+          name={name}
+          avatarURL={avatarURL}
+        />
       </div>
       <style jsx>
         {`

--- a/ui/components/SignTransaction/SignTransactionNetworkAccountInfoTopBar.tsx
+++ b/ui/components/SignTransaction/SignTransactionNetworkAccountInfoTopBar.tsx
@@ -1,20 +1,14 @@
-import { HexString } from "@tallyho/tally-background/types"
-import { getAccountTotal } from "@tallyho/tally-background/redux-slices/selectors"
+import { AccountTotal } from "@tallyho/tally-background/redux-slices/selectors"
 import React, { ReactElement } from "react"
-import { useBackgroundSelector } from "../../hooks"
 import SharedCurrentAccountInformation from "../Shared/SharedCurrentAccountInformation"
 
 type Props = {
-  transactionSenderAddress: HexString
+  accountTotal: AccountTotal
 }
 
 export default function SignTransactionNetworkAccountInfoTopBar({
-  transactionSenderAddress,
+  accountTotal,
 }: Props): ReactElement {
-  const accountTotal = useBackgroundSelector((state) =>
-    getAccountTotal(state, transactionSenderAddress)
-  )
-
   if (typeof accountTotal === "undefined") {
     return <></>
   }

--- a/ui/components/TopMenu/TopMenuProfileButton.tsx
+++ b/ui/components/TopMenu/TopMenuProfileButton.tsx
@@ -1,13 +1,27 @@
+import { selectCurrentAccountTotal } from "@tallyho/tally-background/redux-slices/selectors"
 import React, { ReactElement } from "react"
+import { useBackgroundSelector } from "../../hooks"
 import SharedCurrentAccountInformation from "../Shared/SharedCurrentAccountInformation"
 
 export default function TopMenuProfileButton(props: {
   onClick?: () => void
 }): ReactElement {
+  const { shortenedAddress, name, avatarURL } =
+    useBackgroundSelector(selectCurrentAccountTotal) ?? {}
+
   const { onClick } = props
+
   return (
     <button type="button" onClick={onClick}>
-      <SharedCurrentAccountInformation />
+      {typeof shortenedAddress === "undefined" ? (
+        <></>
+      ) : (
+        <SharedCurrentAccountInformation
+          shortenedAddress={shortenedAddress}
+          name={name}
+          avatarURL={avatarURL}
+        />
+      )}
       <style jsx>
         {`
           button {

--- a/ui/pages/SignTransaction.tsx
+++ b/ui/pages/SignTransaction.tsx
@@ -11,7 +11,9 @@ import {
   signTransaction,
   updateTransactionOptions,
 } from "@tallyho/tally-background/redux-slices/transaction-construction"
+import { getAccountTotal } from "@tallyho/tally-background/redux-slices/selectors"
 import { BlockEstimate } from "@tallyho/tally-background/networks"
+import { AccountType } from "@tallyho/tally-background/redux-slices/accounts"
 import SharedButton from "../components/Shared/SharedButton"
 import SharedPanelSwitcher from "../components/Shared/SharedPanelSwitcher"
 import SignTransactionSwapAssetBlock from "../components/SignTransaction/SignTransactionSwapAssetBlock"
@@ -63,6 +65,12 @@ export default function SignTransaction(): ReactElement {
     ({ transactionConstruction }) => transactionConstruction.signedTransaction
   )
   const transactionDetails = useBackgroundSelector(selectTransactionData)
+
+  const signerAccountTotal = useBackgroundSelector((state) =>
+    typeof transactionDetails === "undefined"
+      ? undefined
+      : getAccountTotal(state, transactionDetails.from)
+  )
 
   const [gasLimit, setGasLimit] = useState("")
   const estimatedFeesPerGas = useBackgroundSelector(selectEstimatedFeesPerGas)
@@ -126,7 +134,10 @@ export default function SignTransaction(): ReactElement {
     return <></>
   }
 
-  if (typeof transactionDetails === "undefined") {
+  if (
+    typeof transactionDetails === "undefined" ||
+    typeof signerAccountTotal === "undefined"
+  ) {
     // TODO Some sort of unexpected state error if we end up here... Or do we
     // go back in history? That won't work for dApp popovers though.
     return <></>
@@ -184,7 +195,7 @@ export default function SignTransaction(): ReactElement {
   return (
     <section>
       <SignTransactionNetworkAccountInfoTopBar
-        transactionSenderAddress={transactionDetails.from}
+        accountTotal={signerAccountTotal}
       />
       <h1 className="serif_header title">{signContent[signType].title}</h1>
       <div className="primary_info_card standard_width">
@@ -230,15 +241,19 @@ export default function SignTransaction(): ReactElement {
         >
           Reject
         </SharedButton>
-        <SharedButton
-          type="primary"
-          iconSize="large"
-          size="large"
-          onClick={handleConfirm}
-          showLoadingOnClick
-        >
-          {signContent[signType].confirmButtonText}
-        </SharedButton>
+        {signerAccountTotal.accountType === AccountType.Imported ? (
+          <SharedButton
+            type="primary"
+            iconSize="large"
+            size="large"
+            onClick={handleConfirm}
+            showLoadingOnClick
+          >
+            {signContent[signType].confirmButtonText}
+          </SharedButton>
+        ) : (
+          <span className="no-signing">Read-only accounts cannot sign</span>
+        )}
       </div>
       <style jsx>
         {`

--- a/ui/pages/SignTransaction.tsx
+++ b/ui/pages/SignTransaction.tsx
@@ -183,7 +183,9 @@ export default function SignTransaction(): ReactElement {
 
   return (
     <section>
-      <SignTransactionNetworkAccountInfoTopBar />
+      <SignTransactionNetworkAccountInfoTopBar
+        transactionSenderAddress={transactionDetails.from}
+      />
       <h1 className="serif_header title">{signContent[signType].title}</h1>
       <div className="primary_info_card standard_width">
         {signContent[signType].component()}


### PR DESCRIPTION
The approach here roughly follows what I outlined in [this comment](https://github.com/tallycash/extension/issues/705#issuecomment-996413752).

In particular:
- The provider bridge only reports authorized addresses to dApps, not all
  wallet addresses. This bug could leak information.
- The provider bridge instantly rejects any signature requests for a
  transaction whose `from` address is not authorized. This occurs before
  the transaction transitions into the internal provider.
- The dApp connection icon in the header only appears if the current tab's
  origin is authorized to access the currently-selected account in the wallet.
- The sign transaction page header shows the account associated with the
  `from` address in the transaction being signed, rather than the currently-
  selected wallet account. For internal dApps and interactions like ETH send,
  these will be equivalent, but for dApp interactions they may not be, since
  the user may be connected with an account other than the one they last
  viewed in the wallet.

One additional tidbit here that followed naturally from the above: the user
may connect to a dApp with a read-only account, by design—this enables a
cross-dApp “explore” mode for users to explore dApps with cold accounts or
accounts they may be interested in learning more about. However, these accounts
naturally cannot sign. Previously, attempting to sign a transaction from such
an account would simply hang. Now, a message appears instead of the Sign button
letting the user know read-only accounts cannot sign. We should polish that up,
but it's better than the hang :)

--------

Fixes #705.

See #662, though this doesn't fix it—but I would argue this behavior is
overall preferable in some ways...