### PR TITLE
Asset-ic Acid: Improve asset deduplication and merging

### DIFF
--- a/background/assets.ts
+++ b/background/assets.ts
@@ -122,8 +122,8 @@ export type AnyAsset =
 /*
  * The primary type representing amounts in fungible asset transactions.
  */
-export type AnyAssetAmount = {
-  asset: AnyAsset
+export type AnyAssetAmount<T extends AnyAsset = AnyAsset> = {
+  asset: T
   amount: bigint
 }
 

--- a/background/assets.ts
+++ b/background/assets.ts
@@ -170,7 +170,7 @@ export type AssetTransfer = {
 /**
  * Type guard to check if an AnyAsset is actually a FungibleAsset.
  */
-function isFungibleAsset(asset: AnyAsset): asset is FungibleAsset {
+export function isFungibleAsset(asset: AnyAsset): asset is FungibleAsset {
   return "decimals" in asset
 }
 

--- a/background/redux-slices/accounts.ts
+++ b/background/redux-slices/accounts.ts
@@ -3,7 +3,7 @@ import Emittery from "emittery"
 import { createBackgroundAsyncThunk } from "./utils"
 import { AccountBalance, AddressNetwork, NameNetwork } from "../accounts"
 import { AnyEVMBlock, Network } from "../networks"
-import { AnyAssetAmount } from "../assets"
+import { AnyAsset, AnyAssetAmount } from "../assets"
 import {
   AssetMainCurrencyAmount,
   AssetDecimalAmount,
@@ -66,9 +66,10 @@ export type CombinedAccountData = {
  * An asset amount including localized and numeric main currency and decimal
  * equivalents, where applicable.
  */
-export type CompleteAssetAmount = AnyAssetAmount &
-  AssetMainCurrencyAmount &
-  AssetDecimalAmount
+export type CompleteAssetAmount<
+  E extends AnyAsset = AnyAsset,
+  T extends AnyAssetAmount<E> = AnyAssetAmount<E>
+> = T & AssetMainCurrencyAmount & AssetDecimalAmount
 
 export const initialState = {
   accountsData: {},

--- a/background/redux-slices/assets.ts
+++ b/background/redux-slices/assets.ts
@@ -1,5 +1,6 @@
 import { createSelector, createSlice } from "@reduxjs/toolkit"
 import { AnyAsset, PricePoint } from "../assets"
+import { normalizeEVMAddress } from "../lib/utils"
 
 type SingleAssetState = AnyAsset & {
   prices: PricePoint[]
@@ -162,7 +163,8 @@ const assetsSlice = createSlice({
                 "homeNetwork" in a &&
                 "contractAddress" in a &&
                 a.homeNetwork.name === asset.homeNetwork.name &&
-                a.contractAddress === asset.contractAddress) ||
+                normalizeEVMAddress(a.contractAddress) ===
+                  normalizeEVMAddress(asset.contractAddress)) ||
               asset.name === a.name
           )
           // if there aren't duplicates, add the asset

--- a/background/redux-slices/utils.ts
+++ b/background/redux-slices/utils.ts
@@ -151,3 +151,17 @@ export function createBackgroundAsyncThunk<
 
   return webextActionCreator
 }
+
+/**
+ * Utility type to extract the fulfillment type of an async thunk. Useful when
+ * wanting to declare something as "the type that this thunk will return once
+ * it completes".
+ */
+export type AsyncThunkFulfillmentType<T> = T extends Pick<
+  // We don't really need the other two inferred values.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  AsyncThunk<infer Returned, infer _1, infer _2>,
+  "fulfilled"
+>
+  ? Returned
+  : never

--- a/background/redux-slices/utils.ts
+++ b/background/redux-slices/utils.ts
@@ -6,6 +6,7 @@ import {
   AsyncThunkPayloadCreator,
   createAsyncThunk,
 } from "@reduxjs/toolkit"
+import logger from "../lib/logger"
 
 // Below, we use `any` to deal with the fact that allAliases is a heterogeneous
 // collection of async thunk actions whose payload types have little in common
@@ -119,7 +120,14 @@ export function createBackgroundAsyncThunk<
   // Use reduxtools' createAsyncThunk to build the infrastructure.
   const baseThunkActionCreator = createAsyncThunk(
     typePrefix,
-    payloadCreator,
+    async (...args: Parameters<typeof payloadCreator>) => {
+      try {
+        return await payloadCreator(...args)
+      } catch (error) {
+        logger.error(error)
+        throw error
+      }
+    },
     options
   )
 

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -406,7 +406,12 @@ export default class IndexingService extends BaseService<Events> {
         this.db
           .savePriceMeasurement(pricePoint, measuredAt, "coingecko")
           .catch((err) =>
-            logger.error("Error saving price point", pricePoint, measuredAt)
+            logger.error(
+              "Error saving price point",
+              err,
+              pricePoint,
+              measuredAt
+            )
           )
       })
     } catch (e) {

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -169,9 +169,10 @@ export default class IndexingService extends BaseService<Events> {
     const tokenListPrefs =
       await this.preferenceService.getTokenListPreferences()
     const tokenLists = await this.db.getLatestTokenLists(tokenListPrefs.urls)
+
     return baseAssets
       .concat(customAssets)
-      .concat(networkAssetsFromLists(tokenLists))
+      .concat(networkAssetsFromLists(getEthereumNetwork(), tokenLists))
   }
 
   /**

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -17,6 +17,7 @@ import { getTokenBalances, getTokenMetadata } from "../../lib/alchemy"
 import { getPrices, getEthereumTokenPrices } from "../../lib/prices"
 import {
   fetchAndValidateTokenList,
+  mergeAssets,
   networkAssetsFromLists,
 } from "../../lib/tokenList"
 import { getEthereumNetwork } from "../../lib/utils"
@@ -170,9 +171,11 @@ export default class IndexingService extends BaseService<Events> {
       await this.preferenceService.getTokenListPreferences()
     const tokenLists = await this.db.getLatestTokenLists(tokenListPrefs.urls)
 
-    return baseAssets
-      .concat(customAssets)
-      .concat(networkAssetsFromLists(getEthereumNetwork(), tokenLists))
+    return mergeAssets(
+      baseAssets,
+      customAssets,
+      networkAssetsFromLists(getEthereumNetwork(), tokenLists)
+    )
   }
 
   /**


### PR DESCRIPTION
This is the second PR extracted from the swaps flow rework, again
rebased against main for holistic review. This one is focused on
a cleaner set of available assets, which feeds the swap buy list
in the new quote-based flow.

The outcome still isn't perfect here, and to update existing installs
will require clearing and repopulating the asset store from
`getCachedAssets`. Nonetheless, this should be a large improvement,
removing a whole swath of duplicates and irrelevant assets that were
slipping through before.

Also packaged here are a few type-level tidbits that are useful
external to the assets pipeline.

------

One thing to look at carefully: right now the new `mergeAssets` helper
merges assets by symbol if a contract address is unavailable. This
may not be the correct behavior, so please check me if that's the case
and we can drop that.