### PR TITLE
Show real ETH balances when importing from Ledger

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -547,6 +547,12 @@ export default class Main extends BaseService<never> {
     return this.ledgerService.refreshConnectedLedger()
   }
 
+  async getAccountEthBalanceUncached(address: string): Promise<bigint> {
+    const amountBigNumber =
+      await this.chainService.pollingProviders.ethereum.getBalance(address)
+    return amountBigNumber.toBigInt()
+  }
+
   async connectChainService(): Promise<void> {
     // Wire up chain service to account slice.
     this.chainService.emitter.on("accountBalance", (accountWithBalance) => {


### PR DESCRIPTION
Replace fake ETH balances with real balance, when importing accounts from a Ledger.

**Implementation.** Keeps existing Redux slice and thunk. A method `getAccountEthBalanceUncached` is added to the `main` service, which, in turn, invokes `chainService.pollingProviders.ethereum.getBalance`. The thunk is changed to use this new method instead of the fake one, and the fake one is removed.

![Screenshot from 2022-02-09 11-16-28](https://user-images.githubusercontent.com/4115717/153583306-051319af-136a-412d-8ad6-c15c1916f9dc.png)