### PR TITLE
🧬 Fix dispatching `importLegacyKeyring` twice

### DIFF
--- a/ui/pages/Onboarding/OnboardingImportMetamask.tsx
+++ b/ui/pages/Onboarding/OnboardingImportMetamask.tsx
@@ -94,7 +94,6 @@ export default function OnboardingImportMetamask(props: Props): ReactElement {
     const trimmedRecoveryPhrase = recoveryPhrase.trim()
     if (isValidMnemonic(trimmedRecoveryPhrase)) {
       setIsImporting(true)
-      dispatch(importLegacyKeyring({ mnemonic: recoveryPhrase.trim(), path }))
       dispatch(importLegacyKeyring({ mnemonic: trimmedRecoveryPhrase, path }))
     } else {
       setErrorMessage("Invalid recovery phrase")


### PR DESCRIPTION
Looks like resolving merge conflicts went wrong at some point. Noticed and fixed by @7alip in #788. I want to get this in quickly w/o needing to review/accept the other changes.