### PR TITLE
Moar Accounts Plz: Support additional address derivation in KeyringService

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -497,6 +497,10 @@ export default class Main extends BaseService<never> {
       await this.keyringService.unlock(password)
     })
 
+    keyringSliceEmitter.on("deriveAddress", async (keyringID) => {
+      await this.keyringService.deriveAddress(keyringID)
+    })
+
     keyringSliceEmitter.on("generateNewKeyring", async () => {
       // TODO move unlocking to a reasonable place in the initialization flow
       await this.keyringService.generateNewKeyring(

--- a/background/package.json
+++ b/background/package.json
@@ -31,7 +31,7 @@
     "@ethersproject/providers": "^5.4.3",
     "@ethersproject/transactions": "^5.4.0",
     "@ethersproject/web": "^5.4.0",
-    "@tallyho/hd-keyring": "^0.3.2",
+    "@tallyho/hd-keyring": "^0.3.3",
     "@tallyho/provider-bridge-shared": "0.0.1",
     "@tallyho/window-provider": "0.0.1",
     "@uniswap/token-lists": "^1.0.0-beta.25",

--- a/background/redux-slices/keyrings.ts
+++ b/background/redux-slices/keyrings.ts
@@ -30,6 +30,7 @@ export type Events = {
   createPassword: string
   unlockKeyrings: string
   generateNewKeyring: never
+  deriveAddress: string
   importLegacyKeyring: { mnemonic: string; path?: string }
 }
 
@@ -106,6 +107,13 @@ export const generateNewKeyring = createBackgroundAsyncThunk(
   "keyrings/generateNewKeyring",
   async () => {
     await emitter.emit("generateNewKeyring")
+  }
+)
+
+export const deriveAddress = createBackgroundAsyncThunk(
+  "keyrings/deriveAddress",
+  async (id: string) => {
+    await emitter.emit("deriveAddress", id)
   }
 )
 

--- a/background/services/keyring/index.ts
+++ b/background/services/keyring/index.ts
@@ -304,6 +304,23 @@ export default class KeyringService extends BaseService<Events> {
   }
 
   /**
+   * Return an array of keyring representations that can safely be stored and
+   * used outside the extension.
+   */
+  getKeyrings(): Keyring[] {
+    this.requireUnlocked()
+
+    return this.#keyrings.map((kr) => ({
+      // TODO this type is meanlingless from the library's perspective.
+      // Reconsider, or explicitly track which keyrings have been generated vs
+      // imported as well as their strength
+      type: KeyringTypes.mnemonicBIP39S256,
+      addresses: [...kr.getAddressesSync()],
+      id: kr.id,
+    }))
+  }
+
+  /**
    * Derive and return the next address from an HDKeyring.
    *
    * @param keyringID - a string ID corresponding to an unlocked keyring.
@@ -397,11 +414,7 @@ export default class KeyringService extends BaseService<Events> {
   // //////////////////
 
   private emitKeyrings() {
-    const keyrings = this.#keyrings.map((kr) => ({
-      type: KeyringTypes.mnemonicBIP39S256,
-      addresses: [...kr.getAddressesSync()],
-      id: kr.id,
-    }))
+    const keyrings = this.getKeyrings()
     this.emitter.emit("keyrings", keyrings)
   }
 

--- a/background/services/keyring/index.ts
+++ b/background/services/keyring/index.ts
@@ -304,6 +304,29 @@ export default class KeyringService extends BaseService<Events> {
   }
 
   /**
+   * Derive and return the next address from an HDKeyring.
+   *
+   * @param keyringID - a string ID corresponding to an unlocked keyring.
+   */
+  async deriveAddress(keyringID: string): Promise<HexString> {
+    this.requireUnlocked()
+
+    // find the keyring using a linear search
+    const keyring = this.#keyrings.find((kr) => kr.id === keyringID)
+    if (!keyring) {
+      throw new Error("Keyring not found.")
+    }
+
+    const [newAddress] = keyring.addAddressesSync(1)
+    await this.persistKeyrings()
+
+    this.emitter.emit("address", newAddress)
+    this.emitKeyrings()
+
+    return newAddress
+  }
+
+  /**
    * Sign a transaction.
    *
    * @param account - the account desired to sign the transaction

--- a/background/tests/keyring-integration.test.ts
+++ b/background/tests/keyring-integration.test.ts
@@ -180,6 +180,41 @@ describe("KeyringService when initialized", () => {
     await service.generateNewKeyring(KeyringTypes.mnemonicBIP39S256)
   })
 
+  it("will return keyring IDs and addresses", async () => {
+    const keyrings = service.getKeyrings()
+    expect(keyrings).toHaveLength(1)
+    expect(keyrings[0]).toMatchObject({
+      id: expect.anything(),
+      addresses: expect.arrayContaining([
+        expect.stringMatching(new RegExp(address, "i")),
+      ]),
+    })
+  })
+
+  it.only("will derive a new address", async () => {
+    const [
+      {
+        id,
+        addresses: [originalAddress],
+      },
+    ] = service.getKeyrings()
+
+    const newAddress = id ? await service.deriveAddress(id) : ""
+    expect(newAddress).toEqual(
+      expect.not.stringMatching(new RegExp(originalAddress, "i"))
+    )
+
+    const keyrings = service.getKeyrings()
+    expect(keyrings).toHaveLength(1)
+    expect(keyrings[0]).toMatchObject({
+      id: expect.anything(),
+      addresses: expect.arrayContaining([
+        expect.stringMatching(new RegExp(originalAddress, "i")),
+        expect.stringMatching(new RegExp(newAddress, "i")),
+      ]),
+    })
+  })
+
   it("will sign a transaction", async () => {
     const transactionWithFrom = {
       ...validTransactionRequests.simple,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2245,10 +2245,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@tallyho/hd-keyring@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@tallyho/hd-keyring/-/hd-keyring-0.3.2.tgz#bedc770c712af45ae00261b5615f8c5911dea75b"
-  integrity sha512-FlIR1lMvL+5sJDY7ExVMwvpm2L8oSTK8nh9JTskQA2QDjWTh3EgUooGKyzmhhV5095CCLhLUy6fVKHaFgX/Lxw==
+"@tallyho/hd-keyring@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@tallyho/hd-keyring/-/hd-keyring-0.3.3.tgz#41b61cba5e0552fad6d3b9a2bef8cabfd661e1bb"
+  integrity sha512-bbUr/dA7SvC+SYtlHBgtrxIkqoMyyZlhscMdnH7bTg79lTthPjfaXfAuJVwU1dS9Y36Eukqf0suzHHkw6G67ow==
   dependencies:
     "@ethersproject/abstract-provider" "^5.4.0"
     "@ethersproject/abstract-signer" "^5.4.0"


### PR DESCRIPTION
Backend component for the "Add Address" feature, allowing users to derive new addresses from a recovery phrase.

- [x] Add `KeyringService.getAddresses(keyringID)`
- [x] Add `KeyringService.deriveAddress()` and Redux wiring
- [x] Test both

Ran into and squashed a small bug in `hd-keyring` along the way.

Closes #763 
