### PR TITLE
Nitsy Bitsy: Fix a few nits here and there from the last release

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -792,10 +792,14 @@ export default class Main extends BaseService<never> {
     })
 
     keyringSliceEmitter.on("deriveAddress", async (keyringID) => {
-      await this.signingService.deriveAddress({
-        type: "keyring",
-        accountID: keyringID,
-      })
+      if (HIDE_IMPORT_LEDGER) {
+        await this.keyringService.deriveAddress(keyringID)
+      } else {
+        await this.signingService.deriveAddress({
+          type: "keyring",
+          accountID: keyringID,
+        })
+      }
     })
 
     keyringSliceEmitter.on("generateNewKeyring", async () => {

--- a/background/redux-slices/0x-swap.ts
+++ b/background/redux-slices/0x-swap.ts
@@ -111,7 +111,6 @@ const gatedParameters =
     ? {
         affiliateAddress: COMMUNITY_MULTISIG_ADDRESS,
         feeRecipient: COMMUNITY_MULTISIG_ADDRESS,
-        // includedSources: "RFQT", FIXME This seems to limit available liquidity considerably
         buyTokenPercentageFee: SWAP_FEE,
       }
     : {}

--- a/background/redux-slices/transaction-construction.ts
+++ b/background/redux-slices/transaction-construction.ts
@@ -143,7 +143,7 @@ const transactionSlice = createSlice({
       estimatedFeesPerGas: state.estimatedFeesPerGas,
       lastGasEstimatesRefreshed: state.lastGasEstimatesRefreshed,
       status: payload,
-      feeTypeSelected: NetworkFeeTypeChosen.Regular,
+      feeTypeSelected: state.feeTypeSelected ?? NetworkFeeTypeChosen.Regular,
       broadcastOnSign: false,
       signedTransaction: undefined,
     }),

--- a/background/services/chain/utils.ts
+++ b/background/services/chain/utils.ts
@@ -150,9 +150,11 @@ export function enrichTransactionWithReceipt(
   receipt: EthersTransactionReceipt
 ): ConfirmedEVMTransaction {
   const gasUsed = receipt.gasUsed.toBigInt()
+
   return {
     ...transaction,
     gasUsed,
+    gasPrice: receipt.effectiveGasPrice.toBigInt(),
     status:
       receipt.status ??
       // Pre-Byzantium transactions require a guesswork approach or an

--- a/ui/components/Swap/SwapTransactionSettingsChooser.tsx
+++ b/ui/components/Swap/SwapTransactionSettingsChooser.tsx
@@ -98,8 +98,8 @@ export default function SwapTransactionSettingsChooser({
           </SharedSlideUpMenu>
 
           <div className="top_label label">
-            Transaction settings
-            <button type="button" onClick={openSettings}>
+            <label htmlFor="open-settings">Transaction settings</label>
+            <button type="button" id="open-settings" onClick={openSettings}>
               <span className="icon_cog" />
             </button>
           </div>
@@ -131,6 +131,9 @@ export default function SwapTransactionSettingsChooser({
           }
           .top_label {
             margin-bottom: 7px;
+          }
+          .top_label label {
+            flex-grow: 2;
           }
           .row {
             padding: 15px 0px;


### PR DESCRIPTION
Fixes here for add address not working, approve transactions not
preserving network fee info from the swap page, gas price
correctness on the activity page (for new transactions; old ones
for now remain unmigrated), and a small adjustment to give more
clickable area to the swap transaction settings button.

### Testing

For add address, just crack open that address dropdown and hit Add
address. If it works, it works! Make sure the build has Ledger disabled;
the issue here only shows up in those cases.

For the approve issue, go to swap and either pick a from asset that
you haven't approved yet, or zero out your approval first. Then,
change the default fee settings from Regular to Express or Instant
on the swap settings, and hit Approve asset. The selected fee on the
sign page should be the same as that on the swap page.

For the gas price, submit a transaction and check that, once confirmed,
the gas price listed in the activity details is different from the max
fee per gas.

Closes #980, closes #981, closes #982.