### PR TITLE
Wire up Ledger UI and services

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -812,7 +812,11 @@ export default class Main extends BaseService<never> {
         )
 
         const resolveAndClear = (signedTransaction: SignedEVMTransaction) => {
-          this.keyringService.emitter.off("signedTx", resolveAndClear)
+          if (HIDE_IMPORT_LEDGER) {
+            this.keyringService.emitter.off("signedTx", resolveAndClear)
+          } else {
+            this.signingService.emitter.off("signedTx", resolveAndClear)
+          }
           transactionConstructionSliceEmitter.off(
             "signatureRejected",
             // Ye olde mutual dependency.
@@ -823,7 +827,11 @@ export default class Main extends BaseService<never> {
         }
 
         const rejectAndClear = () => {
-          this.keyringService.emitter.off("signedTx", resolveAndClear)
+          if (HIDE_IMPORT_LEDGER) {
+            this.keyringService.emitter.off("signedTx", resolveAndClear)
+          } else {
+            this.signingService.emitter.off("signedTx", resolveAndClear)
+          }
           transactionConstructionSliceEmitter.off(
             "signatureRejected",
             rejectAndClear
@@ -831,7 +839,11 @@ export default class Main extends BaseService<never> {
           rejecter()
         }
 
-        this.keyringService.emitter.on("signedTx", resolveAndClear)
+        if (HIDE_IMPORT_LEDGER) {
+          this.keyringService.emitter.on("signedTx", resolveAndClear)
+        } else {
+          this.signingService.emitter.on("signedTx", resolveAndClear)
+        }
         transactionConstructionSliceEmitter.on(
           "signatureRejected",
           rejectAndClear

--- a/background/main.ts
+++ b/background/main.ts
@@ -74,7 +74,10 @@ import {
   SignTypedDataRequest,
   typedDataRequest,
 } from "./redux-slices/signing"
-import { resetLedgerState } from "./redux-slices/ledger"
+import {
+  resetLedgerState,
+  setDeviceConnectionStatus,
+} from "./redux-slices/ledger"
 import { ETHEREUM } from "./constants"
 import { HIDE_IMPORT_LEDGER } from "./features/features"
 
@@ -720,6 +723,18 @@ export default class Main extends BaseService<never> {
 
   async connectLedgerService(): Promise<void> {
     this.store.dispatch(resetLedgerState())
+
+    this.ledgerService.emitter.on("connected", ({ id }) => {
+      this.store.dispatch(
+        setDeviceConnectionStatus({ deviceID: id, status: "available" })
+      )
+    })
+
+    this.ledgerService.emitter.on("disconnected", ({ id }) => {
+      this.store.dispatch(
+        setDeviceConnectionStatus({ deviceID: id, status: "disconnected" })
+      )
+    })
   }
 
   async connectKeyringService(): Promise<void> {

--- a/background/main.ts
+++ b/background/main.ts
@@ -585,9 +585,7 @@ export default class Main extends BaseService<never> {
 
     transactionConstructionSliceEmitter.on(
       "requestSignature",
-      async (
-        transaction: EIP1559TransactionRequest & { nonce: number | undefined }
-      ) => {
+      async ({ transaction, method }) => {
         if (HIDE_IMPORT_LEDGER) {
           const transactionWithNonce =
             await this.chainService.populateEVMTransactionNonce(transaction)
@@ -608,8 +606,8 @@ export default class Main extends BaseService<never> {
         } else {
           try {
             const signedTx = await this.signingService.signTransaction(
-              transaction.from,
-              transaction
+              transaction,
+              method
             )
             this.store.dispatch(signed(signedTx))
           } catch (exception) {

--- a/background/main.ts
+++ b/background/main.ts
@@ -74,7 +74,10 @@ import {
   SignTypedDataRequest,
   typedDataRequest,
 } from "./redux-slices/signing"
-import { emitter as ledgerSliceEmitter } from "./redux-slices/ledger"
+import {
+  emitter as ledgerSliceEmitter,
+  resetLedgerState,
+} from "./redux-slices/ledger"
 import { ETHEREUM } from "./constants"
 import { HIDE_IMPORT_LEDGER } from "./features/features"
 
@@ -685,6 +688,8 @@ export default class Main extends BaseService<never> {
   }
 
   async connectLedgerService(): Promise<void> {
+    this.store.dispatch(resetLedgerState())
+
     ledgerSliceEmitter.on("importLedgerAccounts", async (accounts) => {
       for (let i = 0; i < accounts.length; i += 1) {
         const { path, address } = accounts[i]

--- a/background/main.ts
+++ b/background/main.ts
@@ -528,8 +528,8 @@ export default class Main extends BaseService<never> {
     })
   }
 
-  async connectLedger(): Promise<string> {
-    return this.ledgerService.connectLedger()
+  async connectLedger(): Promise<string | null> {
+    return this.ledgerService.refreshConnectedLedger()
   }
 
   async connectChainService(): Promise<void> {

--- a/background/main.ts
+++ b/background/main.ts
@@ -80,6 +80,7 @@ import {
 } from "./redux-slices/ledger"
 import { ETHEREUM } from "./constants"
 import { HIDE_IMPORT_LEDGER } from "./features/features"
+import { SignatureResponse } from "./services/signing"
 
 // This sanitizer runs on store and action data before serializing for remote
 // redux devtools. The goal is to end up with an object that is directly
@@ -612,6 +613,7 @@ export default class Main extends BaseService<never> {
             this.store.dispatch(signed(signedTx))
           } catch (exception) {
             logger.error("Error signing transaction", exception)
+            this.store.dispatch(clearTransactionState())
           }
         }
       }
@@ -811,38 +813,48 @@ export default class Main extends BaseService<never> {
           2 /* TODO desiredDecimals should be configurable */
         )
 
-        const resolveAndClear = (signedTransaction: SignedEVMTransaction) => {
+        const clear = () => {
           if (HIDE_IMPORT_LEDGER) {
+            // Ye olde mutual dependency.
+            // eslint-disable-next-line @typescript-eslint/no-use-before-define
             this.keyringService.emitter.off("signedTx", resolveAndClear)
           } else {
-            this.signingService.emitter.off("signedTx", resolveAndClear)
+            // eslint-disable-next-line @typescript-eslint/no-use-before-define
+            this.signingService.emitter.off("signingResponse", handleAndClear)
           }
           transactionConstructionSliceEmitter.off(
             "signatureRejected",
-            // Ye olde mutual dependency.
             // eslint-disable-next-line @typescript-eslint/no-use-before-define
             rejectAndClear
           )
+        }
+
+        const handleAndClear = (response: SignatureResponse) => {
+          clear()
+          switch (response.type) {
+            case "success":
+              resolver(response.signedTx)
+              break
+            default:
+              rejecter()
+              break
+          }
+        }
+
+        const resolveAndClear = (signedTransaction: SignedEVMTransaction) => {
+          clear()
           resolver(signedTransaction)
         }
 
         const rejectAndClear = () => {
-          if (HIDE_IMPORT_LEDGER) {
-            this.keyringService.emitter.off("signedTx", resolveAndClear)
-          } else {
-            this.signingService.emitter.off("signedTx", resolveAndClear)
-          }
-          transactionConstructionSliceEmitter.off(
-            "signatureRejected",
-            rejectAndClear
-          )
+          clear()
           rejecter()
         }
 
         if (HIDE_IMPORT_LEDGER) {
           this.keyringService.emitter.on("signedTx", resolveAndClear)
         } else {
-          this.signingService.emitter.on("signedTx", resolveAndClear)
+          this.signingService.emitter.on("signingResponse", handleAndClear)
         }
         transactionConstructionSliceEmitter.on(
           "signatureRejected",

--- a/background/main.ts
+++ b/background/main.ts
@@ -66,7 +66,6 @@ import {
   emitter as providerBridgeSliceEmitter,
   initializeAllowedPages,
 } from "./redux-slices/dapp-permission"
-import { EnrichedEIP1559TransactionRequest } from "./services/enrichment"
 import logger from "./lib/logger"
 import {
   signedTypedData,

--- a/background/redux-slices/ledger.ts
+++ b/background/redux-slices/ledger.ts
@@ -74,7 +74,7 @@ const ledgerSlice = createSlice({
       immerState.devices[deviceID] = {
         id: deviceID,
         accounts: {},
-        status: "disconnected",
+        status: "available",
       }
     },
     setCurrentDevice: (

--- a/background/redux-slices/ledger.ts
+++ b/background/redux-slices/ledger.ts
@@ -56,6 +56,15 @@ const ledgerSlice = createSlice({
   name: "ledger",
   initialState,
   reducers: {
+    resetLedgerState: (immerState) => {
+      Object.values(immerState.devices).forEach((device) => {
+        device.status = "disconnected" // eslint-disable-line no-param-reassign
+        Object.values(device.accounts).forEach((account) => {
+          account.fetchingAddress = false // eslint-disable-line no-param-reassign
+          account.fetchingBalance = false // eslint-disable-line no-param-reassign
+        })
+      })
+    },
     addLedgerDevice: (
       immerState,
       { payload: deviceID }: { payload: string }
@@ -140,7 +149,7 @@ const ledgerSlice = createSlice({
   },
 })
 
-export const { addLedgerAccount } = ledgerSlice.actions
+export const { resetLedgerState, addLedgerAccount } = ledgerSlice.actions
 
 export default ledgerSlice.reducer
 

--- a/background/redux-slices/ledger.ts
+++ b/background/redux-slices/ledger.ts
@@ -186,9 +186,12 @@ export const connectLedger = createBackgroundAsyncThunk(
   "ledger/connectLedger",
   async (unused, { dispatch, extra: { main } }) => {
     const deviceID = await main.connectLedger()
+    if (!deviceID) {
+      return
+    }
+
     dispatch(ledgerSlice.actions.addLedgerDevice(deviceID))
     dispatch(ledgerSlice.actions.setCurrentDevice(deviceID))
-    return { deviceID }
   }
 )
 

--- a/background/redux-slices/ledger.ts
+++ b/background/redux-slices/ledger.ts
@@ -20,6 +20,7 @@ export interface LedgerDeviceState {
 }
 
 export type LedgerState = {
+  currentDeviceID: string | null
   /** Devices by ID */
   devices: Record<string, LedgerDeviceState>
 }
@@ -46,6 +47,7 @@ export type Events = {
 }
 
 export const initialState: LedgerState = {
+  currentDeviceID: null,
   devices: {},
 }
 
@@ -54,6 +56,7 @@ const ledgerSlice = createSlice({
   initialState,
   reducers: {
     resetLedgerState: (immerState) => {
+      immerState.currentDeviceID = null
       Object.values(immerState.devices).forEach((device) => {
         device.status = "disconnected" // eslint-disable-line no-param-reassign
         Object.values(device.accounts).forEach((account) => {
@@ -73,6 +76,13 @@ const ledgerSlice = createSlice({
         accounts: {},
         status: "disconnected",
       }
+    },
+    setCurrentDevice: (
+      immerState,
+      { payload: deviceID }: { payload: string }
+    ) => {
+      if (!(deviceID in immerState.devices)) return
+      immerState.currentDeviceID = deviceID
     },
     addLedgerAccount: (
       immerState,
@@ -166,6 +176,7 @@ export const connectLedger = createBackgroundAsyncThunk(
   async (unused, { dispatch, extra: { main } }) => {
     const deviceID = await main.connectLedger()
     dispatch(ledgerSlice.actions.addLedgerDevice(deviceID))
+    dispatch(ledgerSlice.actions.setCurrentDevice(deviceID))
     return { deviceID }
   }
 )

--- a/background/redux-slices/ledger.ts
+++ b/background/redux-slices/ledger.ts
@@ -84,6 +84,16 @@ const ledgerSlice = createSlice({
       if (!(deviceID in immerState.devices)) return
       immerState.currentDeviceID = deviceID
     },
+    setDeviceConnectionStatus: (
+      immerState,
+      {
+        payload: { deviceID, status },
+      }: { payload: { deviceID: string; status: LedgerConnectionStatus } }
+    ) => {
+      const device = immerState.devices[deviceID]
+      if (!device) return
+      device.status = status
+    },
     addLedgerAccount: (
       immerState,
       {
@@ -156,7 +166,8 @@ const ledgerSlice = createSlice({
   },
 })
 
-export const { resetLedgerState, addLedgerAccount } = ledgerSlice.actions
+export const { resetLedgerState, setDeviceConnectionStatus, addLedgerAccount } =
+  ledgerSlice.actions
 
 export default ledgerSlice.reducer
 

--- a/background/redux-slices/selectors/ledgerSelectors.ts
+++ b/background/redux-slices/selectors/ledgerSelectors.ts
@@ -5,9 +5,13 @@ import { SigningMethod } from "../signing"
 // For consistency with similar modules:
 // eslint-disable-next-line import/prefer-default-export
 export const selectLedgerSigningMethodEntries = createSelector(
-  (state: RootState) => state.ledger.devices,
-  (devices) =>
-    Object.values(devices).flatMap((device) =>
+  (state: RootState) => state.ledger,
+  (ledgerSlice) => {
+    if (typeof ledgerSlice === "undefined") {
+      return []
+    }
+
+    return Object.values(ledgerSlice.devices).flatMap((device) =>
       Object.values(device.accounts).flatMap(
         (account): Array<[string, SigningMethod]> => {
           if (account.address === null) return []
@@ -20,4 +24,5 @@ export const selectLedgerSigningMethodEntries = createSelector(
         }
       )
     )
+  }
 )

--- a/background/redux-slices/selectors/ledgerSelectors.ts
+++ b/background/redux-slices/selectors/ledgerSelectors.ts
@@ -1,0 +1,23 @@
+import { createSelector } from "@reduxjs/toolkit"
+import { RootState } from ".."
+import { SigningMethod } from "../signing"
+
+// For consistency with similar modules:
+// eslint-disable-next-line import/prefer-default-export
+export const selectLedgerSigningMethodEntries = createSelector(
+  (state: RootState) => state.ledger.devices,
+  (devices) =>
+    Object.values(devices).flatMap((device) =>
+      Object.values(device.accounts).flatMap(
+        (account): Array<[string, SigningMethod]> => {
+          if (account.address === null) return []
+          return [
+            [
+              account.address,
+              { type: "ledger", deviceID: device.id, path: account.path },
+            ],
+          ]
+        }
+      )
+    )
+)

--- a/background/redux-slices/selectors/signingSelectors.ts
+++ b/background/redux-slices/selectors/signingSelectors.ts
@@ -2,14 +2,22 @@ import { createSelector } from "@reduxjs/toolkit"
 import { RootState } from ".."
 import { SigningMethod } from "../signing"
 import { selectKeyringSigningAddresses } from "./keyringsSelectors"
+import { selectLedgerSigningMethodEntries } from "./ledgerSelectors"
 import { selectCurrentAccount } from "./uiSelectors"
 
 export const selectAddressSigningMethods = createSelector(
   selectKeyringSigningAddresses,
-  (signingAddresses) =>
-    Object.fromEntries(
-      signingAddresses.map((address) => [address, { type: "keyring" }])
-    ) as Record<string, SigningMethod | undefined>
+  selectLedgerSigningMethodEntries,
+  (signingAddresses, ledgerSigningMethodEntries) =>
+    Object.fromEntries([
+      ...ledgerSigningMethodEntries,
+      // Give priority to keyring over Ledger, if an address is signable by both.
+      // TODO: check this is the intended behavior
+      ...signingAddresses.map((address): [string, SigningMethod] => [
+        address,
+        { type: "keyring" },
+      ]),
+    ])
 )
 
 export const selectCurrentAccountSigningMethod = createSelector(

--- a/background/redux-slices/transaction-construction.ts
+++ b/background/redux-slices/transaction-construction.ts
@@ -237,7 +237,6 @@ export const {
   signed,
   setFeeType,
   estimatedFeesPerGas,
-  clearTransactionState,
 } = transactionSlice.actions
 
 export default transactionSlice.reducer

--- a/background/redux-slices/transaction-construction.ts
+++ b/background/redux-slices/transaction-construction.ts
@@ -17,6 +17,7 @@ import {
   EnrichedEIP1559TransactionRequest,
   EnrichedEVMTransactionSignatureRequest,
 } from "../services/enrichment"
+import { SigningMethod } from "./signing"
 
 import { createBackgroundAsyncThunk } from "./utils"
 
@@ -70,9 +71,14 @@ export const initialState: TransactionConstruction = {
   lastGasEstimatesRefreshed: Date.now(),
 }
 
+export interface SignatureRequest {
+  transaction: EIP1559TransactionRequest
+  method: SigningMethod
+}
+
 export type Events = {
   updateOptions: EnrichedEVMTransactionSignatureRequest
-  requestSignature: EIP1559TransactionRequest
+  requestSignature: SignatureRequest
   signatureRejected: never
   broadcastSignedTransaction: SignedEVMTransaction
 }
@@ -89,8 +95,8 @@ export const updateTransactionOptions = createBackgroundAsyncThunk(
 
 export const signTransaction = createBackgroundAsyncThunk(
   "transaction-construction/sign",
-  async (transaction: EIP1559TransactionRequest) => {
-    await emitter.emit("requestSignature", transaction)
+  async (request: SignatureRequest) => {
+    await emitter.emit("requestSignature", request)
   }
 )
 

--- a/background/redux-slices/transaction-construction.ts
+++ b/background/redux-slices/transaction-construction.ts
@@ -21,7 +21,7 @@ import { SigningMethod } from "./signing"
 
 import { createBackgroundAsyncThunk } from "./utils"
 
-const enum TransactionConstructionStatus {
+export const enum TransactionConstructionStatus {
   Idle = "idle",
   Pending = "pending",
   Loaded = "loaded",
@@ -237,6 +237,7 @@ export const {
   signed,
   setFeeType,
   estimatedFeesPerGas,
+  clearTransactionState,
 } = transactionSlice.actions
 
 export default transactionSlice.reducer

--- a/background/services/keyring/index.ts
+++ b/background/services/keyring/index.ts
@@ -16,6 +16,7 @@ import { EIP1559TransactionRequest, SignedEVMTransaction } from "../../networks"
 import BaseService from "../base"
 import { ETH, MINUTE } from "../../constants"
 import { ethersTransactionRequestFromEIP1559TransactionRequest } from "../chain/utils"
+import { HIDE_IMPORT_LEDGER } from "../../features/features"
 
 export const MAX_KEYRING_IDLE_TIME = 60 * MINUTE
 export const MAX_OUTSIDE_IDLE_TIME = 60 * MINUTE
@@ -404,7 +405,9 @@ export default class KeyringService extends BaseService<Events> {
       asset: ETH,
       network: getEthereumNetwork(),
     }
-    this.emitter.emit("signedTx", signedTx)
+    if (HIDE_IMPORT_LEDGER) {
+      this.emitter.emit("signedTx", signedTx)
+    }
     return signedTx
   }
   /**

--- a/background/services/ledger/index.ts
+++ b/background/services/ledger/index.ts
@@ -253,9 +253,8 @@ export default class LedgerService extends BaseService<Events> {
           this.#currentLedgerId
         } accountID: ${accountID} error: ${err}`
       )
+      throw err
     }
-
-    throw new Error("Address derivation is unsuccessful!")
   }
 
   async saveAddress(path: HexString, address: string): Promise<void> {
@@ -362,71 +361,59 @@ export default class LedgerService extends BaseService<Events> {
           this.#currentLedgerId
         } transactionRequest: ${transactionRequest} error: ${err}`
       )
-    }
 
-    throw new Error("Transaction signing is unsuccessful!")
+      throw err
+    }
   }
 
   async signTypedData(
     typedData: EIP712TypedData,
     account: HexString
   ): Promise<string> {
-    try {
-      if (!this.transport) {
-        throw new Error("Uninitialized transport!")
-      }
-
-      if (!this.#currentLedgerId) {
-        throw new Error("Uninitialized Ledger ID!")
-      }
-
-      const eth = new Eth(this.transport)
-      const hashedDomain = TypedDataUtils.hashStruct(
-        "EIP712Domain",
-        typedData.domain,
-        typedData.types,
-        true
-      )
-      const hashedMessage = TypedDataUtils.hashStruct(
-        typedData.primaryType,
-        typedData.message,
-        typedData.types,
-        true
-      )
-
-      const signature = await eth.signEIP712HashedMessage(
-        account,
-        bufferToHex(hashedDomain),
-        bufferToHex(hashedMessage)
-      )
-      this.emitter.emit("signedData", signatureToString(signature))
-      return signatureToString(signature)
-    } catch (error) {
-      throw new Error("Signing data failed")
+    if (!this.transport) {
+      throw new Error("Uninitialized transport!")
     }
 
-    throw new Error("Typed data signing is unsuccessful!")
+    if (!this.#currentLedgerId) {
+      throw new Error("Uninitialized Ledger ID!")
+    }
+
+    const eth = new Eth(this.transport)
+    const hashedDomain = TypedDataUtils.hashStruct(
+      "EIP712Domain",
+      typedData.domain,
+      typedData.types,
+      true
+    )
+    const hashedMessage = TypedDataUtils.hashStruct(
+      typedData.primaryType,
+      typedData.message,
+      typedData.types,
+      true
+    )
+
+    const signature = await eth.signEIP712HashedMessage(
+      account,
+      bufferToHex(hashedDomain),
+      bufferToHex(hashedMessage)
+    )
+    this.emitter.emit("signedData", signatureToString(signature))
+    return signatureToString(signature)
   }
 
   async signMessage(address: string, message: string): Promise<string> {
-    try {
-      if (!this.transport) {
-        throw new Error("Uninitialized transport!")
-      }
-
-      if (!this.#currentLedgerId) {
-        throw new Error("Uninitialized Ledger ID!")
-      }
-
-      const eth = new Eth(this.transport)
-
-      const signature = await eth.signPersonalMessage(address, message)
-      this.emitter.emit("signedData", signatureToString(signature))
-      return signatureToString(signature)
-    } catch (error) {
-      throw new Error("Signing data failed")
+    if (!this.transport) {
+      throw new Error("Uninitialized transport!")
     }
 
-    throw new Error("Typed data signing is unsuccessful!")
+    if (!this.#currentLedgerId) {
+      throw new Error("Uninitialized Ledger ID!")
+    }
+
+    const eth = new Eth(this.transport)
+
+    const signature = await eth.signPersonalMessage(address, message)
+    this.emitter.emit("signedData", signatureToString(signature))
+    return signatureToString(signature)
   }
 }

--- a/background/services/ledger/index.ts
+++ b/background/services/ledger/index.ts
@@ -300,16 +300,11 @@ export default class LedgerService extends BaseService<Events> {
       const eth = new Eth(this.transport)
       const signature = await eth.signTransaction(path, serializedTx, null)
 
-      const alteredSig = {
-        r: signature.r,
-        s: signature.s,
+      const signedTransaction = serialize(ethersTx as UnsignedTransaction, {
+        r: `0x${signature.r}`,
+        s: `0x${signature.s}`,
         v: parseInt(signature.v, 16),
-      }
-
-      const signedTransaction = serialize(
-        ethersTx as UnsignedTransaction,
-        alteredSig
-      )
+      })
       const tx = parseRawTransaction(signedTransaction)
 
       if (

--- a/background/services/ledger/index.ts
+++ b/background/services/ledger/index.ts
@@ -212,7 +212,7 @@ export default class LedgerService extends BaseService<Events> {
       throw new Error("No paired device when the Ledger is connected!?")
     }
 
-    this.onConnection(devArray[0].productId)
+    await this.onConnection(devArray[0].productId)
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return this.#currentLedgerId!

--- a/background/services/ledger/index.ts
+++ b/background/services/ledger/index.ts
@@ -170,7 +170,7 @@ export default class LedgerService extends BaseService<Events> {
     }
   }
 
-  async #onUSBConnect(event: USBConnectionEvent): Promise<void> {
+  #handleUSBConnect = async (event: USBConnectionEvent): Promise<void> => {
     if (!TestedProductId(event.device.productId)) {
       return
     }
@@ -178,7 +178,7 @@ export default class LedgerService extends BaseService<Events> {
     this.onConnection(event.device.productId)
   }
 
-  async #onUSBDisconnect(event: USBConnectionEvent): Promise<void> {
+  #handleUSBDisconnect = async (event: USBConnectionEvent): Promise<void> => {
     if (!this.#currentLedgerId) {
       return
     }
@@ -194,15 +194,15 @@ export default class LedgerService extends BaseService<Events> {
   protected async internalStartService(): Promise<void> {
     await super.internalStartService() // Not needed, but better to stick to the patterns
 
-    navigator.usb.addEventListener("connect", this.#onUSBConnect)
-    navigator.usb.addEventListener("disconnect", this.#onUSBDisconnect)
+    navigator.usb.addEventListener("connect", this.#handleUSBConnect)
+    navigator.usb.addEventListener("disconnect", this.#handleUSBDisconnect)
   }
 
   protected async internalStopService(): Promise<void> {
     await super.internalStartService() // Not needed, but better to stick to the patterns
 
-    navigator.usb.removeEventListener("disconnect", this.#onUSBDisconnect)
-    navigator.usb.removeEventListener("connect", this.#onUSBConnect)
+    navigator.usb.removeEventListener("disconnect", this.#handleUSBDisconnect)
+    navigator.usb.removeEventListener("connect", this.#handleUSBConnect)
   }
 
   async connectLedger(): Promise<string> {

--- a/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
+++ b/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
@@ -8,6 +8,7 @@ import {
 import { useHistory } from "react-router-dom"
 import { ETHEREUM } from "@tallyho/tally-background/constants/networks"
 import { AccountType } from "@tallyho/tally-background/redux-slices/accounts"
+import { HIDE_IMPORT_LEDGER } from "@tallyho/tally-background/features/features"
 import SharedPanelAccountItem from "../Shared/SharedPanelAccountItem"
 import SharedButton from "../Shared/SharedButton"
 import {
@@ -166,57 +167,62 @@ export default function AccountsNotificationPanelAccounts({
     }
   }, [onCurrentAddressChange, pendingSelectedAddress, selectedAccountAddress])
 
+  const accountTypes = [AccountType.Imported, AccountType.ReadOnly]
+
+  if (!HIDE_IMPORT_LEDGER) {
+    accountTypes.push(AccountType.Ledger)
+  }
+
+  const accountSwitcher = accountTypes
+    .filter((type) => (accountTotals[type]?.length ?? 0) > 0)
+    .map((accountType) => {
+      // Known-non-null due to above filter.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const accountTypeTotals = accountTotals[accountType]!
+
+      return (
+        <section key={accountType}>
+          <WalletTypeHeader
+            accountType={accountType}
+            onClickAddAddress={
+              accountType === "imported"
+                ? () => {
+                    if (firstKeyringId) {
+                      dispatch(deriveAddress(firstKeyringId))
+                    }
+                  }
+                : undefined
+            }
+          />
+          <ul>
+            {accountTypeTotals.map((accountTotal) => {
+              const lowerCaseAddress = accountTotal.address.toLocaleLowerCase()
+              return (
+                <li key={lowerCaseAddress}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      updateCurrentAccount(lowerCaseAddress)
+                    }}
+                  >
+                    <SharedPanelAccountItem
+                      key={lowerCaseAddress}
+                      accountTotal={accountTotal}
+                      isSelected={lowerCaseAddress === selectedAccountAddress}
+                      hideMenu
+                    />
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        </section>
+      )
+    })
+
   return (
     <div className="switcher_wrap">
-      {[AccountType.Imported, AccountType.ReadOnly]
-        .filter((type) => (accountTotals[type]?.length ?? 0) > 0)
-        .map((accountType) => {
-          // Known-non-null due to above filter.
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          const accountTypeTotals = accountTotals[accountType]!
-
-          return (
-            <section key={accountType}>
-              <WalletTypeHeader
-                accountType={accountType}
-                onClickAddAddress={
-                  accountType === "imported"
-                    ? () => {
-                        if (firstKeyringId) {
-                          dispatch(deriveAddress(firstKeyringId))
-                        }
-                      }
-                    : undefined
-                }
-              />
-              <ul>
-                {accountTypeTotals.map((accountTotal) => {
-                  const lowerCaseAddress =
-                    accountTotal.address.toLocaleLowerCase()
-                  return (
-                    <li key={lowerCaseAddress}>
-                      <button
-                        type="button"
-                        onClick={() => {
-                          updateCurrentAccount(lowerCaseAddress)
-                        }}
-                      >
-                        <SharedPanelAccountItem
-                          key={lowerCaseAddress}
-                          accountTotal={accountTotal}
-                          isSelected={
-                            lowerCaseAddress === selectedAccountAddress
-                          }
-                          hideMenu
-                        />
-                      </button>
-                    </li>
-                  )
-                })}
-              </ul>
-            </section>
-          )
-        })}
+      {accountSwitcher}
       <footer>
         <SharedButton
           type="tertiary"

--- a/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
+++ b/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
@@ -173,56 +173,57 @@ export default function AccountsNotificationPanelAccounts({
     accountTypes.push(AccountType.Ledger)
   }
 
-  const accountSwitcher = accountTypes
-    .filter((type) => (accountTotals[type]?.length ?? 0) > 0)
-    .map((accountType) => {
-      // Known-non-null due to above filter.
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const accountTypeTotals = accountTotals[accountType]!
-
-      return (
-        <section key={accountType}>
-          <WalletTypeHeader
-            accountType={accountType}
-            onClickAddAddress={
-              accountType === "imported"
-                ? () => {
-                    if (firstKeyringId) {
-                      dispatch(deriveAddress(firstKeyringId))
-                    }
-                  }
-                : undefined
-            }
-          />
-          <ul>
-            {accountTypeTotals.map((accountTotal) => {
-              const lowerCaseAddress = accountTotal.address.toLocaleLowerCase()
-              return (
-                <li key={lowerCaseAddress}>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      updateCurrentAccount(lowerCaseAddress)
-                    }}
-                  >
-                    <SharedPanelAccountItem
-                      key={lowerCaseAddress}
-                      accountTotal={accountTotal}
-                      isSelected={lowerCaseAddress === selectedAccountAddress}
-                      hideMenu
-                    />
-                  </button>
-                </li>
-              )
-            })}
-          </ul>
-        </section>
-      )
-    })
-
   return (
     <div className="switcher_wrap">
-      {accountSwitcher}
+      {accountTypes
+        .filter((type) => (accountTotals[type]?.length ?? 0) > 0)
+        .map((accountType) => {
+          // Known-non-null due to above filter.
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          const accountTypeTotals = accountTotals[accountType]!
+
+          return (
+            <section key={accountType}>
+              <WalletTypeHeader
+                accountType={accountType}
+                onClickAddAddress={
+                  accountType === "imported"
+                    ? () => {
+                        if (firstKeyringId) {
+                          dispatch(deriveAddress(firstKeyringId))
+                        }
+                      }
+                    : undefined
+                }
+              />
+              <ul>
+                {accountTypeTotals.map((accountTotal) => {
+                  const lowerCaseAddress =
+                    accountTotal.address.toLocaleLowerCase()
+                  return (
+                    <li key={lowerCaseAddress}>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          updateCurrentAccount(lowerCaseAddress)
+                        }}
+                      >
+                        <SharedPanelAccountItem
+                          key={lowerCaseAddress}
+                          accountTotal={accountTotal}
+                          isSelected={
+                            lowerCaseAddress === selectedAccountAddress
+                          }
+                          hideMenu
+                        />
+                      </button>
+                    </li>
+                  )
+                })}
+              </ul>
+            </section>
+          )
+        })}
       <footer>
         <SharedButton
           type="tertiary"

--- a/ui/components/Shared/SharedSelect.tsx
+++ b/ui/components/Shared/SharedSelect.tsx
@@ -59,11 +59,12 @@ export default function SharedSelect(props: Props): ReactElement {
     [initialOptions]
   )
 
-  const currentLabel = activeIndex ? options[activeIndex].label : placeholder
-  const currentValue =
+  const currentOption =
     activeIndex !== null && activeIndex !== undefined
-      ? options[activeIndex].value
+      ? options[activeIndex]
       : null
+  const currentLabel = currentOption?.label ?? null
+  const currentValue = currentOption?.value ?? null
 
   useEffect(() => {
     if (currentValue) onChange(currentValue)

--- a/ui/components/Shared/SharedSelect.tsx
+++ b/ui/components/Shared/SharedSelect.tsx
@@ -60,7 +60,10 @@ export default function SharedSelect(props: Props): ReactElement {
   )
 
   const currentLabel = activeIndex ? options[activeIndex].label : placeholder
-  const currentValue = activeIndex ? options[activeIndex].value : null
+  const currentValue =
+    activeIndex !== null && activeIndex !== undefined
+      ? options[activeIndex].value
+      : null
 
   useEffect(() => {
     if (currentValue) onChange(currentValue)

--- a/ui/pages/Ledger/LedgerImportAccounts.tsx
+++ b/ui/pages/Ledger/LedgerImportAccounts.tsx
@@ -9,9 +9,9 @@ import classNames from "classnames"
 import React, { ReactElement, useEffect, useState } from "react"
 import { useBackgroundDispatch } from "../../hooks"
 import SharedButton from "../../components/Shared/SharedButton"
-import SharedSelect from "../../components/Shared/SharedSelect"
 import LedgerContinueButton from "../../components/Ledger/LedgerContinueButton"
 import LedgerPanelContainer from "../../components/Ledger/LedgerPanelContainer"
+import OnboardingDerivationPathSelectAlt from "../../components/Onboarding/OnboardingDerivationPathSelect"
 
 const addressesPerPage = 6
 
@@ -347,12 +347,7 @@ export default function LedgerImportAccounts({
         subHeading="You can select as many as you want"
       >
         <div className="derivation_path">
-          <SharedSelect
-            options={[
-              { label: `m'/44'/60'/0'`, value: `m'/44'/60'/0'` },
-              { label: `m'/44'/60'`, value: `m'/44'/60'` },
-            ]}
-            placeholder="Select derivation path"
+          <OnboardingDerivationPathSelectAlt
             onChange={(value) => {
               setParentPath(value)
             }}

--- a/ui/pages/SignTransaction.tsx
+++ b/ui/pages/SignTransaction.tsx
@@ -93,9 +93,11 @@ export default function SignTransaction({
     return <></>
   }
 
+  const signingMethod = signerAccountTotal?.signingMethod ?? null
   if (
     typeof transactionDetails === "undefined" ||
-    typeof signerAccountTotal === "undefined"
+    typeof signerAccountTotal === "undefined" ||
+    signingMethod === null
   ) {
     // TODO Some sort of unexpected state error if we end up here... Or do we
     // go back in history? That won't work for dApp popovers though.
@@ -108,7 +110,12 @@ export default function SignTransaction({
   }
   const handleConfirm = async () => {
     if (isTransactionDataReady && transactionDetails) {
-      dispatch(signTransaction(transactionDetails))
+      dispatch(
+        signTransaction({
+          transaction: transactionDetails,
+          method: signingMethod,
+        })
+      )
       setIsTransactionSigning(true)
     }
   }


### PR DESCRIPTION
Closes #841 

# Goals

* Handle the import+sign happy cases for the users who can read and follow the instructions on screen ie. unlock and have Ethereum app active, when interacting with the extension
  * Onboarding of Ledger generated addresses with preprogrammed or custom derivation paths
  * Checking Ledger-handled account balances and their history
  * Sending _spice_ (ETH) from Ledger addresses
  * Selecting between all kind of accounts
* Put every Ledger-related thing behind feature flag
  * Ledger onboarding (Add wallet -> Connect to a Ledger)
  * Already imported Ledger accounts in the account selector

# Known bugs
* On import the lists of the available addresses shows fake balance (on import it is populated and refreshed correctly)
* When the extension is reran with disabled Ledger support but the last active account was a Ledger one, it remains active and its behaviour is undefined (supposed workaround: select a keyring-based one)
* Restrict derivation paths available in the dropdrown on import

# Testing
## TC1
### Action to do
- start a transaction on a keyring address and sign it
### Expected outcome
- transaction is sent to the chain
- you see transaction history screen
- you can use the extension

## TC2
### Action to do
- start a transaction on a keyring address and reject it
### Expected outcome
- you are thrown back to the page where you can initiate another send

## TC3
### Action to do
- import accounts (if you don't have at least two imported)
- change between accounts
### Expected outcome
- you can see the selected account's balance correctly
- you can initiate transactions

Only non-Ledger stuff could be tested on this branch. Ledger testing instructions will be provided on the QA branch with enabled feature flag.
So pick one easy thing, that you developed/liked the most, and feel free to share the feedback! :)