### PR TITLE
🐶 In top bar, replace dog name w/ shortened address

### DIFF
--- a/ui/components/Shared/SharedAssetInput.tsx
+++ b/ui/components/Shared/SharedAssetInput.tsx
@@ -262,7 +262,7 @@ export default function SharedAssetInput(
             box-sizing: border-box;
           }
           .token_input {
-            width: 204px;
+            width: 100%;
             height: 34px;
             font-size: 28px;
             font-weight: 500;

--- a/ui/components/Shared/SharedCurrentAccountInformation.tsx
+++ b/ui/components/Shared/SharedCurrentAccountInformation.tsx
@@ -14,7 +14,7 @@ export default function SharedCurrentAccountInformation(): ReactElement {
 
   return (
     <>
-      {name ?? shortenedAddress}
+      {name?.includes(".") ? name : shortenedAddress}
       <div className="avatar" />
       <style jsx>
         {`


### PR DESCRIPTION
Two **tiny** tweaks derived from real problems.

Currently there's a mental disconnect in the top nav wallet info provided, in
the dApp UI (shorted address) and our wallet (dog name), leaving users to
wonder. Basically, it's inconvenient to coordinate what's seen to make
decisions. In ~~buzzword~~ cognitive psychology terms, the cognitive load is too
high!
<img width="341" alt="Screen Shot 407" src="https://user-images.githubusercontent.com/1918798/146723811-b49e7868-0603-4588-9dea-7fa40f99c1a0.png">

So, for #714, we've brought back the shortened address in the top menu.

<img width="383" alt="topmenu" src="https://user-images.githubusercontent.com/1918798/146726136-a545e783-e89e-4485-a9d0-a0a1ebd8c5df.png">

But if you've got an ENS name, let's keep that because:
1) They're lovely.
2) They're what's expected. That's what dApps are displaying.

<img width="379" alt="ENS" src="https://user-images.githubusercontent.com/1918798/146726199-b3d324b1-686f-4da8-8e8d-188f04527469.png">

As for the code, this is resolved in literally one line change. Why? It's easy!
It's simple! But also, for real, once our account switcher names can be edited,
perhaps we'd like to bring back defaulting to the names. To be determined. It's
easy to revert.

Closes #714

<br/>

The other one-liner just fixes the send ETH address input width. The smaller
width originally accommodated the position of the paste button. The paste
button is no longer included. So gimme back the input space. Granted, a working
paste button would be much better. I believe we'd need to ask for more
permissions, though. Specifically clipboardRead. Is it worth getting access to
the whole clipboard for a paste button?