### PR TITLE
💨  Ephemeral existence: extend emittery so `emit()` returns the return value from all the listeners

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,7 +50,17 @@ module.exports = {
     // Don't slap build files for importing devDependencies.
     "import/no-extraneous-dependencies": [
       "error",
-      { devDependencies: ["!+(src/api|ui)/**/*.+(ts|js)"] },
+      {
+        devDependencies: ["!+(src/api|ui)/**/*.+(ts|js)"],
+        packageDir: [
+          "./",
+          "./ui",
+          "./background",
+          "./provider-bridge",
+          "./provider-bridge-shared",
+          "./window-provider",
+        ],
+      },
     ],
     // Add known-safe exceptions to no-param-reassign.
     "no-param-reassign": [

--- a/background/package.json
+++ b/background/package.json
@@ -49,7 +49,6 @@
     "dayjs": "^1.10.7",
     "dexie": "^3.0.3",
     "eip55": "^2.1.0",
-    "emittery": "^0.9.2",
     "eth-sig-util": "^3.0.1",
     "ethereumjs-util": "^7.1.0",
     "ethers": "^5.5.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@tallyho/tally-ui": "0.0.1",
     "@tallyho/window-provider": "0.0.1",
     "buffer": "^6.0.3",
+    "emittery": "^0.9.2",
     "git-revision-webpack-plugin": "^5.0.0",
     "react": "^17.0.2",
     "webext-options-sync": "^2.0.1",

--- a/patches/emittery+0.9.2.patch
+++ b/patches/emittery+0.9.2.patch
@@ -1,0 +1,40 @@
+diff --git a/node_modules/emittery/index.d.ts b/node_modules/emittery/index.d.ts
+index b087aa1..5f30f7e 100644
+--- a/node_modules/emittery/index.d.ts
++++ b/node_modules/emittery/index.d.ts
+@@ -314,7 +314,7 @@ declare class Emittery<
+ 	*/
+ 	on<Name extends keyof AllEventData>(
+ 		eventName: Name,
+-		listener: (eventData: AllEventData[Name]) => void | Promise<void>
++		listener: (eventData: AllEventData[Name]) => unknown | Promise<unknown>
+ 	): Emittery.UnsubscribeFn;
+ 
+ 	/**
+@@ -464,11 +464,11 @@ declare class Emittery<
+ 
+ 	@returns A promise that resolves when all the event listeners are done. *Done* meaning executed if synchronous or resolved when an async/promise-returning function. You usually wouldn't want to wait for this, but you could for example catch possible errors. If any of the listeners throw/reject, the returned promise will be rejected with the error, but the other listeners will not be affected.
+ 	*/
+-	emit<Name extends DatalessEvents>(eventName: Name): Promise<void>;
++	emit<Name extends DatalessEvents>(eventName: Name): Promise<unknown[]>;
+ 	emit<Name extends keyof EventData>(
+ 		eventName: Name,
+ 		eventData: EventData[Name]
+-	): Promise<void>;
++	): Promise<unknown[]>;
+ 
+ 	/**
+ 	Same as `emit()`, but it waits for each listener to resolve before triggering the next one. This can be useful if your events depend on each other. Although ideally they should not. Prefer `emit()` whenever possible.
+diff --git a/node_modules/emittery/index.js b/node_modules/emittery/index.js
+index cd4a5ae..bf695a3 100644
+--- a/node_modules/emittery/index.js
++++ b/node_modules/emittery/index.js
+@@ -300,7 +300,7 @@ class Emittery {
+ 		const staticAnyListeners = isListenerSymbol(eventName) ? [] : [...anyListeners];
+ 
+ 		await resolvedPromise;
+-		await Promise.all([
++		return await Promise.all([
+ 			...staticListeners.map(async listener => {
+ 				if (listeners.has(listener)) {
+ 					return listener(eventData);


### PR DESCRIPTION
# What
Extend emittery so emit() returns the return value from all the listeners

# Why
We did NOT have a way to return temporary data from the background to the UI.
All the data from the background had to go through `dispatch > reducer > store > selector` path
even if the data was ephemeral eg. time-bound quotes or single-use ids

# How 
The `emitter.emit()` already returns a promise, so the infrastructure was in place.
The only problem was that it did not propagate/allow the return value from the listeners.
This patch makes this possible and updates the typings of the lib.

Yarn workspace has installed `emittery` into `node_modules` and `background/node_modules`.
When importing, code from `background/node_modules` was used.
To be able to patch the package it had to be moved to `node_modules`.

When the `emittery` package was not present in the `background/package.json`
the `import/no-extraneous-dependencies` linter rule throw an error when importing emittery.
To solution for this is to inform this rule that we have multiple `package.json` files,
and dependencies can be used from these.

Tried to keep the `emittery` package in the `background` only, but the patch-package
did not run on `yarn install` with that setup.

# Test
- remove the extension from browser
- Apply the following patch in the extension dir:
```
git apply <<- EOF
diff --git a/background/main.ts b/background/main.ts
index 94cbdc89..9748b11d 100644
--- a/background/main.ts
+++ b/background/main.ts
@@ -442,6 +442,7 @@ export default class Main extends BaseService<never> {
     })
     accountSliceEmitter.on("addAccount", async (addressNetwork) => {
       await this.chainService.addAccountToTrack(addressNetwork)
+      return 5
     })

     accountSliceEmitter.on(
diff --git a/background/redux-slices/accounts.ts b/background/redux-slices/accounts.ts
index a0c480ce..cc64a2cd 100644
--- a/background/redux-slices/accounts.ts
+++ b/background/redux-slices/accounts.ts
@@ -279,7 +279,9 @@ export const addAddressNetwork = createBackgroundAsyncThunk(
     }

     dispatch(loadAccount(normalizedAddressNetwork.address))
-    await emitter.emit("addAccount", normalizedAddressNetwork)
+    const ret = await emitter.emit("addAccount", normalizedAddressNetwork)
+    debugger
+    console.log("after await emit", ret)
   }
 )

EOF
```
- add extension to the browser
- open background console 
- import a read-only address

![CleanShot 2022-02-03 at 12 47 46](https://user-images.githubusercontent.com/7690112/152337232-fb5e0dd1-6546-4f76-b8f7-e4e3e1dbc9d0.gif)

