### PR TITLE
✨ Fancy input labels

### DIFF
--- a/ui/components/Keyring/KeyringSetPassword.tsx
+++ b/ui/components/Keyring/KeyringSetPassword.tsx
@@ -66,7 +66,7 @@ export default function KeyringSetPassword(): ReactElement {
         <div className="input_wrap">
           <SharedInput
             type="password"
-            placeholder="Password"
+            label="Password"
             onChange={handleInputChange(setPassword)}
             errorMessage={passwordErrorMessage}
           />
@@ -74,7 +74,7 @@ export default function KeyringSetPassword(): ReactElement {
         <div className="input_wrap repeat_password_wrap">
           <SharedInput
             type="password"
-            placeholder="Repeat Password"
+            label="Repeat Password"
             onChange={handleInputChange(setPasswordConfirmation)}
             errorMessage={passwordErrorMessage}
           />

--- a/ui/components/Keyring/KeyringUnlock.tsx
+++ b/ui/components/Keyring/KeyringUnlock.tsx
@@ -66,7 +66,7 @@ export default function KeyringUnlock(): ReactElement {
         <div className="input_wrap">
           <SharedInput
             type="password"
-            placeholder="Password"
+            label="Password"
             onChange={(value) => {
               setPassword(value)
               // Clear error message on input change

--- a/ui/components/NetworkFees/NetworkFeesChooser.tsx
+++ b/ui/components/NetworkFees/NetworkFeesChooser.tsx
@@ -243,15 +243,14 @@ export default function NetworkFeesChooser({
             })}
             <div className="info">
               <div className="limit">
-                <label className="limit_label" htmlFor="gasLimit">
-                  Gas limit
-                </label>
                 <SharedInput
                   id="gasLimit"
                   value={gasLimit}
                   onChange={(val) => setGasLimit(val)}
+                  defaultValue="21000"
                   label="Gas limit"
                   type="number"
+                  focusedLabelBackgroundColor="var(--green-95)"
                 />
               </div>
               <div className="max_fee">
@@ -327,15 +326,6 @@ export default function NetworkFeesChooser({
             margin: 16px 0;
             width: 40%;
             position: relative;
-          }
-          .limit_label {
-            position: absolute;
-            top: -8px;
-            left: 10px;
-            font-size: 12px;
-            padding: 0 4px;
-            background-color: var(--green-95);
-            color: var(--green-40);
           }
           .title {
             font-size: 22px;

--- a/ui/components/NetworkFees/NetworkFeesChooser.tsx
+++ b/ui/components/NetworkFees/NetworkFeesChooser.tsx
@@ -250,7 +250,7 @@ export default function NetworkFeesChooser({
                   id="gasLimit"
                   value={gasLimit}
                   onChange={(val) => setGasLimit(val)}
-                  placeholder="21000"
+                  label="Gas limit"
                   type="number"
                 />
               </div>

--- a/ui/components/Shared/SharedInput.tsx
+++ b/ui/components/Shared/SharedInput.tsx
@@ -25,7 +25,7 @@ export default function SharedInput(props: Props): ReactElement {
           error: errorMessage,
         })}
       />
-      <label htmlFor={id}>{placeholder}</label>
+      <label htmlFor={id}>{label}</label>
       {errorMessage && <div className="error_message">{errorMessage}</div>}
       <style jsx>
         {`
@@ -89,6 +89,5 @@ export default function SharedInput(props: Props): ReactElement {
 }
 
 SharedInput.defaultProps = {
-  placeholder: "",
   type: "text",
 }

--- a/ui/components/Shared/SharedInput.tsx
+++ b/ui/components/Shared/SharedInput.tsx
@@ -18,13 +18,14 @@ export default function SharedInput(props: Props): ReactElement {
       <input
         id={id}
         type={type}
-        placeholder={placeholder}
+        placeholder=" "
         value={value}
         onChange={(event) => onChange?.(event.target.value)}
         className={classNames({
           error: errorMessage,
         })}
       />
+      <label htmlFor={id}>{placeholder}</label>
       {errorMessage && <div className="error_message">{errorMessage}</div>}
       <style jsx>
         {`
@@ -56,6 +57,30 @@ export default function SharedInput(props: Props): ReactElement {
             font-size: 14px;
             line-height: 20px;
             margin-top: 3px;
+          }
+          label {
+            position: absolute;
+            pointer-events: none;
+            display: flex;
+            width: fit-content;
+            margin-left: 16px;
+            transform: translateY(-32px);
+            background-color: var(--hunter-green);
+            border-radius: 5px;
+            box-sizing: border-box;
+            color: var(--green-40);
+            transition: font-size 0.2s ease, transform 0.2s ease,
+              font-weight 0.2s ease, padding 0.2s ease;
+          }
+          input:focus ~ label,
+          input:not(:placeholder-shown) ~ label {
+            transform: translateY(-57px) translateX(-5px);
+            font-size: 12px;
+            font-weight: 500;
+            padding: 0px 6px;
+          }
+          .error ~ label {
+            color: var(--error);
           }
         `}
       </style>

--- a/ui/components/Shared/SharedInput.tsx
+++ b/ui/components/Shared/SharedInput.tsx
@@ -1,9 +1,12 @@
-import classNames from "classnames"
 import React, { ReactElement } from "react"
+import classNames from "classnames"
+import { useRunOnFirstRender } from "../../hooks"
 
 interface Props {
   id?: string
-  placeholder: string
+  label: string
+  focusedLabelBackgroundColor: string
+  defaultValue?: string
   type: "password" | "text" | "number"
   value?: string | number | undefined
   onChange?: (value: string) => void
@@ -11,7 +14,22 @@ interface Props {
 }
 
 export default function SharedInput(props: Props): ReactElement {
-  const { id, placeholder, type, onChange, value, errorMessage } = props
+  const {
+    id,
+    label,
+    defaultValue,
+    focusedLabelBackgroundColor,
+    type,
+    onChange,
+    value,
+    errorMessage,
+  } = props
+
+  useRunOnFirstRender(() => {
+    if (defaultValue) {
+      onChange?.(defaultValue)
+    }
+  })
 
   return (
     <>
@@ -20,6 +38,7 @@ export default function SharedInput(props: Props): ReactElement {
         type={type}
         placeholder=" "
         value={value}
+        spellCheck={false}
         onChange={(event) => onChange?.(event.target.value)}
         className={classNames({
           error: errorMessage,
@@ -65,7 +84,7 @@ export default function SharedInput(props: Props): ReactElement {
             width: fit-content;
             margin-left: 16px;
             transform: translateY(-32px);
-            background-color: var(--hunter-green);
+            background-color: ${focusedLabelBackgroundColor};
             border-radius: 5px;
             box-sizing: border-box;
             color: var(--green-40);
@@ -90,4 +109,5 @@ export default function SharedInput(props: Props): ReactElement {
 
 SharedInput.defaultProps = {
   type: "text",
+  focusedLabelBackgroundColor: "var(--hunter-green)",
 }

--- a/ui/hooks.ts
+++ b/ui/hooks.ts
@@ -4,7 +4,7 @@ import { selectKeyringStatus } from "@tallyho/tally-background/redux-slices/sele
 import { useHistory } from "react-router-dom"
 
 import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux"
-import { RefObject, useState, useEffect } from "react"
+import { RefObject, useState, useEffect, useRef } from "react"
 
 export const useBackgroundDispatch = (): BackgroundDispatch =>
   useDispatch<BackgroundDispatch>()
@@ -72,6 +72,7 @@ export function useIsDappPopup(): boolean {
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
     const maybePage = params.get("page")
+
     if (isAllowedQueryParamPage(maybePage)) {
       setIsDappPopup(true)
     } else {
@@ -80,4 +81,13 @@ export function useIsDappPopup(): boolean {
   }, [])
 
   return isDappPopup
+}
+
+export function useRunOnFirstRender(func: () => void): void {
+  const isFirst = useRef(true)
+
+  if (isFirst.current) {
+    isFirst.current = false
+    func()
+  }
 }

--- a/ui/pages/Onboarding/OnboardingViewOnlyWallet.tsx
+++ b/ui/pages/Onboarding/OnboardingViewOnlyWallet.tsx
@@ -61,7 +61,7 @@ export default function OnboardingViewOnlyWallet(): ReactElement {
       >
         <div className="input_wrap">
           <SharedInput
-            placeholder="ETH address"
+            label="ETH address"
             onChange={handleInputChange}
             errorMessage={errorMessage}
           />

--- a/ui/public/popup.html
+++ b/ui/public/popup.html
@@ -2,10 +2,6 @@
   <head>
     <meta charset="utf-8" />
     <title>Tally</title>
-    <link rel="preload" as="font" href="./fonts/QuincyCF-Medium.woff2" />
-    <link rel="preload" as="font" href="./fonts/segment-semibold.woff2" />
-    <link rel="preload" as="font" href="./fonts/segment-regular.woff2" />
-    <link rel="preload" as="image" href="./images/dark_forest@2x.png" />
     <link rel="stylesheet" href="./fonts.css" />
     <link rel="stylesheet" href="./index.css" />
   </head>


### PR DESCRIPTION
Of note, I added a `useRunOnFirstRender` hook. I've added it because the
`useEffect` approach of passing `[]` hits snag here — the functions need to be
passed, which breaks it running only on first render.

- `SharedInput` now can accept a default value
- The animated label can adapt to different backgrounds, like in a slide up
menu
- The label will turn red on an error

<img width="340" alt="ENS" src="https://user-images.githubusercontent.com/1918798/147139916-9bb5329a-8a64-4cf6-a55d-daa3756c97f1.gif">