### PR TITLE
IO Transit: Collection of improvements to SharedAssetInput

### DIFF
--- a/background/assets.ts
+++ b/background/assets.ts
@@ -1,7 +1,7 @@
 import { TokenList } from "@uniswap/token-lists"
 import { UNIXTime, HexString } from "./types"
 import { NetworkSpecific, SmartContract, Network } from "./networks"
-import { convertFixedPoint, fromFixedPoint } from "./lib/fixed-point"
+import { fromFixedPoint } from "./lib/fixed-point"
 
 /**
  * A reference to a token list, with the name, URL, and potentially logo of the

--- a/ui/components/Shared/SharedAssetInput.tsx
+++ b/ui/components/Shared/SharedAssetInput.tsx
@@ -64,7 +64,11 @@ function SelectAssetMenuContent<T extends AnyAsset>(
           .map((asset) => {
             return (
               <SharedAssetItem
-                key={asset.metadata?.coinGeckoID || asset.symbol}
+                key={
+                  asset.metadata?.coinGeckoID ??
+                  asset.symbol +
+                    ("contractAddress" in asset ? asset.contractAddress : "")
+                }
                 asset={asset}
                 onClick={setSelectedAssetAndClose}
               />

--- a/ui/components/Shared/SharedAssetInput.tsx
+++ b/ui/components/Shared/SharedAssetInput.tsx
@@ -108,14 +108,15 @@ function SelectAssetMenuContent<T extends AnyAsset>(
 
 interface SelectedAssetButtonProps {
   asset: Asset
+  isDisabled: boolean
   toggleIsAssetMenuOpen?: () => void
 }
 
 function SelectedAssetButton(props: SelectedAssetButtonProps): ReactElement {
-  const { asset, toggleIsAssetMenuOpen } = props
+  const { asset, isDisabled, toggleIsAssetMenuOpen } = props
 
   return (
-    <button type="button" onClick={toggleIsAssetMenuOpen}>
+    <button type="button" disabled={isDisabled} onClick={toggleIsAssetMenuOpen}>
       <div className="asset_icon_wrap">
         <SharedAssetIcon
           logoURL={asset?.metadata?.logoURL}
@@ -134,6 +135,10 @@ function SelectedAssetButton(props: SelectedAssetButtonProps): ReactElement {
           font-weight: 500;
           line-height: 24px;
           text-transform: uppercase;
+        }
+        button:disabled {
+          cursor: default;
+          color: var(--green-40);
         }
         .asset_icon_wrap {
           margin-right: 8px;
@@ -156,6 +161,7 @@ interface SharedAssetInputProps<T extends AnyAsset> {
   maxBalance: number | boolean
   isAssetOptionsLocked: boolean
   disableDropdown: boolean
+  isDisabled?: boolean
   onAssetSelect: (asset: T) => void
   onAmountChange: (value: string, errorMessage: string | undefined) => void
   onSendToAddressChange: (value: string) => void
@@ -173,6 +179,7 @@ export default function SharedAssetInput<T extends AnyAsset>(
     maxBalance,
     isAssetOptionsLocked,
     disableDropdown,
+    isDisabled,
     onAssetSelect,
     onAmountChange,
     onSendToAddressChange,
@@ -244,7 +251,7 @@ export default function SharedAssetInput<T extends AnyAsset>(
             <div>
               {selectedAsset?.symbol ? (
                 <SelectedAssetButton
-                  isDisabled={disableDropdown}
+                  isDisabled={isDisabled || disableDropdown}
                   asset={selectedAsset}
                   toggleIsAssetMenuOpen={toggleIsAssetMenuOpen}
                 />
@@ -252,7 +259,7 @@ export default function SharedAssetInput<T extends AnyAsset>(
                 <SharedButton
                   type="secondary"
                   size="medium"
-                  isDisabled={disableDropdown}
+                  isDisabled={isDisabled || disableDropdown}
                   onClick={toggleIsAssetMenuOpen}
                   icon="chevron"
                 >
@@ -267,6 +274,7 @@ export default function SharedAssetInput<T extends AnyAsset>(
               step="any"
               placeholder="0.0"
               min="0"
+              disabled={isDisabled}
               value={amount}
               spellCheck={false}
               onChange={(event) =>
@@ -341,6 +349,10 @@ export default function SharedAssetInput<T extends AnyAsset>(
           input[type="number"] {
             -moz-appearance: textfield;
           }
+          .input_amount:disabled {
+            cursor: default;
+            color: var(--green-40);
+          }
           .error_message {
             color: var(--error);
             position: absolute;
@@ -365,6 +377,7 @@ SharedAssetInput.defaultProps = {
   isTypeDestination: false,
   isAssetOptionsLocked: false,
   disableDropdown: false,
+  isDisabled: false,
   assets: [{ symbol: "ETH", name: "Example Asset" }],
   defaultAsset: { symbol: "", name: "" },
   label: "",

--- a/ui/components/Shared/SharedAssetInput.tsx
+++ b/ui/components/Shared/SharedAssetInput.tsx
@@ -6,7 +6,6 @@ import React, {
   useState,
 } from "react"
 import { AnyAsset, Asset } from "@tallyho/tally-background/assets"
-import classNames from "classnames"
 import SharedButton from "./SharedButton"
 import SharedSlideUpMenu from "./SharedSlideUpMenu"
 import SharedAssetItem from "./SharedAssetItem"
@@ -242,9 +241,10 @@ export default function SharedAssetInput<T extends AnyAsset>(
           </>
         ) : (
           <>
-            <div className={classNames({ disable_click: disableDropdown })}>
+            <div>
               {selectedAsset?.symbol ? (
                 <SelectedAssetButton
+                  isDisabled={disableDropdown}
                   asset={selectedAsset}
                   toggleIsAssetMenuOpen={toggleIsAssetMenuOpen}
                 />
@@ -252,6 +252,7 @@ export default function SharedAssetInput<T extends AnyAsset>(
                 <SharedButton
                   type="secondary"
                   size="medium"
+                  isDisabled={disableDropdown}
                   onClick={toggleIsAssetMenuOpen}
                   icon="chevron"
                 >
@@ -353,9 +354,6 @@ export default function SharedAssetInput<T extends AnyAsset>(
             background-color: var(--green-95);
             margin-left: 172px;
             z-index: 1;
-          }
-          .disable_click {
-            pointer-events: none;
           }
         `}
       </style>

--- a/ui/components/Shared/SharedAssetInput.tsx
+++ b/ui/components/Shared/SharedAssetInput.tsx
@@ -15,6 +15,7 @@ function SelectAssetMenuContent(
   props: SelectAssetMenuContentProps
 ): ReactElement {
   const { setSelectedAssetAndClose, assets } = props
+  const [searchTerm, setSearchTerm] = useState("")
 
   return (
     <>
@@ -26,21 +27,26 @@ function SelectAssetMenuContent(
             className="search_input"
             placeholder="Search by name or address"
             spellCheck={false}
+            onChange={(event) => setSearchTerm(event.target.value)}
           />
           <span className="icon_search" />
         </div>
       </div>
       <div className="divider" />
       <ul>
-        {assets.map((asset) => {
-          return (
-            <SharedAssetItem
-              key={asset.metadata?.coinGeckoID || asset.symbol}
-              asset={asset}
-              onClick={setSelectedAssetAndClose}
-            />
-          )
-        })}
+        {assets
+          .filter((asset) => {
+            return asset.symbol.toLowerCase().includes(searchTerm.toLowerCase())
+          })
+          .map((asset) => {
+            return (
+              <SharedAssetItem
+                key={asset.metadata?.coinGeckoID || asset.symbol}
+                asset={asset}
+                onClick={setSelectedAssetAndClose}
+              />
+            )
+          })}
       </ul>
       <style jsx>
         {`

--- a/ui/components/Shared/SharedAssetInput.tsx
+++ b/ui/components/Shared/SharedAssetInput.tsx
@@ -142,7 +142,7 @@ interface SharedAssetInputProps {
   label: string
   defaultAsset: Asset
   amount: string
-  maxBalance: number
+  maxBalance: number | boolean
   isAssetOptionsLocked: boolean
   disableDropdown: boolean
   onAssetSelect: (token: Asset) => void
@@ -193,7 +193,8 @@ export default function SharedAssetInput(
 
   const getErrorMessage = (givenAmount: string): string | undefined => {
     return (!isTypeDestination && maxBalance >= Number(givenAmount)) ||
-      Number(givenAmount) === 0
+      Number(givenAmount) === 0 ||
+      !maxBalance
       ? undefined
       : "Insufficient balance"
   }
@@ -358,7 +359,7 @@ SharedAssetInput.defaultProps = {
   defaultAsset: { symbol: "", name: "" },
   label: "",
   amount: "0.0",
-  maxBalance: 0,
+  maxBalance: false,
   onAssetSelect: () => {
     // do nothing by default
     // TODO replace this with support for undefined onClick

--- a/ui/components/Shared/SharedAssetInput.tsx
+++ b/ui/components/Shared/SharedAssetInput.tsx
@@ -1,4 +1,10 @@
-import React, { ReactElement, useCallback, useEffect, useState } from "react"
+import React, {
+  ReactElement,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
 import { Asset } from "@tallyho/tally-background/assets"
 import classNames from "classnames"
 import SharedButton from "./SharedButton"
@@ -16,6 +22,11 @@ function SelectAssetMenuContent(
 ): ReactElement {
   const { setSelectedAssetAndClose, assets } = props
   const [searchTerm, setSearchTerm] = useState("")
+  const searchInput = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    searchInput.current?.focus()
+  }, [searchInput])
 
   return (
     <>
@@ -24,6 +35,7 @@ function SelectAssetMenuContent(
         <div className="search_wrap">
           <input
             type="text"
+            ref={searchInput}
             className="search_input"
             placeholder="Search by name or address"
             spellCheck={false}

--- a/ui/components/Shared/SharedAssetInput.tsx
+++ b/ui/components/Shared/SharedAssetInput.tsx
@@ -5,20 +5,20 @@ import React, {
   useRef,
   useState,
 } from "react"
-import { Asset } from "@tallyho/tally-background/assets"
+import { AnyAsset, Asset } from "@tallyho/tally-background/assets"
 import classNames from "classnames"
 import SharedButton from "./SharedButton"
 import SharedSlideUpMenu from "./SharedSlideUpMenu"
 import SharedAssetItem from "./SharedAssetItem"
 import SharedAssetIcon from "./SharedAssetIcon"
 
-interface SelectAssetMenuContentProps {
-  assets: Asset[]
-  setSelectedAssetAndClose: (asset: Asset) => void
+interface SelectAssetMenuContentProps<T extends AnyAsset> {
+  assets: T[]
+  setSelectedAssetAndClose: (asset: T) => void
 }
 
-function SelectAssetMenuContent(
-  props: SelectAssetMenuContentProps
+function SelectAssetMenuContent<T extends AnyAsset>(
+  props: SelectAssetMenuContentProps<T>
 ): ReactElement {
   const { setSelectedAssetAndClose, assets } = props
   const [searchTerm, setSearchTerm] = useState("")
@@ -148,22 +148,22 @@ SelectedAssetButton.defaultProps = {
   toggleIsAssetMenuOpen: null,
 }
 
-interface SharedAssetInputProps {
+interface SharedAssetInputProps<T extends AnyAsset> {
   isTypeDestination: boolean
-  assets: Asset[]
+  assets: T[]
   label: string
-  defaultAsset: Asset
+  defaultAsset: T
   amount: string
   maxBalance: number | boolean
   isAssetOptionsLocked: boolean
   disableDropdown: boolean
-  onAssetSelect: (token: Asset) => void
+  onAssetSelect: (asset: T) => void
   onAmountChange: (value: string, errorMessage: string | undefined) => void
   onSendToAddressChange: (value: string) => void
 }
 
-export default function SharedAssetInput(
-  props: SharedAssetInputProps
+export default function SharedAssetInput<T extends AnyAsset>(
+  props: SharedAssetInputProps<T>
 ): ReactElement {
   const {
     isTypeDestination,
@@ -194,7 +194,7 @@ export default function SharedAssetInput(
   }, [isAssetOptionsLocked])
 
   const setSelectedAssetAndClose = useCallback(
-    (asset) => {
+    (asset: T) => {
       setSelectedAsset(asset)
       setOpenAssetMenu(false)
       onAssetSelect?.(asset)

--- a/ui/components/Shared/SharedAssetInput.tsx
+++ b/ui/components/Shared/SharedAssetInput.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
 } from "react"
 import { AnyAsset, Asset } from "@tallyho/tally-background/assets"
+import { normalizeEVMAddress } from "@tallyho/tally-background/lib/utils"
 import SharedButton from "./SharedButton"
 import SharedSlideUpMenu from "./SharedSlideUpMenu"
 import SharedAssetItem from "./SharedAssetItem"
@@ -47,7 +48,18 @@ function SelectAssetMenuContent<T extends AnyAsset>(
       <ul>
         {assets
           .filter((asset) => {
-            return asset.symbol.toLowerCase().includes(searchTerm.toLowerCase())
+            return (
+              asset.symbol.toLowerCase().includes(searchTerm.toLowerCase()) ||
+              ("contractAddress" in asset &&
+                searchTerm.startsWith("0x") &&
+                normalizeEVMAddress(asset.contractAddress).includes(
+                  // The replace handles `normalizeEVMAddress`'s
+                  // octet alignment that prefixes a `0` to a partial address
+                  // if it has an uneven number of digits.
+                  normalizeEVMAddress(searchTerm).replace(/^0x0?/, "0x")
+                ) &&
+                asset.contractAddress.length >= searchTerm.length)
+            )
           })
           .map((asset) => {
             return (

--- a/ui/components/Shared/SharedAssetItem.tsx
+++ b/ui/components/Shared/SharedAssetItem.tsx
@@ -1,13 +1,15 @@
 import React, { ReactElement } from "react"
-import { Asset } from "@tallyho/tally-background/assets"
+import { AnyAsset } from "@tallyho/tally-background/assets"
 import SharedAssetIcon from "./SharedAssetIcon"
 
-interface Props {
-  asset: Asset
-  onClick?: (asset: Asset) => void
+interface Props<T> {
+  asset: T
+  onClick?: (asset: T) => void
 }
 
-export default function SharedAssetItem(props: Props): ReactElement {
+export default function SharedAssetItem<T extends AnyAsset>(
+  props: Props<T>
+): ReactElement {
   const { onClick, asset } = props
 
   function handleClick() {

--- a/ui/components/Shared/SharedSlideUpMenu.tsx
+++ b/ui/components/Shared/SharedSlideUpMenu.tsx
@@ -42,7 +42,7 @@ export default function SharedSlideUpMenu(props: Props): ReactElement {
         onClick={close}
         aria-label="Close menu"
       />
-      {children}
+      {isOpen ? children : <></>}
       <style jsx>
         {`
           .slide_up_menu {


### PR DESCRIPTION
Extracted these from the swap work and rebased against main for
holistic review.

Big ticket global change:
- `SharedSlideUpMenu` *only renders its children when open*! This has
  high potential for unexpected bugs, though I haven't found any yet,
  as I believe we weren't *depending* on the behavior of children
  rendering in spite of being invisible. The motivation here was ensuring
  React lifecycle hooks fired at a useful time for slide-up menu contents
  (see the search input auto-focus change mentioned below).

Big ticket changes for `SharedAssetInput`:
- @henryboldi's work from #847, including search by symbol for assets.
- An expansion of this work to search/filter by contract addresses
  where applicable.
- Auto-focusing of the search input when the `SharedAssetInput` asset
  selector is displayed.
- Disabled state for the whole `SharedAssetInput` (in addition to the
  existing ability to only disable asset selection while still allowing
  editing the asset amount).

A couple of small quality-of-life improvements:
- The `SharedAssetInput` type is now parametrized so that more specific
  asset lists preserve their types in the `onAssetChange` callback.
- Disabled states use HTML-native disabled states rather than working
  with pointer events.
- When available, the `key` for asset entries in the asset selector
  includes the asset's contract address. This specifically addresses
  bugs with displaying certain assets like aUSDC that have two versions
  with identical symbols (for Aave aToken v1 vs v2) but different
  contract addresses. Without this change, asset filtering would fail
  to remove these assets due to React's reliance on `key` to properly
  update lists on change, making the whole experience feel broken.