### PR TITLE
Asset Amounty Input: Alternate approach to SharedAssetInput max/balance info

### DIFF
--- a/background/lib/fixed-point.ts
+++ b/background/lib/fixed-point.ts
@@ -170,17 +170,33 @@ export function parseToFixedPointNumber(
   }
 }
 
-export function fixedPointNumberToString({
-  amount,
-  decimals,
-}: FixedPointNumber): string {
+/**
+ * Converts a fixed point number with a bigint amount and a decimals field
+ * indicating the orders of magnitude in `amount` behind the decimal point into
+ * a string in US decimal format (no thousands separators, . for the decimal
+ * separator).
+ *
+ * Note that for UI usage, it is _usually_ a better strategy to use
+ * ``fromFixedPoint`` to convert to a JavaScript number and then use an
+ * Intl.NumberFormat to format the number unless that is not an available
+ * option or precision is critical. This function currently does _not_ respect
+ * localization settings.
+ */
+export function fixedPointNumberToString(
+  { amount, decimals }: FixedPointNumber,
+  trimTrailingZeros = true
+): string {
   const undecimaledAmount = amount.toString()
   const preDecimalLength = undecimaledAmount.length - decimals
 
   const preDecimalCharacters = undecimaledAmount.substring(0, preDecimalLength)
   const postDecimalCharacters = undecimaledAmount.substring(preDecimalLength)
 
-  return `${preDecimalCharacters}.${postDecimalCharacters}`
+  return `${preDecimalCharacters}.${
+    trimTrailingZeros
+      ? postDecimalCharacters.replace(/0*$/, "")
+      : postDecimalCharacters
+  }`
 }
 
 /**

--- a/background/lib/fixed-point.ts
+++ b/background/lib/fixed-point.ts
@@ -141,7 +141,7 @@ export function toFixedPointNumber(
 export function parseToFixedPointNumber(
   floatingPointString: string
 ): FixedPointNumber | undefined {
-  if (!floatingPointString.match(/^[^0-9]*([0-9,]+)(?:\.([0-9]+))?$/)) {
+  if (!floatingPointString.match(/^[^0-9]*([0-9,]+)(?:\.([0-9]*))?$/)) {
     return undefined
   }
 

--- a/background/lib/fixed-point.ts
+++ b/background/lib/fixed-point.ts
@@ -202,11 +202,16 @@ export function fixedPointNumberToString(
     "0".repeat(Math.max(-preDecimalLength, 0)) +
     undecimaledAmount.substring(preDecimalLength)
 
-  return `${preDecimalCharacters}.${
-    trimTrailingZeros
-      ? postDecimalCharacters.replace(/0*$/, "")
-      : postDecimalCharacters
-  }`
+  const trimmedPostDecimalCharacters = trimTrailingZeros
+    ? postDecimalCharacters.replace(/0*$/, "")
+    : postDecimalCharacters
+
+  const decimalString =
+    trimmedPostDecimalCharacters.length > 0
+      ? `.${trimmedPostDecimalCharacters}`
+      : ""
+
+  return `${preDecimalCharacters}${decimalString}`
 }
 
 /**

--- a/background/lib/fixed-point.ts
+++ b/background/lib/fixed-point.ts
@@ -189,8 +189,18 @@ export function fixedPointNumberToString(
   const undecimaledAmount = amount.toString()
   const preDecimalLength = undecimaledAmount.length - decimals
 
-  const preDecimalCharacters = undecimaledAmount.substring(0, preDecimalLength)
-  const postDecimalCharacters = undecimaledAmount.substring(preDecimalLength)
+  const preDecimalCharacters =
+    preDecimalLength > 0
+      ? undecimaledAmount.substring(0, preDecimalLength)
+      : "0"
+  const postDecimalCharacters =
+    // The pre-decimal length is negative if the number is less than 1/10th of
+    // a whole number; in these cases, we have to prefix 0s as the string
+    // representation of the bigint won't have them. For example, the bigint
+    // 5000 with decimals 5 represents 0.05000, but in this case
+    // undecimaledAmount will just be "5000".
+    "0".repeat(Math.max(-preDecimalLength, 0)) +
+    undecimaledAmount.substring(preDecimalLength)
 
   return `${preDecimalCharacters}.${
     trimTrailingZeros

--- a/ui/components/Shared/SharedAssetInput.tsx
+++ b/ui/components/Shared/SharedAssetInput.tsx
@@ -169,7 +169,6 @@ SelectedAssetButton.defaultProps = {
 }
 
 interface SharedAssetInputProps<T extends AnyAsset> {
-  isTypeDestination: boolean
   assets: T[]
   label: string
   defaultAsset: T
@@ -180,14 +179,12 @@ interface SharedAssetInputProps<T extends AnyAsset> {
   isDisabled?: boolean
   onAssetSelect: (asset: T) => void
   onAmountChange: (value: string, errorMessage: string | undefined) => void
-  onSendToAddressChange: (value: string) => void
 }
 
 export default function SharedAssetInput<T extends AnyAsset>(
   props: SharedAssetInputProps<T>
 ): ReactElement {
   const {
-    isTypeDestination,
     assets,
     label,
     defaultAsset,
@@ -198,7 +195,6 @@ export default function SharedAssetInput<T extends AnyAsset>(
     isDisabled,
     onAssetSelect,
     onAmountChange,
-    onSendToAddressChange,
   } = props
 
   const [openAssetMenu, setOpenAssetMenu] = useState(false)
@@ -250,58 +246,42 @@ export default function SharedAssetInput<T extends AnyAsset>(
         )}
       </SharedSlideUpMenu>
       <div className="asset_wrap standard_width">
-        {isTypeDestination ? (
-          <>
-            <input
-              className="asset_input"
-              type="text"
-              placeholder="0x..."
-              spellCheck={false}
-              onChange={(event) => {
-                onSendToAddressChange(event.target.value)
-              }}
+        <div>
+          {selectedAsset?.symbol ? (
+            <SelectedAssetButton
+              isDisabled={isDisabled || disableDropdown}
+              asset={selectedAsset}
+              toggleIsAssetMenuOpen={toggleIsAssetMenuOpen}
             />
-          </>
-        ) : (
-          <>
-            <div>
-              {selectedAsset?.symbol ? (
-                <SelectedAssetButton
-                  isDisabled={isDisabled || disableDropdown}
-                  asset={selectedAsset}
-                  toggleIsAssetMenuOpen={toggleIsAssetMenuOpen}
-                />
-              ) : (
-                <SharedButton
-                  type="secondary"
-                  size="medium"
-                  isDisabled={isDisabled || disableDropdown}
-                  onClick={toggleIsAssetMenuOpen}
-                  icon="chevron"
-                >
-                  Select token
-                </SharedButton>
-              )}
-            </div>
+          ) : (
+            <SharedButton
+              type="secondary"
+              size="medium"
+              isDisabled={isDisabled || disableDropdown}
+              onClick={toggleIsAssetMenuOpen}
+              icon="chevron"
+            >
+              Select token
+            </SharedButton>
+          )}
+        </div>
 
-            <input
-              className="input_amount"
-              type="number"
-              step="any"
-              placeholder="0.0"
-              min="0"
-              disabled={isDisabled}
-              value={amount}
-              spellCheck={false}
-              onChange={(event) =>
-                onAmountChange(
-                  event.target.value,
-                  getErrorMessage(event.target.value)
-                )
-              }
-            />
-          </>
-        )}
+        <input
+          className="input_amount"
+          type="number"
+          step="any"
+          placeholder="0.0"
+          min="0"
+          disabled={isDisabled}
+          value={amount}
+          spellCheck={false}
+          onChange={(event) =>
+            onAmountChange(
+              event.target.value,
+              getErrorMessage(event.target.value)
+            )
+          }
+        />
         <div className="error_message">{getErrorMessage(amount)}</div>
       </div>
       <style jsx>
@@ -390,7 +370,6 @@ export default function SharedAssetInput<T extends AnyAsset>(
 }
 
 SharedAssetInput.defaultProps = {
-  isTypeDestination: false,
   isAssetOptionsLocked: false,
   disableDropdown: false,
   isDisabled: false,
@@ -404,5 +383,4 @@ SharedAssetInput.defaultProps = {
     // TODO replace this with support for undefined onClick
   },
   onAmountChange: () => {},
-  onSendToAddressChange: () => {},
 }

--- a/ui/components/Shared/SharedAssetInput.tsx
+++ b/ui/components/Shared/SharedAssetInput.tsx
@@ -7,14 +7,24 @@ import React, {
 } from "react"
 import { AnyAsset, Asset } from "@tallyho/tally-background/assets"
 import { normalizeEVMAddress } from "@tallyho/tally-background/lib/utils"
+import {
+  convertFixedPointNumber,
+  fixedPointNumberToString,
+  parseToFixedPointNumber,
+} from "@tallyho/tally-background/lib/fixed-point"
 import SharedButton from "./SharedButton"
 import SharedSlideUpMenu from "./SharedSlideUpMenu"
-import SharedAssetItem from "./SharedAssetItem"
+import SharedAssetItem, {
+  AnyAssetWithOptionalAmount,
+  hasAmounts,
+} from "./SharedAssetItem"
 import SharedAssetIcon from "./SharedAssetIcon"
 
-interface SelectAssetMenuContentProps<T extends AnyAsset> {
-  assets: T[]
-  setSelectedAssetAndClose: (asset: T) => void
+interface SelectAssetMenuContentProps<AssetType extends AnyAsset> {
+  assets: AnyAssetWithOptionalAmount<AssetType>[]
+  setSelectedAssetAndClose: (
+    asset: AnyAssetWithOptionalAmount<AssetType>
+  ) => void
 }
 
 function SelectAssetMenuContent<T extends AnyAsset>(
@@ -47,7 +57,7 @@ function SelectAssetMenuContent<T extends AnyAsset>(
       <div className="divider" />
       <ul>
         {assets
-          .filter((asset) => {
+          .filter(({ asset }) => {
             return (
               asset.symbol.toLowerCase().includes(searchTerm.toLowerCase()) ||
               ("contractAddress" in asset &&
@@ -61,7 +71,8 @@ function SelectAssetMenuContent<T extends AnyAsset>(
                 asset.contractAddress.length >= searchTerm.length)
             )
           })
-          .map((asset) => {
+          .map((assetWithOptionalAmount) => {
+            const { asset } = assetWithOptionalAmount
             return (
               <SharedAssetItem
                 key={
@@ -69,8 +80,10 @@ function SelectAssetMenuContent<T extends AnyAsset>(
                   asset.symbol +
                     ("contractAddress" in asset ? asset.contractAddress : "")
                 }
-                asset={asset}
-                onClick={setSelectedAssetAndClose}
+                assetAndAmount={assetWithOptionalAmount}
+                onClick={() =>
+                  setSelectedAssetAndClose(assetWithOptionalAmount)
+                }
               />
             )
           })}
@@ -141,7 +154,6 @@ function SelectedAssetButton(props: SelectedAssetButtonProps): ReactElement {
       </div>
 
       {asset?.symbol}
-
       <style jsx>{`
         button {
           display: flex;
@@ -168,42 +180,52 @@ SelectedAssetButton.defaultProps = {
   toggleIsAssetMenuOpen: null,
 }
 
-interface SharedAssetInputProps<T extends AnyAsset> {
-  assets: T[]
+interface SharedAssetInputProps<AssetType extends AnyAsset> {
+  assetsAndAmounts: AnyAssetWithOptionalAmount<AssetType>[]
   label: string
-  defaultAsset: T
+  defaultAsset: AssetType
   amount: string
-  maxBalance: number | boolean
   isAssetOptionsLocked: boolean
   disableDropdown: boolean
+  showMaxButton: boolean
   isDisabled?: boolean
-  onAssetSelect: (asset: T) => void
-  onAmountChange: (value: string, errorMessage: string | undefined) => void
+  onAssetSelect?: (asset: AssetType) => void
+  onAmountChange?: (value: string, errorMessage: string | undefined) => void
+}
+
+function isSameAsset(asset1: Asset, asset2: Asset) {
+  return asset1.symbol === asset2.symbol // FIXME Once asset similarity logic is extracted, reuse.
+}
+
+function assetWithOptionalAmountFromAsset<T extends AnyAsset>(
+  asset: T,
+  assetsToSearch: AnyAssetWithOptionalAmount<T>[]
+) {
+  return assetsToSearch.find(({ asset: listAsset }) =>
+    isSameAsset(asset, listAsset)
+  )
 }
 
 export default function SharedAssetInput<T extends AnyAsset>(
   props: SharedAssetInputProps<T>
 ): ReactElement {
   const {
-    assets,
+    assetsAndAmounts,
     label,
     defaultAsset,
     amount,
-    maxBalance,
     isAssetOptionsLocked,
     disableDropdown,
+    showMaxButton,
     isDisabled,
     onAssetSelect,
     onAmountChange,
   } = props
 
   const [openAssetMenu, setOpenAssetMenu] = useState(false)
-  const [selectedAsset, setSelectedAsset] = useState(defaultAsset)
-
-  // TODO: Refactor this to track state in a more reasonable way
-  useEffect(() => {
-    setSelectedAsset(defaultAsset)
-  }, [defaultAsset])
+  const [selectedAsset, setSelectedAsset] = useState<
+    AnyAssetWithOptionalAmount<T> | undefined
+  >(assetWithOptionalAmountFromAsset(defaultAsset, assetsAndAmounts))
 
   const toggleIsAssetMenuOpen = useCallback(() => {
     if (!isAssetOptionsLocked) {
@@ -212,49 +234,110 @@ export default function SharedAssetInput<T extends AnyAsset>(
   }, [isAssetOptionsLocked])
 
   const setSelectedAssetAndClose = useCallback(
-    (asset: T) => {
-      setSelectedAsset(asset)
+    (assetWithOptionalAmount: AnyAssetWithOptionalAmount<T>) => {
+      setSelectedAsset(assetWithOptionalAmount)
       setOpenAssetMenu(false)
-      onAssetSelect?.(asset)
+      onAssetSelect?.(assetWithOptionalAmount.asset)
     },
 
     [onAssetSelect]
   )
 
   const getErrorMessage = (givenAmount: string): string | undefined => {
-    return (!isTypeDestination && maxBalance >= Number(givenAmount)) ||
-      Number(givenAmount) === 0 ||
-      !maxBalance
-      ? undefined
-      : "Insufficient balance"
+    if (
+      givenAmount.trim() === "" ||
+      typeof selectedAsset === "undefined" ||
+      !hasAmounts(selectedAsset) ||
+      !("decimals" in selectedAsset.asset)
+    ) {
+      return undefined
+    }
+
+    const parsedGivenAmount = parseToFixedPointNumber(givenAmount.trim())
+    if (typeof parsedGivenAmount === "undefined") {
+      return "Invalid amount"
+    }
+
+    const decimalMatched = convertFixedPointNumber(
+      parsedGivenAmount,
+      selectedAsset.asset.decimals
+    )
+    if (decimalMatched.amount > selectedAsset.amount) {
+      return "Insufficient balance"
+    }
+
+    return undefined
+  }
+
+  const setMaxBalance = () => {
+    if (typeof selectedAsset === "undefined" || !hasAmounts(selectedAsset)) {
+      return
+    }
+
+    const fixedPointAmount = {
+      amount: selectedAsset.amount,
+      decimals:
+        "decimals" in selectedAsset.asset ? selectedAsset.asset.decimals : 0,
+    }
+    const fixedPointString = fixedPointNumberToString(fixedPointAmount)
+
+    onAmountChange?.(fixedPointString, getErrorMessage(fixedPointString))
   }
 
   return (
-    <label className="label">
-      {label}
+    <>
+      <label
+        className="label"
+        htmlFor={
+          typeof selectedAsset === "undefined"
+            ? "asset_selector"
+            : "asset_amount_input"
+        }
+      >
+        {label}
+      </label>
+
+      {typeof selectedAsset !== "undefined" && hasAmounts(selectedAsset) ? (
+        <div className="amount_controls">
+          <span className="available">
+            Balance: {selectedAsset.localizedDecimalAmount}
+          </span>
+          {showMaxButton ? (
+            <button type="button" className="max" onClick={setMaxBalance}>
+              Max
+            </button>
+          ) : (
+            <></>
+          )}
+        </div>
+      ) : (
+        <></>
+      )}
+
       <SharedSlideUpMenu
         isOpen={openAssetMenu}
         close={() => {
           setOpenAssetMenu(false)
         }}
       >
-        {assets && (
+        {assetsAndAmounts && (
           <SelectAssetMenuContent
-            assets={assets}
+            assets={assetsAndAmounts}
             setSelectedAssetAndClose={setSelectedAssetAndClose}
           />
         )}
       </SharedSlideUpMenu>
       <div className="asset_wrap standard_width">
         <div>
-          {selectedAsset?.symbol ? (
+          {selectedAsset?.asset.symbol ? (
             <SelectedAssetButton
               isDisabled={isDisabled || disableDropdown}
-              asset={selectedAsset}
+              asset={selectedAsset.asset}
               toggleIsAssetMenuOpen={toggleIsAssetMenuOpen}
             />
           ) : (
             <SharedButton
+              id="asset_selector"
               type="secondary"
               size="medium"
               isDisabled={isDisabled || disableDropdown}
@@ -267,6 +350,7 @@ export default function SharedAssetInput<T extends AnyAsset>(
         </div>
 
         <input
+          id="asset_amount_input"
           className="input_amount"
           type="number"
           step="any"
@@ -276,7 +360,7 @@ export default function SharedAssetInput<T extends AnyAsset>(
           value={amount}
           spellCheck={false}
           onChange={(event) =>
-            onAmountChange(
+            onAmountChange?.(
               event.target.value,
               getErrorMessage(event.target.value)
             )
@@ -286,6 +370,25 @@ export default function SharedAssetInput<T extends AnyAsset>(
       </div>
       <style jsx>
         {`
+          label,
+          .amount_controls {
+            font-weight: 500;
+          }
+          .amount_controls {
+            line-height: 27px;
+            // align with label top + offset by border radius right
+            margin: -27px 4px 0 0;
+
+            color: var(--green-40);
+            text-align: right;
+            position: relative;
+            font-size: 14px;
+          }
+          .max {
+            margin-left: 8px; // space to balance
+            color: #d08e39;
+            cursor: pointer;
+          }
           .asset_wrap {
             height: 72px;
             border-radius: 4px;
@@ -307,22 +410,6 @@ export default function SharedAssetInput<T extends AnyAsset>(
           .asset_input::placeholder {
             color: var(--green-40);
             opacity: 1;
-          }
-          .paste_button {
-            height: 24px;
-            color: var(--trophy-gold);
-            font-size: 18px;
-            font-weight: 600;
-            line-height: 24px;
-            text-align: center;
-            display: flex;
-          }
-          .icon_paste {
-            background: url("./images/paste@2x.png");
-            background-size: 24px 24px;
-            width: 24px;
-            height: 24px;
-            margin-left: 8px;
           }
           .input_amount::placeholder {
             color: var(--green-40);
@@ -365,7 +452,7 @@ export default function SharedAssetInput<T extends AnyAsset>(
           }
         `}
       </style>
-    </label>
+    </>
   )
 }
 
@@ -373,14 +460,9 @@ SharedAssetInput.defaultProps = {
   isAssetOptionsLocked: false,
   disableDropdown: false,
   isDisabled: false,
-  assets: [{ symbol: "ETH", name: "Example Asset" }],
+  showMaxButton: true,
+  assetsAndAmounts: [],
   defaultAsset: { symbol: "", name: "" },
   label: "",
   amount: "0.0",
-  maxBalance: false,
-  onAssetSelect: () => {
-    // do nothing by default
-    // TODO replace this with support for undefined onClick
-  },
-  onAmountChange: () => {},
 }

--- a/ui/components/Shared/SharedButton.tsx
+++ b/ui/components/Shared/SharedButton.tsx
@@ -6,6 +6,7 @@ import SharedLoadingSpinner from "./SharedLoadingSpinner"
 
 interface Props {
   children: React.ReactNode
+  id?: string
   type:
     | "primary"
     | "secondary"
@@ -27,6 +28,7 @@ interface Props {
 
 export default function SharedButton(props: Props): ReactElement {
   const {
+    id,
     children,
     type,
     size,
@@ -68,6 +70,7 @@ export default function SharedButton(props: Props): ReactElement {
 
   return (
     <button
+      id={id}
       type={isFormSubmit ? "submit" : "button"}
       className={classNames(
         { large: size === "large" },

--- a/ui/pages/Send.tsx
+++ b/ui/pages/Send.tsx
@@ -51,6 +51,8 @@ export default function Send(): ReactElement {
     assetAmounts: [],
   }
 
+  // FIXME Rework this to use selectAssetPricePoint and
+  // FIXME convertAssetAmountViaPricePoint.
   const getTotalLocalizedValue = () => {
     const pricePerUnit = assetAmounts.find(
       (el) => el.asset.symbol === assetSymbol

--- a/ui/pages/Send.tsx
+++ b/ui/pages/Send.tsx
@@ -1,6 +1,5 @@
-import React, { ReactElement, useCallback, useEffect, useState } from "react"
+import React, { ReactElement, useEffect, useState } from "react"
 import { isAddress } from "@ethersproject/address"
-import { formatEther } from "@ethersproject/units"
 import {
   selectCurrentAccount,
   selectCurrentAccountBalances,
@@ -22,7 +21,6 @@ import { useBackgroundDispatch, useBackgroundSelector } from "../hooks"
 import { SignType } from "./SignTransaction"
 import SharedSlideUpMenu from "../components/Shared/SharedSlideUpMenu"
 import FeeSettingsButton from "../components/NetworkFees/FeeSettingsButton"
-import SharedInput from "../components/Shared/SharedInput"
 
 export default function Send(): ReactElement {
   const location = useLocation<{ symbol: string }>()
@@ -33,7 +31,6 @@ export default function Send(): ReactElement {
   const [selectedCount, setSelectedCount] = useState(0)
   const [destinationAddress, setDestinationAddress] = useState("")
   const [amount, setAmount] = useState("")
-  const [currentBalance, setCurrentBalance] = useState("")
   const [gasLimit, setGasLimit] = useState("")
   const [hasError, setHasError] = useState(false)
   const [networkSettingsModalOpen, setNetworkSettingsModalOpen] =
@@ -62,18 +59,7 @@ export default function Send(): ReactElement {
     }
     return 0
   }
-  const findBalance = useCallback(() => {
-    const balance = formatEther(
-      assetAmounts.find((el) => el.asset.symbol === assetSymbol)?.amount || "0"
-    )
-    setCurrentBalance(balance)
-  }, [assetAmounts, assetSymbol])
 
-  const setMaxBalance = () => {
-    if (currentBalance) {
-      setAmount(currentBalance)
-    }
-  }
   const sendTransactionRequest = async () => {
     dispatch(broadcastOnSign(true))
     const transaction = {
@@ -85,10 +71,6 @@ export default function Send(): ReactElement {
     }
     return dispatch(updateTransactionOptions(transaction))
   }
-
-  useEffect(() => {
-    findBalance()
-  }, [findBalance])
 
   useEffect(() => {
     if (assetSymbol) {
@@ -114,28 +96,12 @@ export default function Send(): ReactElement {
         </h1>
         <div className="form">
           <div className="form_input">
-            <div className="balance">
-              Balance: {`${currentBalance.substring(0, 8)}\u2026 `}
-              <button
-                type="button"
-                className="max"
-                onClick={setMaxBalance}
-                tabIndex={0}
-              >
-                Max
-              </button>
-            </div>
             <SharedAssetInput
               label="Asset / Amount"
               onAssetSelect={(token) => {
                 setAssetSymbol(token.symbol)
               }}
-              assets={assetAmounts.map((asset) => {
-                return {
-                  symbol: asset.asset.symbol,
-                  name: asset.asset.name,
-                }
-              })}
+              assetsAndAmounts={assetAmounts}
               onAmountChange={(value, errorMessage) => {
                 setAmount(value)
                 if (errorMessage) {
@@ -146,7 +112,6 @@ export default function Send(): ReactElement {
               }}
               defaultAsset={{ symbol: assetSymbol, name: assetSymbol }}
               amount={amount}
-              maxBalance={Number(currentBalance)}
               disableDropdown
             />
             <div className="value">${getTotalLocalizedValue()}</div>
@@ -249,18 +214,6 @@ export default function Send(): ReactElement {
           }
           .label {
             margin-bottom: 6px;
-          }
-          .balance {
-            color: var(--green-40);
-            text-align: right;
-            position: relative;
-            font-size: 14px;
-            top: 16px;
-            right: 0;
-          }
-          .max {
-            color: #d08e39;
-            cursor: pointer;
           }
           .value {
             display: flex;

--- a/ui/pages/Send.tsx
+++ b/ui/pages/Send.tsx
@@ -22,6 +22,7 @@ import { useBackgroundDispatch, useBackgroundSelector } from "../hooks"
 import { SignType } from "./SignTransaction"
 import SharedSlideUpMenu from "../components/Shared/SharedSlideUpMenu"
 import FeeSettingsButton from "../components/NetworkFees/FeeSettingsButton"
+import SharedInput from "../components/Shared/SharedInput"
 
 export default function Send(): ReactElement {
   const location = useLocation<{ symbol: string }>()
@@ -148,11 +149,14 @@ export default function Send(): ReactElement {
             />
             <div className="value">${getTotalLocalizedValue()}</div>
           </div>
-          <div className="form_input">
-            <SharedAssetInput
-              isTypeDestination
-              label="Send To:"
-              onSendToAddressChange={setDestinationAddress}
+          <div className="form_input send_to_field">
+            <label htmlFor="send_address">Send To:</label>
+            <input
+              id="send_address"
+              type="text"
+              placeholder="0x..."
+              spellCheck={false}
+              onChange={(event) => setDestinationAddress(event.target.value)}
             />
           </div>
           <SharedSlideUpMenu
@@ -265,6 +269,31 @@ export default function Send(): ReactElement {
             color: var(--green-60);
             font-size: 12px;
             line-height: 16px;
+          }
+          div.send_to_field {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            justify-content: space-between;
+          }
+          div.send_to_field label {
+            color: var(--green-40);
+            text-align: right;
+            font-size: 14px;
+          }
+          input#send_address {
+            box-sizing: border-box;
+            height: 72px;
+            width: 100%;
+
+            font-size: 22px;
+            font-weight: 500;
+            line-height: 72px;
+            color: #fff;
+
+            border-radius: 4px;
+            background-color: var(--green-95);
+            padding: 0px 16px;
           }
           .send_footer {
             display: flex;

--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -371,9 +371,11 @@ export default function Swap(): ReactElement {
                 disableDropdown={typeof locationAsset !== "undefined"}
                 isDisabled={sellAmountLoading}
                 onAssetSelect={updateSellAsset}
-                onAmountChange={(newAmount) => {
-                  setSellAmount(newAmount)
-                  updateSwapData("sell", newAmount)
+                onAmountChange={(newAmount, error) => {
+                  if (typeof error === "undefined") {
+                    setSellAmount(newAmount)
+                    updateSwapData("sell", newAmount)
+                  }
                 }}
                 label="Swap from:"
               />
@@ -390,9 +392,11 @@ export default function Swap(): ReactElement {
                 isDisabled={buyAmountLoading}
                 showMaxButton={false}
                 onAssetSelect={updateBuyAsset}
-                onAmountChange={(newAmount) => {
-                  setBuyAmount(newAmount)
-                  updateSwapData("buy", newAmount)
+                onAmountChange={(newAmount, error) => {
+                  if (typeof error === "undefined") {
+                    setBuyAmount(buyAmount)
+                    updateSwapData("buy", newAmount)
+                  }
                 }}
                 label="Swap to:"
               />

--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -366,11 +366,7 @@ export default function Swap(): ReactElement {
             <div className="form_input">
               <SharedAssetInput
                 amount={sellAmount}
-                assets={sellAssetAmounts.map(({ asset }) => asset)}
-                maxBalance={
-                  sellAssetAmounts.find(({ asset }) => asset === sellAsset)
-                    ?.decimalAmount
-                }
+                assetsAndAmounts={sellAssetAmounts}
                 defaultAsset={sellAsset}
                 disableDropdown={typeof locationAsset !== "undefined"}
                 isDisabled={sellAmountLoading}
@@ -388,9 +384,11 @@ export default function Swap(): ReactElement {
             <div className="form_input">
               <SharedAssetInput
                 amount={buyAmount}
-                assets={buyAssets}
+                // FIXME Merge master asset list with account balances.
+                assetsAndAmounts={buyAssets.map((asset) => ({ asset }))}
                 defaultAsset={buyAsset}
                 isDisabled={buyAmountLoading}
+                showMaxButton={false}
                 onAssetSelect={updateBuyAsset}
                 onAmountChange={(newAmount) => {
                   setBuyAmount(newAmount)


### PR DESCRIPTION
This PR is a bigger rework than I originally embarked on. It
implements balance info on the shared asset input, as well as
in the asset selector, and includes a max button that can be
disabled if desired (used in swaps for buy assets).

There were a couple of tangential changes included here:

- The fixed-point library's string handling is much more robust.
- `SharedAssetInput`'s “now for something completely different” option,
  `isTypeDestination`, is gone in favor of custom styling in the Send
  component.

The primary changes to `SharedAssetInput` are one big commit
(should really have been at least 2-3, but time ran out). Here's
the relevant commit message, which covers the details:

```
SharedAssetInput now takes an assetsAndAmounts prop, which is of a new
type, AnyAssetWithOptionalAmount (defined in SharedAssetItem for now).
This type can contain either an asset, or an asset with associated
amount and localized decimal information.

This then cascades into a few additional bits of functionality:

- SharedAssetItem now displays the associated amount in the dropdown if
  available.
- SharedAssetInput now displays the associated amount for the selected
  asset (if any) as a balance.
- SharedAssetInput now displays, by default, a "Max" button to set the
  input amount to the associated amount for the selected asset.

Additionally, the SharedAssetInput now parses the inputted amount using
fixed-point parsing and compares the fixed-point amount to the max
balance using fixed-point comparisons instead of potentially-lossy
JS number parsing.
```

----

Opening as a draft to decide between this approach and the one in #941.

If we stick with 941, I'll drop the big change commit so we can still
land the remaining tidbits in this PR.