### PR TITLE
🔥🦊 Fox Kit: Minify the Firefox production build

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -92,18 +92,6 @@ const baseConfig: Configuration = {
     }) as unknown as WebpackPluginInstance,
   ],
   optimization: {
-    minimizer: [
-      new TerserPlugin({
-        terserOptions: {
-          mangle: false,
-          compress: false,
-          output: {
-            beautify: true,
-            indent_level: 2, // eslint-disable-line camelcase
-          },
-        },
-      }),
-    ],
     splitChunks: { automaticNameDelimiter: "-" },
   },
 }
@@ -122,6 +110,20 @@ const modeConfigs: {
         // FIXME webpack version.
       }) as unknown as WebpackPluginInstance,
     ],
+    optimization: {
+      minimizer: [
+        new TerserPlugin({
+          terserOptions: {
+            mangle: false,
+            compress: false,
+            output: {
+              beautify: true,
+              indent_level: 2, // eslint-disable-line camelcase
+            },
+          },
+        }),
+      ],
+    },
   }),
   production: (browser) => ({
     plugins: [
@@ -129,6 +131,23 @@ const modeConfigs: {
         filename: browser,
       }),
     ],
+    optimization: {
+      minimizer: [
+        new TerserPlugin({
+          terserOptions: {
+            mangle: browser === "firefox",
+            compress: browser === "firefox",
+            output:
+              browser === "firefox"
+                ? undefined
+                : {
+                    beautify: true,
+                    indent_level: 2, // eslint-disable-line camelcase
+                  },
+          },
+        }),
+      ],
+    },
   }),
 }
 


### PR DESCRIPTION
The Mozilla add-on store has an automated policy preventing JS files over 4 MB. Because we use webpack, they already require a full extension source code submission every version bump... leading me to believe that minification, including mangling and compression, is the right approach for Firefox in production versus other options like chunking.

To test this PR thoroughly, make sure...
* `yarn start` works as expected
* `yarn start --config-name chrome` works as expected
* `yarn start --config-name firefox` works as expected
* `yarn build --config-name firefox` produces a zip with a `ui.js` that's smaller than `yarn build --config-name chrome`
* The productions builds behave as expected