### PR TITLE
Pull updated ETH balance after transaction

### DIFF
--- a/background/lib/alchemy.ts
+++ b/background/lib/alchemy.ts
@@ -174,17 +174,6 @@ const isValidAlchemyTokenBalanceResponse = jtdValidatorFor(
   alchemyTokenBalanceJTD
 )
 
-export async function getMainNetworkCurrencyBalance(
-  provider: AlchemyProvider | AlchemyWebSocketProvider,
-  address: HexString
-): Promise<{ amount: bigint }> {
-  const json: HexString = await provider.send("eth_getBalance", [
-    address,
-    "latest",
-  ])
-  return { amount: BigInt(json) }
-}
-
 /**
  * Use Alchemy's getTokenBalances call to get balances for a particular address.
  *

--- a/background/lib/alchemy.ts
+++ b/background/lib/alchemy.ts
@@ -174,6 +174,17 @@ const isValidAlchemyTokenBalanceResponse = jtdValidatorFor(
   alchemyTokenBalanceJTD
 )
 
+export async function getMainNetworkCurrencyBalance(
+  provider: AlchemyProvider | AlchemyWebSocketProvider,
+  address: HexString
+): Promise<{ amount: bigint }> {
+  const json: HexString = await provider.send("eth_getBalance", [
+    address,
+    "latest",
+  ])
+  return { amount: BigInt(json) }
+}
+
 /**
  * Use Alchemy's getTokenBalances call to get balances for a particular address.
  *

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -270,11 +270,7 @@ export default class IndexingService extends BaseService<Events> {
           address: transaction.from.toLowerCase(),
           network: getEthereumNetwork(),
         }
-        const balance = await this.chainService.getLatestBaseAccountBalance(
-          addressNetwork
-        )
-        this.emitter.emit("accountBalance", balance)
-        await this.db.addBalances([balance])
+        await this.chainService.getLatestBaseAccountBalance(addressNetwork)
       }
     })
   }

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -265,7 +265,10 @@ export default class IndexingService extends BaseService<Events> {
       ) {
         this.scheduledTokenRefresh = true
       }
-      if ("status" in transaction && (transaction.status === 1 || 0)) {
+      if (
+        "status" in transaction &&
+        (transaction.status === 1 || transaction.status === 0)
+      ) {
         const addressNetwork = {
           address: transaction.from.toLowerCase(),
           network: getEthereumNetwork(),

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -13,11 +13,7 @@ import {
 } from "../../assets"
 import { BTC, ETH, FIAT_CURRENCIES, USD } from "../../constants"
 import { getBalances as getAssetBalances } from "../../lib/erc20"
-import {
-  getMainNetworkCurrencyBalance,
-  getTokenBalances,
-  getTokenMetadata,
-} from "../../lib/alchemy"
+import { getTokenBalances, getTokenMetadata } from "../../lib/alchemy"
 import { getPrices, getEthereumTokenPrices } from "../../lib/prices"
 import {
   fetchAndValidateTokenList,
@@ -512,23 +508,6 @@ export default class IndexingService extends BaseService<Events> {
     const activeAssetsToTrack = assetsToTrack.filter(
       (t) => t.homeNetwork.chainID === getEthereumNetwork().chainID
     )
-    const accounts = await this.chainService.getAccountsToTrack()
-    const mainCurrencyBalance = await getMainNetworkCurrencyBalance(
-      this.chainService.pollingProviders.ethereum,
-      accounts[0].address
-    )
-    const accountBalance = {
-      address: accounts[0].address,
-      assetAmount: {
-        asset: ETH,
-        amount: mainCurrencyBalance.amount,
-      },
-      network: getEthereumNetwork(),
-      dataSource: "alchemy",
-      retrievedAt: Date.now(),
-    } as AccountBalance
-    this.emitter.emit("accountBalance", accountBalance)
-    await this.db.addBalances([accountBalance])
 
     // wait on balances being written to the db, don't wait on event emission
     await Promise.allSettled(

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -265,6 +265,17 @@ export default class IndexingService extends BaseService<Events> {
       ) {
         this.scheduledTokenRefresh = true
       }
+      if ("status" in transaction && (transaction.status === 1 || 0)) {
+        const addressNetwork = {
+          address: transaction.from.toLowerCase(),
+          network: getEthereumNetwork(),
+        }
+        const balance = await this.chainService.getLatestBaseAccountBalance(
+          addressNetwork
+        )
+        this.emitter.emit("accountBalance", balance)
+        await this.db.addBalances([balance])
+      }
     })
   }
 

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -13,7 +13,11 @@ import {
 } from "../../assets"
 import { BTC, ETH, FIAT_CURRENCIES, USD } from "../../constants"
 import { getBalances as getAssetBalances } from "../../lib/erc20"
-import { getTokenBalances, getTokenMetadata } from "../../lib/alchemy"
+import {
+  getMainNetworkCurrencyBalance,
+  getTokenBalances,
+  getTokenMetadata,
+} from "../../lib/alchemy"
 import { getPrices, getEthereumTokenPrices } from "../../lib/prices"
 import {
   fetchAndValidateTokenList,
@@ -508,6 +512,23 @@ export default class IndexingService extends BaseService<Events> {
     const activeAssetsToTrack = assetsToTrack.filter(
       (t) => t.homeNetwork.chainID === getEthereumNetwork().chainID
     )
+    const accounts = await this.chainService.getAccountsToTrack()
+    const mainCurrencyBalance = await getMainNetworkCurrencyBalance(
+      this.chainService.pollingProviders.ethereum,
+      accounts[0].address
+    )
+    const accountBalance = {
+      address: accounts[0].address,
+      assetAmount: {
+        asset: ETH,
+        amount: mainCurrencyBalance.amount,
+      },
+      network: getEthereumNetwork(),
+      dataSource: "alchemy",
+      retrievedAt: Date.now(),
+    } as AccountBalance
+    this.emitter.emit("accountBalance", accountBalance)
+    await this.db.addBalances([accountBalance])
 
     // wait on balances being written to the db, don't wait on event emission
     await Promise.allSettled(


### PR DESCRIPTION
This PR fixes the ETH balance update once a transaction is completed.

Users should see the new balance within one minute from the transaction confirmation.