### PR TITLE
v0.10.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -55,6 +55,7 @@ body:
       label: Version
       description: What version of the extension are you running?
       options:
+        - Community Edition v0.10.2
         - Community Edition v0.10.1
         - Community Edition v0.10.0
         - Community Edition v0.9.2

--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Tally",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "The community owned and operated Web3 wallet.",
   "homepage_url": "https://tally.cash",
   "author": "https://tally.cash",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tallyho/tally-extension",
   "private": true,
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Tally, the community owned and operated Web3 wallet.",
   "main": "index.js",
   "repository": "git@github.com:thesis/tally-extension.git",


### PR DESCRIPTION
This release includes a number of bug fixes and stability improvements, including a fix to tighten up the CSP for Mozilla. Also included... importing a read-only account by ENS name, and recovery phrase generation (feature-flagged)!

## What's Changed

* 🧬 Fix dispatching `importLegacyKeyring` twice by @henryboldi in https://github.com/tallycash/extension/pull/789
* feat: import read-only wallet by ens by @izayl in https://github.com/tallycash/extension/pull/786
* 🗣 Clarify expecting a 12-word recovery phrase by @henryboldi in https://github.com/tallycash/extension/pull/794
* 🙈 Fix styling issue hiding addresses in account switcher by @henryboldi in https://github.com/tallycash/extension/pull/798
* Switch out the recovery phrase import illustration by @mhluongo in https://github.com/tallycash/extension/pull/799
* 🦥  Precompile validators: Move validator generation from runtime to build time. by @greg-nagy in https://github.com/tallycash/extension/pull/796
* Remove OnboardingDerivationPathSelect component from pages folder by @7alip in https://github.com/tallycash/extension/pull/788
* 🆙 Have version bump script also update bug template by @henryboldi in https://github.com/tallycash/extension/pull/783
* Add .DS_Store to .gitignore by @youfoundron in https://github.com/tallycash/extension/pull/807
* "ENS domain" -> "ENS name" by @youfoundron in https://github.com/tallycash/extension/pull/808
* chore: fix typo by @xwartz in https://github.com/tallycash/extension/pull/809
* 📝 Create a recovery phrase/full account in Tally onboarding by @henryboldi in https://github.com/tallycash/extension/pull/801
* 🪳 Fix for precompiled validation: refactor uniswap token list validation to use precompiled validators by @greg-nagy in https://github.com/tallycash/extension/pull/805

**Full Changelog**: https://github.com/tallycash/extension/compare/v0.10.1...v0.10.2