### PR TITLE
🙅 Prune `updateAccountBalance` dispatches

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -506,9 +506,24 @@ export default class Main extends BaseService<never> {
   }
 
   async connectIndexingService(): Promise<void> {
-    this.indexingService.emitter.on("accountBalance", (accountWithBalance) => {
-      this.store.dispatch(updateAccountBalance(accountWithBalance))
-    })
+    this.indexingService.emitter.on(
+      "accountBalance",
+      async (accountWithBalance) => {
+        const assetsToTrack = await this.indexingService.getAssetsToTrack()
+
+        // TODO support multi-network assets
+        const doesThisBalanceHaveAnAlreadyTrackedAsset = !!assetsToTrack.filter(
+          (t) => t.symbol === accountWithBalance.assetAmount.asset.symbol
+        )[0]
+
+        if (
+          accountWithBalance.assetAmount.amount > 0 ||
+          doesThisBalanceHaveAnAlreadyTrackedAsset
+        ) {
+          this.store.dispatch(updateAccountBalance(accountWithBalance))
+        }
+      }
+    )
 
     this.indexingService.emitter.on("assets", (assets) => {
       this.store.dispatch(assetsLoaded(assets))


### PR DESCRIPTION
Currently, all at once, there are hundreds of dispatches of `updateAccountBalance`. This is believed to be causing performance issues mentioned in https://github.com/tallycash/extension/issues/739. Many of these dispatched asset balances aren't needed in the store.

Still, this should cover:
- Pushing balance changes that drop to 0
- Still balance update w/ transfers that have a newly encountered asset

It now excludes dispatching asset balances that both are 0 and aren't for an already tracked asset. This saves us from a significant majority of the dispatches.

A flawed attempt to address the same problem was discussed here https://github.com/tallycash/extension/pull/353/files/f48a511bc0abba92b36ffa09d43bb2d5bbd9af11..41ad2bbd9afaabddcbc59f0528dcf50daec1298f#r733777078

Thanks to @greg-nagy for working through this with me.