### PR TITLE
🐦 Migratory Bird Treaty Act: Refactor the Redux store with a proposed migration mechanism

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -81,15 +81,62 @@ const devToolsSanitizer = (input: unknown) => {
 
 // The version of persisted Redux state the extension is expecting. Any previous
 // state without this version, or with a lower version, ought to be migrated.
-const REDUX_STATE_VERSION = 1
+const REDUX_STATE_VERSION = 2
+
+type Migration = (prevState: Record<string, unknown>) => Record<string, unknown>
+
+// An object mapping a version number to a state migration. Each migration for
+// version n is expected to take a state consistent with version n-1, and return
+// state consistent with version n.
+const REDUX_MIGRATIONS: { [version: number]: Migration } = {
+  2: (prevState: Record<string, unknown>) => {
+    // Migrate the old currentAccount SelectedAccount type to a bare
+    // selectedAccount AddressNetwork type. Note the avoidance of imported types
+    // so this migration will work in the future, regardless of other code changes
+    type BroadAddressNetwork = {
+      address: string
+      network: Record<string, unknown>
+    }
+    type OldState = {
+      ui: {
+        currentAccount?: {
+          addressNetwork: BroadAddressNetwork
+          truncatedAddress: string
+        }
+      }
+    }
+    const newState = { ...prevState }
+    const addressNetwork = (prevState as OldState)?.ui?.currentAccount
+      ?.addressNetwork
+    delete (newState as OldState)?.ui?.currentAccount
+    newState.selectedAccount = addressNetwork as BroadAddressNetwork
+    return newState
+  },
+}
 
 // Migrate a previous version of the Redux state to that expected by the current
 // code base.
 function migrateReduxState(
   previousState: Record<string, unknown>,
-  version?: number
+  previousVersion?: number
 ): Record<string, unknown> {
-  return previousState
+  const resolvedVersion = previousVersion ?? 1
+  let migratedState: Record<string, unknown> = previousState
+
+  if (resolvedVersion < REDUX_STATE_VERSION) {
+    const outstandingMigrations = Object.entries(REDUX_MIGRATIONS)
+      .sort()
+      .filter(([version]) => parseInt(version, 10) > resolvedVersion)
+      .map(([, migration]) => migration)
+    migratedState = outstandingMigrations.reduce(
+      (state: Record<string, unknown>, migration: Migration) => {
+        return migration(state)
+      },
+      migratedState
+    )
+  }
+
+  return migratedState
 }
 
 const reduxCache: Middleware = (store) => (next) => (action) => {

--- a/background/main.ts
+++ b/background/main.ts
@@ -21,6 +21,7 @@ import {
 
 import { KeyringTypes } from "./types"
 import { EIP1559TransactionRequest, SignedEVMTransaction } from "./networks"
+import { ETHEREUM } from "./constants/networks"
 
 import rootReducer from "./redux-slices"
 import {
@@ -43,7 +44,7 @@ import {
   initializationLoadingTimeHitLimit,
   emitter as uiSliceEmitter,
   setDefaultWallet,
-  setCurrentAccount,
+  setSelectedAccount,
 } from "./redux-slices/ui"
 import {
   estimatedFeesPerGas,
@@ -616,12 +617,16 @@ export default class Main extends BaseService<never> {
           // Initialize redux from the db
           // !!! Important: this action belongs to a regular reducer.
           // NOT to be confused with the setNewCurrentAddress asyncThunk
-          this.store.dispatch(setCurrentAccount(dbCurrentAddress))
+          this.store.dispatch(
+            setSelectedAccount({
+              address: dbCurrentAddress,
+              network: ETHEREUM,
+            })
+          )
         } else {
           // Update currentAddress in db if it's not set but it is in the store
           // should run only one time
-          const { address } =
-            this.store.getState().ui.currentAccount.addressNetwork
+          const { address } = this.store.getState().ui.selectedAccount
 
           if (address) {
             await this.preferenceService.setCurrentAddress(address)

--- a/background/main.ts
+++ b/background/main.ts
@@ -21,7 +21,7 @@ import {
 
 import { KeyringTypes } from "./types"
 import { EIP1559TransactionRequest, SignedEVMTransaction } from "./networks"
-import { ETHEREUM } from "./constants/networks"
+import { AddressNetwork } from "./accounts"
 
 import rootReducer from "./redux-slices"
 import {
@@ -610,36 +610,31 @@ export default class Main extends BaseService<never> {
     )
 
     this.preferenceService.emitter.on(
-      "initializeCurrentAddress",
-      async (dbCurrentAddress: string) => {
-        if (dbCurrentAddress) {
+      "initializeSelectedAccount",
+      async (dbAddressNetwork: AddressNetwork) => {
+        if (dbAddressNetwork) {
           // TBD: naming the normal reducer and async thunks
           // Initialize redux from the db
           // !!! Important: this action belongs to a regular reducer.
           // NOT to be confused with the setNewCurrentAddress asyncThunk
-          this.store.dispatch(
-            setSelectedAccount({
-              address: dbCurrentAddress,
-              network: ETHEREUM,
-            })
-          )
+          this.store.dispatch(setSelectedAccount(dbAddressNetwork))
         } else {
           // Update currentAddress in db if it's not set but it is in the store
           // should run only one time
-          const { address } = this.store.getState().ui.selectedAccount
+          const addressNetwork = this.store.getState().ui.selectedAccount
 
-          if (address) {
-            await this.preferenceService.setCurrentAddress(address)
+          if (addressNetwork) {
+            await this.preferenceService.setSelectedAccount(addressNetwork)
           }
         }
       }
     )
 
-    uiSliceEmitter.on("newCurrentAddress", async (newCurrentAddress) => {
-      await this.preferenceService.setCurrentAddress(newCurrentAddress)
+    uiSliceEmitter.on("newSelectedAccount", async (addressNetwork) => {
+      await this.preferenceService.setSelectedAccount(addressNetwork)
 
       this.providerBridgeService.notifyContentScriptsAboutAddressChange(
-        newCurrentAddress
+        addressNetwork.address
       )
     })
 

--- a/background/redux-slices/keyrings.ts
+++ b/background/redux-slices/keyrings.ts
@@ -2,7 +2,7 @@ import { createSlice } from "@reduxjs/toolkit"
 import Emittery from "emittery"
 
 import { KeyringTypes } from "../types"
-import { setNewCurrentAddress } from "./ui"
+import { setNewSelectedAccount, UIState } from "./ui"
 import { createBackgroundAsyncThunk } from "./utils"
 
 // TODO this is very simple. We'll want to expand to include "capabilities" per
@@ -44,16 +44,16 @@ export const importLegacyKeyring = createBackgroundAsyncThunk(
   ) => {
     await emitter.emit("importLegacyKeyring", { mnemonic, path })
 
+    const { keyrings, ui } = getState() as { keyrings: KeyringsState, ui: UIState }
     // Set the selected account as the first address of the last added keyring,
     // which will correspond to the last imported keyring, AKA this one. Note that
     // this does rely on the KeyringService's behavior of pushing new keyrings to
     // the end of the keyring list.
     dispatch(
-      setNewCurrentAddress(
-        (getState() as { keyrings: KeyringsState }).keyrings.keyrings.slice(
-          -1
-        )[0].addresses[0]
-      )
+      setNewSelectedAccount({
+        address: keyrings.keyrings.slice(-1)[0].addresses[0],
+        network: ui.selectedAccount.network,
+      })
     )
   }
 )

--- a/background/redux-slices/keyrings.ts
+++ b/background/redux-slices/keyrings.ts
@@ -44,7 +44,10 @@ export const importLegacyKeyring = createBackgroundAsyncThunk(
   ) => {
     await emitter.emit("importLegacyKeyring", { mnemonic, path })
 
-    const { keyrings, ui } = getState() as { keyrings: KeyringsState, ui: UIState }
+    const { keyrings, ui } = getState() as {
+      keyrings: KeyringsState
+      ui: UIState
+    }
     // Set the selected account as the first address of the last added keyring,
     // which will correspond to the last imported keyring, AKA this one. Note that
     // this does rely on the KeyringService's behavior of pushing new keyrings to

--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -29,9 +29,7 @@ const userValueDustThreshold = 2
 
 const getAccountState = (state: RootState) => state.account
 const getCurrentAccountState = (state: RootState) => {
-  return state.account.accountsData[
-    state.ui.selectedAccount.address
-  ]
+  return state.account.accountsData[state.ui.selectedAccount.address]
 }
 const getAssetsState = (state: RootState) => state.assets
 

--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -30,7 +30,7 @@ const userValueDustThreshold = 2
 const getAccountState = (state: RootState) => state.account
 const getCurrentAccountState = (state: RootState) => {
   return state.account.accountsData[
-    state.ui.currentAccount.addressNetwork.address
+    state.ui.selectedAccount.address
   ]
 }
 const getAssetsState = (state: RootState) => state.assets

--- a/background/redux-slices/selectors/uiSelectors.ts
+++ b/background/redux-slices/selectors/uiSelectors.ts
@@ -33,16 +33,17 @@ export const selectShowingActivityDetail = createSelector(
 )
 
 export const selectCurrentAccount = createSelector(
-  (state: RootState) => state.ui.currentAccount,
-  ({ addressNetwork: { address }, truncatedAddress }) => ({
+  (state: RootState) => state.ui.selectedAccount,
+  ({ address, network }) => ({
     address,
-    truncatedAddress,
+    network,
+    truncatedAddress: address.toLowerCase().slice(0, 7),
   })
 )
 
 export const selectCurrentAddressNetwork = createSelector(
-  (state: RootState) => state.ui.currentAccount,
-  (currentAccount) => currentAccount
+  (state: RootState) => state.ui.selectedAccount,
+  (selectedAccount) => selectedAccount
 )
 
 export const selectMainCurrency = createSelector(

--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -20,7 +20,7 @@ export type UIState = {
 export type Events = {
   snackbarMessage: string
   newDefaultWalletValue: boolean
-  newCurrentAddress: string
+  newSelectedAccount: AddressNetwork
 }
 
 export const emitter = new Emittery<Events>()
@@ -115,7 +115,7 @@ export const setNewDefaultWalletValue = createBackgroundAsyncThunk(
 export const setNewSelectedAccount = createBackgroundAsyncThunk(
   "ui/setNewCurrentAddressValue",
   async (addressNetwork: AddressNetwork, { dispatch }) => {
-    await emitter.emit("newCurrentAddress", addressNetwork.address)
+    await emitter.emit("newSelectedAccount", addressNetwork)
     // Once the default value has persisted, propagate to the store.
     dispatch(uiSlice.actions.setSelectedAccount(addressNetwork))
   }

--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -4,18 +4,13 @@ import { AddressNetwork } from "../accounts"
 import { getEthereumNetwork } from "../lib/utils"
 import { createBackgroundAsyncThunk } from "./utils"
 
-type SelectedAccount = {
-  addressNetwork: AddressNetwork
-  truncatedAddress: string
-}
-
 const defaultSettings = {
   hideDust: false,
   defaultWallet: false,
 }
 
 export type UIState = {
-  currentAccount: SelectedAccount
+  selectedAccount: AddressNetwork
   showingActivityDetailID: string | null
   initializationLoadingTimeExpired: boolean
   settings: { hideDust: boolean; defaultWallet: boolean }
@@ -32,9 +27,9 @@ export const emitter = new Emittery<Events>()
 
 export const initialState: UIState = {
   showingActivityDetailID: null,
-  currentAccount: {
-    addressNetwork: { address: "", network: getEthereumNetwork() },
-    truncatedAddress: "",
+  selectedAccount: {
+    address: "",
+    network: getEthereumNetwork(),
   },
   initializationLoadingTimeExpired: false,
   settings: defaultSettings,
@@ -61,16 +56,8 @@ const uiSlice = createSlice({
       ...state,
       showingActivityDetailID: transactionID,
     }),
-    setCurrentAccount: (immerState, { payload: address }) => {
-      const lowercaseAddress = address.toLowerCase()
-
-      immerState.currentAccount = {
-        addressNetwork: {
-          address: lowercaseAddress,
-          network: getEthereumNetwork(),
-        },
-        truncatedAddress: lowercaseAddress.slice(0, 7),
-      }
+    setSelectedAccount: (immerState, { payload: addressNetwork }) => {
+      immerState.selectedAccount = addressNetwork
     },
     initializationLoadingTimeHitLimit: (state) => ({
       ...state,
@@ -106,7 +93,7 @@ export const {
   setShowingActivityDetail,
   initializationLoadingTimeHitLimit,
   toggleHideDust,
-  setCurrentAccount,
+  setSelectedAccount,
   setSnackbarMessage,
   setDefaultWallet,
   clearSnackbarMessage,
@@ -125,12 +112,12 @@ export const setNewDefaultWalletValue = createBackgroundAsyncThunk(
 )
 
 // TBD @Antonio: It would be good to have a consistent naming strategy
-export const setNewCurrentAddress = createBackgroundAsyncThunk(
+export const setNewSelectedAccount = createBackgroundAsyncThunk(
   "ui/setNewCurrentAddressValue",
-  async (currentAddress: string, { dispatch }) => {
-    await emitter.emit("newCurrentAddress", currentAddress)
+  async (addressNetwork: AddressNetwork, { dispatch }) => {
+    await emitter.emit("newCurrentAddress", addressNetwork.address)
     // Once the default value has persisted, propagate to the store.
-    dispatch(uiSlice.actions.setCurrentAccount(currentAddress))
+    dispatch(uiSlice.actions.setSelectedAccount(addressNetwork))
   }
 )
 

--- a/background/services/internal-ethereum-provider/index.ts
+++ b/background/services/internal-ethereum-provider/index.ts
@@ -132,8 +132,8 @@ export default class InternalEthereumProviderService extends BaseService<Events>
         return this.chainService.send(method, params)
       case "eth_accounts": {
         // This is a special method, because Alchemy provider DO support it, but always return null (because they do not store keys.)
-        const currentAccount = await this.preferenceService.getCurrentAddress()
-        return [currentAccount]
+        const { address } = await this.preferenceService.getSelectedAccount()
+        return [address]
       }
       case "eth_sendTransaction":
         return this.signTransaction(params[0] as EthersTransactionRequest).then(

--- a/background/services/preferences/db.ts
+++ b/background/services/preferences/db.ts
@@ -1,5 +1,7 @@
 import Dexie, { Transaction } from "dexie"
+
 import { FiatCurrency } from "../../assets"
+import { AddressNetwork } from "../../accounts"
 
 import DEFAULT_PREFERENCES from "./defaults"
 
@@ -8,10 +10,11 @@ import DEFAULT_PREFERENCES from "./defaults"
 export interface Preferences {
   id?: number
   savedAt: number
-  tokenLists: { autoUpdate: boolean; urls: Array<string> }
+  tokenLists: { autoUpdate: boolean; urls: string[] }
   currency: FiatCurrency
   defaultWallet: boolean
-  currentAddress: string
+  currentAddress?: string
+  selectedAccount: AddressNetwork
 }
 
 export class PreferenceDatabase extends Dexie {
@@ -57,10 +60,32 @@ export class PreferenceDatabase extends Dexie {
       preferences: "++id", // removed all the unused indexes
     })
 
+    //
+    this.version(4)
+      .stores({
+        preferences: "++id",
+      })
+      .upgrade((tx) => {
+        return tx
+          .table("preferences")
+          .toCollection()
+          .modify((storedPreferences: Preferences) => {
+            if (storedPreferences.currentAddress) {
+              storedPreferences.selectedAccount = {
+                network: DEFAULT_PREFERENCES.selectedAccount.network,
+                address: storedPreferences.currentAddress,
+              }
+            } else {
+              storedPreferences.selectedAccount =
+                DEFAULT_PREFERENCES.selectedAccount
+            }
+          })
+      })
+
     // This is the old version for populate
     // https://dexie.org/docs/Dexie/Dexie.on.populate-(old-version)
     // The this does not behave according the new docs, but works
-    this.on("populate", function (tx: Transaction) {
+    this.on("populate", (tx: Transaction) => {
       // This could be tx.preferences but the typing for populate
       // is not generic so it does not know about the preferences table
       tx.table("preferences").add(DEFAULT_PREFERENCES)
@@ -77,8 +102,8 @@ export class PreferenceDatabase extends Dexie {
     await this.preferences.toCollection().modify({ defaultWallet })
   }
 
-  async setCurrentAddress(currentAddress: string): Promise<void> {
-    await this.preferences.toCollection().modify({ currentAddress })
+  async setSelectedAccount(addressNetwork: AddressNetwork): Promise<void> {
+    await this.preferences.toCollection().modify({ selectedAccount: addressNetwork })
   }
 }
 

--- a/background/services/preferences/db.ts
+++ b/background/services/preferences/db.ts
@@ -43,7 +43,7 @@ export class PreferenceDatabase extends Dexie {
           .toCollection()
           .modify((storedPreferences: Preferences) => {
             if (!storedPreferences.defaultWallet) {
-              // Dexie api expects modification of the argument:
+              // Dexie API expects modification of the argument:
               // https://dexie.org/docs/Collection/Collection.modify()
               // eslint-disable-next-line no-param-reassign
               storedPreferences.defaultWallet =
@@ -71,11 +71,13 @@ export class PreferenceDatabase extends Dexie {
           .toCollection()
           .modify((storedPreferences: Preferences) => {
             if (storedPreferences.currentAddress) {
+              // eslint-disable-next-line no-param-reassign
               storedPreferences.selectedAccount = {
                 network: DEFAULT_PREFERENCES.selectedAccount.network,
                 address: storedPreferences.currentAddress,
               }
             } else {
+              // eslint-disable-next-line no-param-reassign
               storedPreferences.selectedAccount =
                 DEFAULT_PREFERENCES.selectedAccount
             }
@@ -103,7 +105,9 @@ export class PreferenceDatabase extends Dexie {
   }
 
   async setSelectedAccount(addressNetwork: AddressNetwork): Promise<void> {
-    await this.preferences.toCollection().modify({ selectedAccount: addressNetwork })
+    await this.preferences
+      .toCollection()
+      .modify({ selectedAccount: addressNetwork })
   }
 }
 

--- a/background/services/preferences/defaults.ts
+++ b/background/services/preferences/defaults.ts
@@ -1,7 +1,7 @@
-import { USD } from "../../constants"
+import { ETHEREUM, USD } from "../../constants"
 import { Preferences } from "./types"
 
-export default {
+const defaultPreferences: Preferences = {
   tokenLists: {
     autoUpdate: false,
     urls: [
@@ -15,5 +15,10 @@ export default {
   },
   currency: USD,
   defaultWallet: true,
-  currentAddress: "",
-} as Preferences
+  selectedAccount: {
+    address: "",
+    network: ETHEREUM,
+  },
+}
+
+export default defaultPreferences

--- a/background/services/preferences/index.ts
+++ b/background/services/preferences/index.ts
@@ -1,4 +1,5 @@
 import { FiatCurrency } from "../../assets"
+import { AddressNetwork } from "../../accounts"
 import { ServiceLifecycleEvents, ServiceCreatorFunction } from "../types"
 
 import { Preferences, TokenListPreferences } from "./types"
@@ -8,7 +9,7 @@ import BaseService from "../base"
 interface Events extends ServiceLifecycleEvents {
   preferencesChanges: Preferences
   initializeDefaultWallet: boolean
-  initializeCurrentAddress: string
+  initializeSelectedAccount: AddressNetwork
 }
 
 /*
@@ -36,8 +37,8 @@ export default class PreferenceService extends BaseService<Events> {
 
     this.emitter.emit("initializeDefaultWallet", await this.getDefaultWallet())
     this.emitter.emit(
-      "initializeCurrentAddress",
-      await this.getCurrentAddress()
+      "initializeSelectedAccount",
+      await this.getSelectedAccount()
     )
   }
 
@@ -63,11 +64,11 @@ export default class PreferenceService extends BaseService<Events> {
     return this.db.setDefaultWalletValue(newDefaultWalletValue)
   }
 
-  async getCurrentAddress(): Promise<string> {
-    return (await this.db.getPreferences())?.currentAddress
+  async getSelectedAccount(): Promise<AddressNetwork> {
+    return (await this.db.getPreferences())?.selectedAccount
   }
 
-  async setCurrentAddress(currentAddress: string): Promise<void> {
-    return this.db.setCurrentAddress(currentAddress)
+  async setSelectedAccount(addressNetwork: AddressNetwork): Promise<void> {
+    return this.db.setSelectedAccount(addressNetwork)
   }
 }

--- a/background/services/preferences/types.ts
+++ b/background/services/preferences/types.ts
@@ -1,4 +1,5 @@
 import { FiatCurrency } from "../../assets"
+import { AddressNetwork } from "../../accounts"
 
 export interface TokenListPreferences {
   autoUpdate: boolean
@@ -9,4 +10,5 @@ export interface Preferences {
   tokenLists: TokenListPreferences
   currency: FiatCurrency
   defaultWallet: boolean
+  selectedAccount: AddressNetwork
 }

--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -134,7 +134,7 @@ export default class ProviderBridgeService extends BaseService<Events> {
       // if it's external communication AND the dApp does not have permission BUT asks for it
       // then let's ask the user what he/she thinks
 
-      const accountAddress = await this.preferenceService.getCurrentAddress()
+      const { address: accountAddress } = await this.preferenceService.getSelectedAccount()
       const permissionRequest: PermissionRequest = {
         key: `${origin}_${accountAddress}`,
         origin,
@@ -241,9 +241,12 @@ export default class ProviderBridgeService extends BaseService<Events> {
     // FIXME proper error handling if this happens - should not tho
     if (permission.state !== "deny" || !permission.accountAddress) return
 
+    const { address } = await this.preferenceService.getSelectedAccount()
+
+    // TODO make this multi-network friendly
     await this.db.deletePermission(
       permission.origin,
-      await this.preferenceService.getCurrentAddress()
+      address,
     )
 
     if (this.#pendingPermissionsRequests[permission.origin]) {
@@ -258,8 +261,9 @@ export default class ProviderBridgeService extends BaseService<Events> {
     origin: string,
     address?: string
   ): Promise<PermissionRequest | undefined> {
-    const currentAddress =
-      address ?? (await await this.preferenceService.getCurrentAddress())
+    const { address: selectedAddress } = await this.preferenceService.getSelectedAccount()
+    const currentAddress = address ?? selectedAddress
+    // TODO make this multi-network friendly
     return this.db.checkPermission(origin, currentAddress)
   }
 

--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -134,7 +134,8 @@ export default class ProviderBridgeService extends BaseService<Events> {
       // if it's external communication AND the dApp does not have permission BUT asks for it
       // then let's ask the user what he/she thinks
 
-      const { address: accountAddress } = await this.preferenceService.getSelectedAccount()
+      const { address: accountAddress } =
+        await this.preferenceService.getSelectedAccount()
       const permissionRequest: PermissionRequest = {
         key: `${origin}_${accountAddress}`,
         origin,
@@ -244,10 +245,7 @@ export default class ProviderBridgeService extends BaseService<Events> {
     const { address } = await this.preferenceService.getSelectedAccount()
 
     // TODO make this multi-network friendly
-    await this.db.deletePermission(
-      permission.origin,
-      address,
-    )
+    await this.db.deletePermission(permission.origin, address)
 
     if (this.#pendingPermissionsRequests[permission.origin]) {
       this.#pendingPermissionsRequests[permission.origin]("Time to move on")
@@ -261,7 +259,8 @@ export default class ProviderBridgeService extends BaseService<Events> {
     origin: string,
     address?: string
   ): Promise<PermissionRequest | undefined> {
-    const { address: selectedAddress } = await this.preferenceService.getSelectedAccount()
+    const { address: selectedAddress } =
+      await this.preferenceService.getSelectedAccount()
     const currentAddress = address ?? selectedAddress
     // TODO make this multi-network friendly
     return this.db.checkPermission(origin, currentAddress)

--- a/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
+++ b/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
@@ -1,9 +1,10 @@
 import React, { ReactElement, useEffect, useState } from "react"
-import { setNewCurrentAddress } from "@tallyho/tally-background/redux-slices/ui"
+import { setNewSelectedAccount } from "@tallyho/tally-background/redux-slices/ui"
 import {
   selectAccountTotalsByCategory,
   selectCurrentAccount,
 } from "@tallyho/tally-background/redux-slices/selectors"
+import { ETHEREUM } from "@tallyho/tally-background/constants/networks"
 import { AccountType } from "@tallyho/tally-background/redux-slices/accounts"
 import SharedPanelAccountItem from "../Shared/SharedPanelAccountItem"
 import SharedButton from "../Shared/SharedButton"
@@ -125,7 +126,10 @@ export default function AccountsNotificationPanelAccounts({
 
   const updateCurrentAccount = (address: string) => {
     setPendingSelectedAddress(address)
-    dispatch(setNewCurrentAddress(address))
+    dispatch(setNewSelectedAccount({
+        address,
+        network: ETHEREUM,
+    }))
   }
 
   useEffect(() => {

--- a/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
+++ b/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
@@ -126,10 +126,12 @@ export default function AccountsNotificationPanelAccounts({
 
   const updateCurrentAccount = (address: string) => {
     setPendingSelectedAddress(address)
-    dispatch(setNewSelectedAccount({
+    dispatch(
+      setNewSelectedAccount({
         address,
         network: ETHEREUM,
-    }))
+      })
+    )
   }
 
   useEffect(() => {

--- a/ui/components/SignTransaction/SignTransactionSignBlock.tsx
+++ b/ui/components/SignTransaction/SignTransactionSignBlock.tsx
@@ -19,9 +19,7 @@ interface Props {
 export default function SignTransactionSignBlock({
   transactionDetails,
 }: Props): ReactElement {
-  const {
-    addressNetwork: { network },
-  } = useBackgroundSelector(selectCurrentAddressNetwork)
+  const { network } = useBackgroundSelector(selectCurrentAddressNetwork)
   const baseAssetPricePoint = useBackgroundSelector((state) =>
     selectAssetPricePoint(state.assets, network.baseAsset.symbol, USD.symbol)
   )

--- a/ui/pages/Onboarding/OnboardingViewOnlyWallet.tsx
+++ b/ui/pages/Onboarding/OnboardingViewOnlyWallet.tsx
@@ -2,8 +2,8 @@ import React, { ReactElement, useCallback, useState } from "react"
 import { Redirect } from "react-router-dom"
 import { isAddress } from "@ethersproject/address"
 import { addAddressNetwork } from "@tallyho/tally-background/redux-slices/accounts"
-import { getEthereumNetwork } from "@tallyho/tally-background/lib/utils"
-import { setNewCurrentAddress } from "@tallyho/tally-background/redux-slices/ui"
+import { ETHEREUM } from "@tallyho/tally-background/constants/networks"
+import { setNewSelectedAccount } from "@tallyho/tally-background/redux-slices/ui"
 import { useBackgroundDispatch } from "../../hooks"
 import SharedInput from "../../components/Shared/SharedInput"
 import SharedButton from "../../components/Shared/SharedButton"
@@ -19,13 +19,14 @@ export default function OnboardingViewOnlyWallet(): ReactElement {
     const trimmedAddress = address.trim()
 
     if (isAddress(trimmedAddress)) {
+      const addressNetwork = {
+      address: trimmedAddress,
+      network: ETHEREUM,
+    }
       await dispatch(
-        addAddressNetwork({
-          address: trimmedAddress,
-          network: getEthereumNetwork(),
-        })
+        addAddressNetwork(addressNetwork)
       )
-      dispatch(setNewCurrentAddress(trimmedAddress))
+      dispatch(setNewSelectedAccount(addressNetwork))
       setRedirect(true)
     } else {
       setErrorMessage("Please enter a valid address")

--- a/ui/pages/Onboarding/OnboardingViewOnlyWallet.tsx
+++ b/ui/pages/Onboarding/OnboardingViewOnlyWallet.tsx
@@ -20,12 +20,10 @@ export default function OnboardingViewOnlyWallet(): ReactElement {
 
     if (isAddress(trimmedAddress)) {
       const addressNetwork = {
-      address: trimmedAddress,
-      network: ETHEREUM,
-    }
-      await dispatch(
-        addAddressNetwork(addressNetwork)
-      )
+        address: trimmedAddress,
+        network: ETHEREUM,
+      }
+      await dispatch(addAddressNetwork(addressNetwork))
       dispatch(setNewSelectedAccount(addressNetwork))
       setRedirect(true)
     } else {


### PR DESCRIPTION
> [The **Migratory Bird Treaty Act of 1918** (MBTA), codified at 16 U.S.C. §§ 703–712 (although §709 is omitted), is a United States federal law, first enacted in 1918 to implement the convention for the protection of migratory birds between the United States and Canada .[1] The statute makes it unlawful without a waiver to pursue, hunt, take, capture, kill, or sell nearly 1,100 species of birds listed therein as migratory birds. The statute does not discriminate between live or dead birds and also grants full protection to any bird parts including feathers, eggs, and nests. A March 2020 update of the list increased the number of species to 1,093.](https://en.wikipedia.org/wiki/Migratory_Bird_Treaty_Act_of_1918) — Wikipedia

We need to do some serious refactoring to the Redux store, but we haven't settled on a migration mechanism! After a conversation I had with @greg-nagy today, I decided to push the thing I've had in my head.

Here, I've made a small refactor to the Redux store as well as `PreferenceService` necessary for multi-network support. I've included migrations that I believe are production-ready, and tested them in a couple extension upgrade paths.

Interested to hear whether I'm headed in the right direction. I tried to stick with a small but central store change to help keep discussion focused.