### PR TITLE
chore: fix typo

### DIFF
--- a/ui/pages/Onboarding/OnboardingSaveSeed.tsx
+++ b/ui/pages/Onboarding/OnboardingSaveSeed.tsx
@@ -18,7 +18,7 @@ export default function OnboardingSaveSeed(props: Props): ReactElement {
         Save and store your recovery seed
       </h1>
       <div className="subtitle">
-        This is the only way to restore your tally wallett
+        This is the only way to restore your tally wallet
       </div>
       <div className="words_group">
         <div className="column_wrap">


### PR DESCRIPTION
`wallett` -> `wallet`