### PR TITLE
Fix a bug where low balance ETH would be hidden

### DIFF
--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -172,6 +172,7 @@ export const selectCurrentAccountBalances = createSelector(
           typeof assetAmount.mainCurrencyAmount === "undefined"
             ? true
             : assetAmount.mainCurrencyAmount > userValueDustThreshold
+        // TODO Update below to be network responsive
         const isPresent =
           assetAmount.decimalAmount > 0 || assetAmount.asset.symbol === "ETH"
 

--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -172,7 +172,8 @@ export const selectCurrentAccountBalances = createSelector(
           typeof assetAmount.mainCurrencyAmount === "undefined"
             ? true
             : assetAmount.mainCurrencyAmount > userValueDustThreshold
-        const isPresent = assetAmount.decimalAmount > 0
+        const isPresent =
+          assetAmount.decimalAmount > 0 || assetAmount.asset.symbol === "ETH"
 
         // Hide dust and missing amounts.
         return hideDust ? isNotDust && isPresent : isPresent


### PR DESCRIPTION
We always want to show ETH balance regardless of its amount.