### PR TITLE
Signing fixes

### DIFF
--- a/background/services/keyring/index.ts
+++ b/background/services/keyring/index.ts
@@ -427,13 +427,12 @@ export default class KeyringService extends BaseService<Events> {
     // find the keyring using a linear search
     const keyring = await this.#findKeyring(account)
     // When signing we should not include EIP712Domain type
-    delete types.EIP712Domain
-
+    const { EIP712Domain, ...typesForSigning } = types
     try {
       const signature = await keyring.signTypedData(
         account,
         domain,
-        types,
+        typesForSigning,
         message
       )
       this.emitter.emit("signedData", signature)

--- a/ui/components/NetworkFees/NetworkSettingsSelect.tsx
+++ b/ui/components/NetworkFees/NetworkSettingsSelect.tsx
@@ -17,7 +17,7 @@ import React, {
 import { weiToGwei } from "@tallyho/tally-background/lib/utils"
 import SharedInput from "../Shared/SharedInput"
 import { useBackgroundSelector } from "../../hooks"
-import { capitalize } from "../../utils/formatting"
+import capitalize from "../../utils/capitalize"
 
 interface NetworkSettingsSelectProps {
   estimatedFeesPerGas: EstimatedFeesPerGas | undefined

--- a/ui/pages/SignData.tsx
+++ b/ui/pages/SignData.tsx
@@ -14,7 +14,7 @@ import {
   useBackgroundDispatch,
   useBackgroundSelector,
 } from "../hooks"
-import { capitalize } from "../utils/formatting"
+import capitalize from "../utils/capitalize"
 
 export enum SignDataType {
   TypedData = "sign-typed-data",

--- a/ui/pages/SignTransaction.tsx
+++ b/ui/pages/SignTransaction.tsx
@@ -19,6 +19,7 @@ import {
 } from "../hooks"
 import SignTransactionTransferBlock from "../components/SignTransaction/SignTransactionTransferBlock"
 import SignTransactionContainer from "../components/SignTransaction/SignTransactionContainer"
+import SignTransactionApproveSpendAssetBlock from "../components/SignTransaction/SignTransactionApproveSpendAssetBlock"
 
 export enum SignType {
   Sign = "sign",
@@ -148,9 +149,14 @@ export default function SignTransaction({
       return (
         <SignTransactionContainer
           signerAccountTotal={signerAccountTotal}
-          title="Swap assets"
-          infoBlock={<SignTransactionSwapAssetBlock />}
-          confirmButtonLabel="Confirm"
+          title="Approve asset spend"
+          infoBlock={
+            <SignTransactionApproveSpendAssetBlock
+              transactionDetails={transactionDetails}
+              parsedTx={parsedTx}
+            />
+          }
+          confirmButtonLabel="Approve"
           handleConfirm={handleConfirm}
           handleReject={handleReject}
         />

--- a/ui/utils/capitalize.ts
+++ b/ui/utils/capitalize.ts
@@ -1,0 +1,3 @@
+export default function capitalize(s: string): string {
+  return s[0].toUpperCase() + s.slice(1)
+}

--- a/ui/utils/formatting.ts
+++ b/ui/utils/formatting.ts
@@ -1,4 +1,0 @@
-// eslint-disable-next-line import/prefer-default-export
-export function capitalize(s: string): string {
-  return s[0].toUpperCase() + s.slice(1)
-}


### PR DESCRIPTION
When restructuring the SignTransaction page we have accidentally omitted Approval Page.

In order to avoid future unexpected outcomes from deleting type from types to be signed we now destructure it instead.

Removed eslint disable from capitalization function.

