### PR TITLE
Minty Fresh: Fix a few outstanding bugs in swaps

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -23,7 +23,7 @@ import {
 } from "./services"
 
 import { EIP712TypedData, HexString, KeyringTypes } from "./types"
-import { EIP1559TransactionRequest, SignedEVMTransaction } from "./networks"
+import { SignedEVMTransaction } from "./networks"
 import { AddressNetwork, NameNetwork } from "./accounts"
 
 import rootReducer from "./redux-slices"
@@ -56,9 +56,9 @@ import {
   transactionRequest,
   signed,
   updateTransactionOptions,
-  broadcastOnSign,
   clearTransactionState,
   selectDefaultNetworkFeeSettings,
+  TransactionConstructionStatus,
 } from "./redux-slices/transaction-construction"
 import { allAliases } from "./redux-slices/utils"
 import {
@@ -480,7 +480,9 @@ export default class Main extends BaseService<never> {
 
     // FIXME Should no longer be necessary once transaction queueing enters the
     // FIXME picture.
-    this.store.dispatch(clearTransactionState())
+    this.store.dispatch(
+      clearTransactionState(TransactionConstructionStatus.Idle)
+    )
   }
 
   async addAccount(addressNetwork: AddressNetwork): Promise<void> {
@@ -625,7 +627,9 @@ export default class Main extends BaseService<never> {
             this.store.dispatch(signed(signedTx))
           } catch (exception) {
             logger.error("Error signing transaction", exception)
-            this.store.dispatch(clearTransactionState())
+            this.store.dispatch(
+              clearTransactionState(TransactionConstructionStatus.Idle)
+            )
           }
         }
       }
@@ -818,7 +822,9 @@ export default class Main extends BaseService<never> {
     this.internalEthereumProviderService.emitter.on(
       "transactionSignatureRequest",
       async ({ payload, resolver, rejecter }) => {
-        this.store.dispatch(clearTransactionState())
+        this.store.dispatch(
+          clearTransactionState(TransactionConstructionStatus.Pending)
+        )
         this.enrichmentService.enrichTransactionSignature(
           payload,
           2 /* TODO desiredDecimals should be configurable */

--- a/background/main.ts
+++ b/background/main.ts
@@ -819,7 +819,6 @@ export default class Main extends BaseService<never> {
       "transactionSignatureRequest",
       async ({ payload, resolver, rejecter }) => {
         this.store.dispatch(clearTransactionState())
-        this.store.dispatch(broadcastOnSign(false))
         this.enrichmentService.enrichTransactionSignature(
           payload,
           2 /* TODO desiredDecimals should be configurable */

--- a/background/redux-slices/transaction-construction.ts
+++ b/background/redux-slices/transaction-construction.ts
@@ -139,7 +139,11 @@ const transactionSlice = createSlice({
     clearTransactionState: (state) => ({
       estimatedFeesPerGas: state.estimatedFeesPerGas,
       lastGasEstimatesRefreshed: state.lastGasEstimatesRefreshed,
-      status: TransactionConstructionStatus.Idle,
+      status:
+        // If the transaction state is already pending, maintain that state.
+        state.status === TransactionConstructionStatus.Pending
+          ? TransactionConstructionStatus.Pending
+          : TransactionConstructionStatus.Idle,
       feeTypeSelected: NetworkFeeTypeChosen.Regular,
       broadcastOnSign: false,
       signedTransaction: undefined,

--- a/background/redux-slices/transaction-construction.ts
+++ b/background/redux-slices/transaction-construction.ts
@@ -136,14 +136,13 @@ const transactionSlice = createSlice({
       },
       transactionLikelyFails,
     }),
-    clearTransactionState: (state) => ({
+    clearTransactionState: (
+      state,
+      { payload }: { payload: TransactionConstructionStatus }
+    ) => ({
       estimatedFeesPerGas: state.estimatedFeesPerGas,
       lastGasEstimatesRefreshed: state.lastGasEstimatesRefreshed,
-      status:
-        // If the transaction state is already pending, maintain that state.
-        state.status === TransactionConstructionStatus.Pending
-          ? TransactionConstructionStatus.Pending
-          : TransactionConstructionStatus.Idle,
+      status: payload,
       feeTypeSelected: NetworkFeeTypeChosen.Regular,
       broadcastOnSign: false,
       signedTransaction: undefined,
@@ -252,7 +251,11 @@ export const rejectTransactionSignature = createBackgroundAsyncThunk(
   async (_, { dispatch }) => {
     await emitter.emit("signatureRejected")
     // Provide a clean slate for future transactions.
-    dispatch(transactionSlice.actions.clearTransactionState())
+    dispatch(
+      transactionSlice.actions.clearTransactionState(
+        TransactionConstructionStatus.Idle
+      )
+    )
   }
 )
 

--- a/ui/components/Shared/SharedAssetInput.tsx
+++ b/ui/components/Shared/SharedAssetInput.tsx
@@ -423,7 +423,7 @@ export default function SharedAssetInput<T extends AnyAsset>(
             opacity: 1;
           }
           .input_amount {
-            width: 98px;
+            max-width: 125px;
             height: 32px;
             color: #ffffff;
             font-size: 22px;

--- a/ui/components/Snackbar/Snackbar.tsx
+++ b/ui/components/Snackbar/Snackbar.tsx
@@ -81,6 +81,11 @@ export default function Snackbar(): ReactElement {
             user-select: none;
           }
           .hidden {
+            // Take up no space, and let pointer events through just in case. No
+            // hidden snackbar should get in the way of a user's actions.
+            padding: 0;
+            pointer-events: none;
+
             opacity: 0;
             transform: translateY(10px);
           }

--- a/ui/components/Swap/SwapQuote.tsx
+++ b/ui/components/Swap/SwapQuote.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback, useState } from "react"
+import React, { ReactElement, useCallback } from "react"
 import { utils } from "ethers"
 
 import {
@@ -7,6 +7,10 @@ import {
 } from "@tallyho/tally-background/redux-slices/0x-swap"
 import { useHistory } from "react-router-dom"
 import { FungibleAsset } from "@tallyho/tally-background/assets"
+import {
+  clearTransactionState,
+  TransactionConstructionStatus,
+} from "@tallyho/tally-background/redux-slices/transaction-construction"
 import SharedButton from "../Shared/SharedButton"
 import SharedActivityHeader from "../Shared/SharedActivityHeader"
 import SwapQuoteAssetCard from "./SwapQuoteAssetCard"
@@ -46,6 +50,11 @@ export default function SwapQuote({
 
   const handleApproveClick = useCallback(async () => {
     const { gasPrice, ...quoteWithoutGasPrice } = finalQuote
+
+    // FIXME Set state to pending so SignTransaction doesn't redirect back; drop after
+    // FIXME proper transaction queueing is in effect.
+    await dispatch(clearTransactionState(TransactionConstructionStatus.Pending))
+
     dispatch(
       executeSwap({
         ...quoteWithoutGasPrice,

--- a/ui/pages/EarnDeposit.tsx
+++ b/ui/pages/EarnDeposit.tsx
@@ -168,7 +168,7 @@ export default function EarnDeposit(): ReactElement {
                 setHasError(false)
               }
             }}
-            defaultAsset={asset}
+            selectedAsset={asset}
             amount={amount}
             disableDropdown
           />

--- a/ui/pages/Send.tsx
+++ b/ui/pages/Send.tsx
@@ -110,7 +110,7 @@ export default function Send(): ReactElement {
                   setHasError(false)
                 }
               }}
-              defaultAsset={{ symbol: assetSymbol, name: assetSymbol }}
+              selectedAsset={{ symbol: assetSymbol, name: assetSymbol }}
               amount={amount}
               disableDropdown
             />


### PR DESCRIPTION
This hits a few issues observed during final QA of swaps:

- Closes #937 .
- Reworks handling of transaction state so that the swap transition
  to transaction signing works correctly; when transaction state
  clearing became more aggressive, it left the sign transaction page
  in a state where it might decide it was seeing a rejected transaction
  and redirect back to the caller---not great!
- Rework selected asset handling in `SharedAssetInput` so that the
  caller provides the currently-selected asset at all times (instead of
  providing the starting default). This allowed the swap flip button to
  correctly update the selected assets in the UI.
- Added sorting for assets in `SharedAssetInput`. Sorting without a
  search term sorts alphabetically by symbol, while sorting with a search
  term sorts alphabetically but bubbles to the top any search term matches
  that match at the beginning of the symbol. This bubbles close-to-exact
  matches up where they're easier to get to, and tends to push down
  LP tokens and similar derivative tokens that include the base symbol
  in their name. Sorting is locale-aware based on the current JS locale
  at all times.

### Testing

For the snackbar issue, the Get Final Quote button and Approve button on
swaps should be clickable across the button; on main, it should have dead
space in the middle.

For the transaction signing issue, try to execute a swap. If the sign
transaction screen comes up every time, you win! Rejection should also
work, Send signing should work, and dApp signing should work.

For the `SharedAssetInput` changes, look at swaps and make sure that,
after selecting two assets and doing a quote, the flip button in the
middle flips both amount and assets. The swap-to list should show the
sorting behavior noted above. Finally, make sure that the other uses
of `SharedAssetInput` continue to work as expected with the sorting
behavior; these include Earn (with feature flag) and the unchangeable
asset input in the Send flow (which is hardcoded to ETH).