### PR TITLE
MiG-21: Handle migrations of assets and pending transactions

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -98,7 +98,7 @@ const devToolsSanitizer = (input: unknown) => {
 
 // The version of persisted Redux state the extension is expecting. Any previous
 // state without this version, or with a lower version, ought to be migrated.
-const REDUX_STATE_VERSION = 2
+const REDUX_STATE_VERSION = 3
 
 type Migration = (prevState: Record<string, unknown>) => Record<string, unknown>
 
@@ -127,6 +127,15 @@ const REDUX_MIGRATIONS: { [version: number]: Migration } = {
       ?.addressNetwork
     delete (newState as OldState)?.ui?.currentAccount
     newState.selectedAccount = addressNetwork as BroadAddressNetwork
+    return newState
+  },
+  3: (prevState: Record<string, unknown>) => {
+    const { assets, ...newState } = prevState
+
+    // Clear assets collection; these should be immediately repopulated by the
+    // IndexingService in startService.
+    newState.assets = []
+
     return newState
   },
 }

--- a/background/networks.ts
+++ b/background/networks.ts
@@ -18,6 +18,7 @@ type NetworkBaseAsset = {
  * Represents a cryptocurrency network; these can potentially be L1 or L2.
  */
 export type Network = {
+  // Considered a primary key; two Networks should never share a name.
   name: string
   baseAsset: NetworkBaseAsset
   family: NetworkFamily

--- a/background/services/chain/db.ts
+++ b/background/services/chain/db.ts
@@ -140,6 +140,23 @@ export class ChainDatabase extends Dexie {
     )
   }
 
+  /**
+   * Looks up and returns all pending transactions for the given network.
+   */
+  async getNetworkPendingTransactions(
+    network: Network
+  ): Promise<(AnyEVMTransaction & { firstSeen: UNIXTime })[]> {
+    return this.chainTransactions
+      .where("network.name")
+      .equals(network.name)
+      .filter(
+        (transaction) =>
+          !("status" in transaction) &&
+          (transaction.blockHash === null || transaction.blockHeight === null)
+      )
+      .toArray()
+  }
+
   async getBlock(
     network: Network,
     blockHash: string


### PR DESCRIPTION
> [The **Mikoyan-Gurevich MiG-21** (Russian: Микоян и Гуревич МиГ-21; NATO reporting name: **Fishbed**) is a supersonic jet fighter and interceptor aircraft, designed by the Mikoyan-Gurevich Design Bureau in the Soviet Union. Its nicknames include: "balalaika", because its planform resembles the stringed musical instrument of the same name; "Ołówek", Polish for "pencil", due to the shape of its fuselage,[2] and "Én Bạc", meaning "silver swallow", in Vietnamese.](https://en.wikipedia.org/wiki/Mikoyan-Gurevich_MiG-21)
>
> [Approximately 60 countries on four continents have flown the MiG-21, and it still serves many nations six decades after its maiden flight. It made aviation records, becoming the most-produced supersonic jet aircraft in aviation history, the most-produced combat aircraft since the Korean War and previously the longest production run of a combat aircraft (now exceeded by both the McDonnell Douglas F-15 Eagle and General Dynamics F-16 Fighting Falcon).](https://en.wikipedia.org/wiki/Mikoyan-Gurevich_MiG-21)

Assets are cleared at startup to allow the indexing service to repopulate
the list from scratch. Note that this means prices will disappear until
they are re-resolved.

Pending transactions are queued for a status check at startup. This
is added alongside an expiration for queued transaction lookup, which
will stop requeueing the transaction after 10 hours. At the same time,
if the transaction whose requeueing is halted is already in the db and
has no status, it is marked as failed.

The outcome is that we can currently treat the db/redux condition
`blockHeight === null && status === 0` as *roughly* but not *completely*
equivalent to "dropped".

Open to other ideas here, but this felt like (a) a material improvement,
(b) an imperfect but reasonable starting heuristic, and (c) expedient. If
we wanted to improve the heuristic to make sure that transactions still
in the mempool aren't marked this way, the transactions in this state are
clearly distinguishable from others. Similarly, we may want to hide these
transactions from the activity list for now (until we have a strategy for
handling them visually), and they are identifiable for that purpose as well.

Note that transactions that are still in the mempool should *in general*
not be affected, because `handleQueuedTransactionAlarm` will find the
transaction and set it up for confirmation monitoring, vs failing to find
it repeatedly and then marking it failed. It will only be affected if there
are inconsistent views of the mempool in our reference node. What we won't
be able to do is distinguish between transactions that were dropped after
inclusion in the mempool and transactions that were dropped before inclusion
(e.g. due to bad gas prices or other issues that made the transaction invalid
in the first place).