### PR TITLE
✍️ Update recovery phrase flow to 24 words

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -622,7 +622,7 @@ export default class Main extends BaseService<never> {
         id: string
         mnemonic: string[]
       } = await this.keyringService.generateNewKeyring(
-        KeyringTypes.mnemonicBIP39S128
+        KeyringTypes.mnemonicBIP39S256
       )
 
       this.store.dispatch(setKeyringToVerify(generated))

--- a/background/services/keyring/index.ts
+++ b/background/services/keyring/index.ts
@@ -255,13 +255,13 @@ export default class KeyringService extends BaseService<Events> {
   ): Promise<{ id: string; mnemonic: string[] }> {
     this.requireUnlocked()
 
-    if (type !== KeyringTypes.mnemonicBIP39S128) {
+    if (type !== KeyringTypes.mnemonicBIP39S256) {
       throw new Error(
-        "KeyringService only supports generating 128-bit HD key trees"
+        "KeyringService only supports generating 256-bit HD key trees"
       )
     }
 
-    const newKeyring = new HDKeyring({ strength: 128 })
+    const newKeyring = new HDKeyring({ strength: 256 })
 
     const { mnemonic } = newKeyring.serializeSync()
 

--- a/background/tests/keyring-integration.test.ts
+++ b/background/tests/keyring-integration.test.ts
@@ -123,16 +123,16 @@ describe("KeyringService when uninitialized", () => {
       }
     )
 
-    it("will create multiple distinct BIP-39 S128 accounts and expose mnemonics", async () => {
+    it("will create multiple distinct BIP-39 S256 accounts and expose mnemonics", async () => {
       const keyringOne = service.generateNewKeyring(
-        KeyringTypes.mnemonicBIP39S128
+        KeyringTypes.mnemonicBIP39S256
       )
       await expect(keyringOne).resolves.toMatchObject({
         id: expect.stringMatching(/.+/),
       })
 
       const keyringTwo = service.generateNewKeyring(
-        KeyringTypes.mnemonicBIP39S128
+        KeyringTypes.mnemonicBIP39S256
       )
       await expect(keyringTwo).resolves.toMatchObject({
         id: expect.stringMatching(/.+/),
@@ -143,8 +143,8 @@ describe("KeyringService when uninitialized", () => {
 
       expect(idOne).not.toEqual(idTwo)
       expect(mnemonicOne).not.toEqual(mnemonicTwo)
-      expect(mnemonicOne.length).toEqual(12)
-      expect(mnemonicTwo.length).toEqual(12)
+      expect(mnemonicOne.length).toEqual(24)
+      expect(mnemonicTwo.length).toEqual(24)
     })
   })
 })
@@ -178,7 +178,7 @@ describe("KeyringService when initialized", () => {
       address = emittedAddress
     })
     const { mnemonic } = await service.generateNewKeyring(
-      KeyringTypes.mnemonicBIP39S128
+      KeyringTypes.mnemonicBIP39S256
     )
     await service.importKeyring(mnemonic.join(" "))
   })
@@ -296,7 +296,7 @@ describe("KeyringService when saving keyrings", () => {
             vault: expect.objectContaining({
               salt: expectBase64String(),
               initializationVector: expectBase64String(),
-              cipherText: expectBase64String({ minLength: 12, maxLength: 12 }),
+              cipherText: expectBase64String({ minLength: 24, maxLength: 24 }),
             }),
           }),
         ],
@@ -304,7 +304,7 @@ describe("KeyringService when saving keyrings", () => {
     })
 
     const { mnemonic } = await service.generateNewKeyring(
-      KeyringTypes.mnemonicBIP39S128
+      KeyringTypes.mnemonicBIP39S256
     )
     await service.importKeyring(mnemonic.join(" "))
 
@@ -316,7 +316,7 @@ describe("KeyringService when saving keyrings", () => {
             vault: expect.objectContaining({
               salt: expectBase64String(),
               initializationVector: expectBase64String(),
-              cipherText: expectBase64String({ minLength: 12, maxLength: 12 }),
+              cipherText: expectBase64String({ minLength: 24, maxLength: 24 }),
             }),
           }),
           expect.objectContaining({
@@ -405,7 +405,7 @@ describe("Keyring service when autolocking", () => {
       address = emittedAddress
     })
     const { mnemonic } = await service.generateNewKeyring(
-      KeyringTypes.mnemonicBIP39S128
+      KeyringTypes.mnemonicBIP39S256
     )
     await service.importKeyring(mnemonic.join(" "))
   })
@@ -451,7 +451,7 @@ describe("Keyring service when autolocking", () => {
     {
       action: "generating a keyring",
       call: async () => {
-        await service.generateNewKeyring(KeyringTypes.mnemonicBIP39S128)
+        await service.generateNewKeyring(KeyringTypes.mnemonicBIP39S256)
       },
     },
   ])("will bump keyring activity idle time when $action", async ({ call }) => {
@@ -490,7 +490,7 @@ describe("Keyring service when autolocking", () => {
     jest
       .spyOn(Date, "now")
       .mockReturnValue(dateNowValue + MAX_KEYRING_IDLE_TIME - 1)
-    await service.generateNewKeyring(KeyringTypes.mnemonicBIP39S128)
+    await service.generateNewKeyring(KeyringTypes.mnemonicBIP39S256)
 
     callAutolockHandler(MAX_OUTSIDE_IDLE_TIME)
     expect(service.locked()).toEqual(false)

--- a/ui/pages/Onboarding/OnboardingAddWallet.tsx
+++ b/ui/pages/Onboarding/OnboardingAddWallet.tsx
@@ -3,6 +3,7 @@ import {
   HIDE_ADD_SEED,
   HIDE_CREATE_PHRASE,
 } from "@tallyho/tally-background/features/features"
+import { useHistory } from "react-router-dom"
 import { generateNewKeyring } from "@tallyho/tally-background/redux-slices/keyrings"
 import { useBackgroundDispatch, useAreKeyringsUnlocked } from "../../hooks"
 import SharedBackButton from "../../components/Shared/SharedBackButton"
@@ -10,6 +11,7 @@ import SharedButton from "../../components/Shared/SharedButton"
 
 export default function OnboardingStartTheHunt(): ReactElement {
   const dispatch = useBackgroundDispatch()
+  const history = useHistory()
 
   useAreKeyringsUnlocked(!HIDE_CREATE_PHRASE && true)
 
@@ -60,9 +62,9 @@ export default function OnboardingStartTheHunt(): ReactElement {
               <SharedButton
                 type="secondary"
                 size="medium"
-                linkTo="/onboarding/saveSeed"
-                onClick={() => {
-                  dispatch(generateNewKeyring())
+                onClick={async () => {
+                  await dispatch(generateNewKeyring())
+                  history.push("/onboarding/saveSeed")
                 }}
               >
                 Create new wallet

--- a/ui/pages/Onboarding/OnboardingSaveSeed.tsx
+++ b/ui/pages/Onboarding/OnboardingSaveSeed.tsx
@@ -18,44 +18,42 @@ export default function OnboardingSaveSeed(): ReactElement {
       <h1 className="serif_header center_text title">
         Write down your recovery phrase
       </h1>
-      <div className="subtitle">
-        This is the only way to restore your Tally wallet
+      <div className="words_group">
+        {freshMnemonic && (
+          <>
+            <div className="column_wrap">
+              <div className="column numbers">1 2 3 4 5 6 7 8 9 10 11 12</div>
+              <div className="column dashes">- - - - - - - - - - - -</div>
+              <div className="column words">
+                {freshMnemonic?.slice(0, 12).map((word) => {
+                  return (
+                    <>
+                      {word}
+                      <br />
+                    </>
+                  )
+                })}
+              </div>
+            </div>
+            <div className="column_wrap">
+              <div className="column numbers">
+                13 14 15 16 17 18 19 20 21 22 23 24
+              </div>
+              <div className="column dashes">- - - - - - - - - - - -</div>
+              <div className="column words">
+                {freshMnemonic?.slice(12, 24).map((word) => {
+                  return (
+                    <>
+                      {word}
+                      <br />
+                    </>
+                  )
+                })}
+              </div>
+            </div>
+          </>
+        )}
       </div>
-      {freshMnemonic && (
-        <>
-          <div className="words_group">
-            <div className="column_wrap">
-              <div className="column numbers">1 2 3 4 5 6</div>
-              <div className="column dashes">- - - - - -</div>
-              <div className="column words">
-                {freshMnemonic?.slice(0, 6).map((word) => {
-                  return (
-                    <>
-                      {word}
-                      <br />
-                    </>
-                  )
-                })}
-              </div>
-            </div>
-            <div className="column_wrap">
-              <div className="column numbers">7 8 9 10 11 12</div>
-              <div className="column dashes">- - - - - -</div>
-              <div className="column words">
-                {freshMnemonic?.slice(6, 12).map((word) => {
-                  return (
-                    <>
-                      {word}
-                      <br />
-                    </>
-                  )
-                })}
-              </div>
-            </div>
-          </div>
-        </>
-      )}
-
       <div className="button_group">
         <SharedButton
           type="primary"
@@ -64,7 +62,7 @@ export default function OnboardingSaveSeed(): ReactElement {
           iconSize="large"
           linkTo="/onboarding/verifySeed"
         >
-          Verify recovery seed
+          I wrote it down
         </SharedButton>
       </div>
       <style jsx>
@@ -74,17 +72,17 @@ export default function OnboardingSaveSeed(): ReactElement {
             display: flex;
             width: 250px;
             justify-content: space-between;
+            height: 272px;
             margin-bottom: 40px;
+            margin-top: 5px;
+          }
+          .serif_header {
+            font-size: 31px;
+            margin-top: 16px;
           }
           .numbers {
             width: 18px;
             text-align: right;
-          }
-          .dashes {
-            width: 12px;
-          }
-          .words {
-            width: 69px;
           }
           section {
             padding-top: 25px;
@@ -92,7 +90,7 @@ export default function OnboardingSaveSeed(): ReactElement {
           .column {
             height: 142px;
             color: #ffffff;
-            font-size: 18px;
+            font-size: 16px;
             font-weight: 600;
             line-height: 24px;
             text-align: right;
@@ -101,10 +99,12 @@ export default function OnboardingSaveSeed(): ReactElement {
             display: flex;
           }
           .dashes {
+            width: 12px;
             margin-right: 8px;
             margin-left: 5px;
           }
           .words {
+            width: 69px;
             text-align: left;
           }
           .button_group {
@@ -112,8 +112,6 @@ export default function OnboardingSaveSeed(): ReactElement {
             flex-direction: column;
             justify-content: center;
             align-items: center;
-            position: fixed;
-            bottom: 68px;
           }
           .copy_button {
             margin: 16px 0px 4px 0px;
@@ -121,7 +119,7 @@ export default function OnboardingSaveSeed(): ReactElement {
           .top {
             display: flex;
             width: 100%;
-            height: 58px;
+            height: 47px;
           }
           .wordmark {
             background: url("./images/wordmark@2x.png");

--- a/ui/pages/Onboarding/OnboardingVerifySeed.tsx
+++ b/ui/pages/Onboarding/OnboardingVerifySeed.tsx
@@ -84,17 +84,17 @@ export default function OnboardingVerifySeed(): ReactElement {
     })
 
   function hasUserSelectedCorrectOrder() {
-    for (let i = 0; i < isSelected.length; i + 1) {
-      const word = isSelected[i]
+    let result = true
+    isSelected.forEach((word, i) => {
       const assignedNumber =
-        (sortedIndexesOfRandomOrderedMnemonic &&
-          sortedIndexesOfRandomOrderedMnemonic[i]) ||
+        (sortedIndexesOfRandomOrderedMnemonicPart &&
+          sortedIndexesOfRandomOrderedMnemonicPart[i]) ||
         0
       if (mnemonicToVerify && mnemonicToVerify[assignedNumber] !== word) {
-        return false
+        result = false
       }
-    }
-    return true
+    })
+    return result
   }
 
   const [isNotSelected, setIsNotSelected] = useState(randomOrderedMnemonic)

--- a/ui/pages/Onboarding/OnboardingVerifySeed.tsx
+++ b/ui/pages/Onboarding/OnboardingVerifySeed.tsx
@@ -64,19 +64,20 @@ export default function OnboardingVerifySeed(): ReactElement {
     return state.keyrings.keyringToVerify?.mnemonic
   })
 
-  const [randomOrderedMnemonic] = useState(
+  // A random set of 8 from the mnemonic used for verification UI
+  const [randomOrderedMnemonicPart] = useState(
     mnemonicToVerify
       ?.slice()
       .sort(() => Math.random() - 0.5)
       .slice(0, 8)
   )
 
-  const indexesOfRandomOrderedMnemonic = randomOrderedMnemonic?.map((item) => {
-    return mnemonicToVerify?.indexOf(item)
-  })
-
-  const sortedIndexesOfRandomOrderedMnemonic =
-    indexesOfRandomOrderedMnemonic?.sort((a, b) => {
+  // To display the order of verification in the UI (the unfilled numbers "1 -", "7 -", etc)
+  const sortedIndexesOfRandomOrderedMnemonicPart = randomOrderedMnemonicPart
+    ?.map((item) => {
+      return mnemonicToVerify?.indexOf(item)
+    })
+    ?.sort((a, b) => {
       if (a === 0) {
         return -1
       }
@@ -97,7 +98,7 @@ export default function OnboardingVerifySeed(): ReactElement {
     return result
   }
 
-  const [isNotSelected, setIsNotSelected] = useState(randomOrderedMnemonic)
+  const [isNotSelected, setIsNotSelected] = useState(randomOrderedMnemonicPart)
 
   const handleAdd = useCallback((item) => {
     setIsSelected((currentlySelected) => [...currentlySelected, item])
@@ -140,7 +141,7 @@ export default function OnboardingVerifySeed(): ReactElement {
           return (
             <div className="column_wrap">
               <div className="column numbers">
-                {sortedIndexesOfRandomOrderedMnemonic
+                {sortedIndexesOfRandomOrderedMnemonicPart
                   ?.slice(posOne, posTwo)
                   .map((n) => typeof n === "number" && n + 1)
                   .join(" ")}

--- a/ui/pages/Onboarding/OnboardingVerifySeed.tsx
+++ b/ui/pages/Onboarding/OnboardingVerifySeed.tsx
@@ -118,6 +118,11 @@ export default function OnboardingVerifySeed(): ReactElement {
     })
   }, [])
 
+  const columnEnds = [
+    [0, 4],
+    [4, 8],
+  ]
+
   return (
     <section>
       <div className="top">
@@ -129,54 +134,37 @@ export default function OnboardingVerifySeed(): ReactElement {
       </h1>
       <div className="subtitle">Add the missing words in order</div>
       <div className="words_group">
-        <div className="column_wrap">
-          <div className="column numbers">
-            {sortedIndexesOfRandomOrderedMnemonic
-              ?.slice(0, 4)
-              .map((n) => typeof n === "number" && n + 1)
-              .join(" ")}
-          </div>
-          <div className="column dashes">- - - -</div>
-          <div className="column words">
-            {isSelected.slice(0, 4).map((item, index) => (
-              <div className="button_spacing" key={item}>
-                <SharedButton
-                  type="deemphasizedWhite"
-                  size="small"
-                  onClick={() => {
-                    handleRemove(item)
-                  }}
-                  icon="close"
-                >{`${item}`}</SharedButton>
+        {columnEnds.map((positions) => {
+          const posOne = positions[0]
+          const posTwo = positions[1]
+          return (
+            <div className="column_wrap">
+              <div className="column numbers">
+                {sortedIndexesOfRandomOrderedMnemonic
+                  ?.slice(posOne, posTwo)
+                  .map((n) => typeof n === "number" && n + 1)
+                  .join(" ")}
               </div>
-            ))}
-          </div>
-        </div>
-        <div className="column_wrap">
-          <div className="column numbers">
-            {sortedIndexesOfRandomOrderedMnemonic
-              ?.slice(4, 8)
-              .map((n) => typeof n === "number" && n + 1)
-              .join(" ")}
-          </div>
-          <div className="column dashes">- - - -</div>
-          <div className="column words">
-            {isSelected.slice(4, 8).map((item, index) => (
-              <div className="button_spacing" key={item}>
-                <SharedButton
-                  type="deemphasizedWhite"
-                  size="small"
-                  onClick={() => {
-                    handleRemove(item)
-                  }}
-                  icon="close"
-                >
-                  {item}
-                </SharedButton>
+              <div className="column dashes">- - - -</div>
+              <div className="column words">
+                {isSelected.slice(posOne, posTwo).map((item, index) => (
+                  <div className="button_spacing" key={item}>
+                    <SharedButton
+                      type="deemphasizedWhite"
+                      size="small"
+                      onClick={() => {
+                        handleRemove(item)
+                      }}
+                      icon="close"
+                    >
+                      {item}
+                    </SharedButton>
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
-        </div>
+            </div>
+          )
+        })}
       </div>
       <ul className="standard_width_padded button_group center_horizontal bottom">
         {isNotSelected?.length === 0 ? (


### PR DESCRIPTION
For now, this matches Vlad's design in terms of concept but not in the visual details. I'm unhappy about the verify phrase page's **wonky typings and repetitiveness; I've got improvements in mind to add**. That said, this is still behind a feature flag. Above all, ✨it works ✨ 😊🤞


@VladUXUI's review,
> I’m 80% happy with that, so if you don’t want to spend the time or don’t have the time to bring it closer, I’m good to leave it as an update for later

List of 24 words,
<img width="340" alt="write down" src="https://user-images.githubusercontent.com/1918798/148917904-fdcd16a3-325b-405e-877a-7f40a0287832.png">

Verify 8 random words in phrase,
<img width="340" alt="verify" src="https://user-images.githubusercontent.com/1918798/148919675-cc79d5da-2cdc-4dd8-8be1-a2ce606df45b.png">

