### PR TITLE
Alchemical Misadventures: Loosen the Alchemy API validation to allow errors

### DIFF
--- a/background/lib/alchemy.ts
+++ b/background/lib/alchemy.ts
@@ -161,8 +161,8 @@ const alchemyTokenBalanceJTD = {
       elements: {
         properties: {
           contractAddress: { type: "string" },
-          error: { type: "string", nullable: true },
           tokenBalance: { type: "string", nullable: true },
+          error: {},
         },
       },
     },


### PR DESCRIPTION
A couple bad token contracts were preventing us from balance checking the entire token list. This should handle it.

Closes #746