### PR TITLE
Fix Edge Case When Adding Pricepoint for "0th" Asset

### DIFF
--- a/background/redux-slices/assets.ts
+++ b/background/redux-slices/assets.ts
@@ -189,7 +189,7 @@ const assetsSlice = createSlice({
         const index = findClosestAsset(pricedAsset, [
           ...immerState,
         ] as AnyAsset[])
-        if (index) {
+        if (index !== null) {
           // append to longer-running prices
           const prices = prunePrices(
             [...immerState[index].prices].concat([pricePoint])


### PR DESCRIPTION
This PR adds an explicit null check that fixes a bug where the 1st asset in the asset list was not having its prices populated.  Since we explicitly prepend the assets array with ETH and BTC this would always result in ETH not having its prices populated.

This was a fun one - I went down the rabbit hole into indexDb and alchemy.ts before coming back out. 🐰

Closes #813 