### PR TITLE
Multi-network Prep: Prep the codebase for multi-network refactoring

### DIFF
--- a/background/accounts.ts
+++ b/background/accounts.ts
@@ -38,7 +38,7 @@ export type AccountBalance = {
 /**
  * An address on a particular network. That's it. That's the comment.
  */
-export type AddressNetwork = {
+export type AddressOnNetwork = {
   address: HexString
   network: EVMNetwork
 }
@@ -46,7 +46,7 @@ export type AddressNetwork = {
 /**
  * A domain name, with a particular network.
  */
-export type NameNetwork = {
+export type NameOnNetwork = {
   name: string
   network: EVMNetwork
 }

--- a/background/accounts.ts
+++ b/background/accounts.ts
@@ -1,5 +1,5 @@
 import { AnyAssetAmount } from "./assets"
-import { Network } from "./networks"
+import { EVMNetwork } from "./networks"
 import { HexString } from "./types"
 
 /**
@@ -19,7 +19,7 @@ export type AccountBalance = {
   /**
    * The network on which the account balance was measured.
    */
-  network: Network
+  network: EVMNetwork
   /**
    * The block height at while the balance measurement is valid.
    */
@@ -40,7 +40,7 @@ export type AccountBalance = {
  */
 export type AddressNetwork = {
   address: HexString
-  network: Network
+  network: EVMNetwork
 }
 
 /**
@@ -48,5 +48,5 @@ export type AddressNetwork = {
  */
 export type NameNetwork = {
   name: string
-  network: Network
+  network: EVMNetwork
 }

--- a/background/assets.ts
+++ b/background/assets.ts
@@ -148,8 +148,8 @@ export type PricePoint = {
  * In almost all cases, PricePoint should be preferred. UnitPricePoint should
  * only be used when the details of the other side of a price pair are unknown.
  */
-export type UnitPricePoint = {
-  unitPrice: AnyAssetAmount
+export type UnitPricePoint<T extends AnyAsset> = {
+  unitPrice: AnyAssetAmount<T>
   time: UNIXTime
 }
 
@@ -283,7 +283,7 @@ export function convertAssetAmountViaPricePoint<T extends AnyAssetAmount>(
  */
 export function unitPricePointForPricePoint(
   assetPricePoint: PricePoint
-): (UnitPricePoint & { unitPrice: FungibleAssetAmount }) | undefined {
+): UnitPricePoint<FungibleAsset> | undefined {
   const sourceAsset = assetPricePoint.pair[0]
 
   const unitPrice = convertAssetAmountViaPricePoint(

--- a/background/assets.ts
+++ b/background/assets.ts
@@ -104,10 +104,7 @@ export type AssetAmount = {
 /*
  * The primary type representing amounts in fungible asset transactions.
  */
-export type FungibleAssetAmount = {
-  asset: FungibleAsset
-  amount: bigint
-}
+export type FungibleAssetAmount = AnyAssetAmount<FungibleAsset>
 
 /*
  * A union of all assets we expect to price.
@@ -185,6 +182,9 @@ export function isSmartContractFungibleAsset(
 
 /**
  * Type guard to check if an AnyAssetAmount is actually a FungibleAssetAmount.
+ *
+ * WARNING: Only use this if AnyAssetAmount<T> typing isn't enough to carry the
+ * FungibleAsset nature of the internal asset!
  */
 export function isFungibleAssetAmount(
   assetAmount: AnyAssetAmount
@@ -209,7 +209,8 @@ export function isFungibleAssetAmount(
  * @param sourceAssetAmount The AssetAmount being converted. The asset of this
  *        amount should match the first asset in the price point.
  * @param assetPricePoint A PricePoint with the first item being the source asset
- *        and the second being the target asset.
+ *        and the second being the target asset. If undefined, this function will
+ *        return undefined.
  *
  * @return If the source and target assets are both fungible, the target asset
  *         amount corresponding to the passed source asset amount. If the source
@@ -219,8 +220,12 @@ export function isFungibleAssetAmount(
  */
 export function convertAssetAmountViaPricePoint<T extends AnyAssetAmount>(
   sourceAssetAmount: T,
-  assetPricePoint: PricePoint
+  assetPricePoint: PricePoint | undefined
 ): FungibleAssetAmount | undefined {
+  if (typeof assetPricePoint === "undefined") {
+    return undefined
+  }
+
   const [sourceAsset, targetAsset] = assetPricePoint.pair
   const [sourceConversionFactor, targetConversionFactor] =
     assetPricePoint.amounts
@@ -280,10 +285,18 @@ export function convertAssetAmountViaPricePoint<T extends AnyAssetAmount>(
  * equivalent to one of the first asset. In addition to handling strange
  * ratios, recognizes a unit in the appropriate fixed point decimal count of
  * the target asset.
+ *
+ * Like convertAssetAmountViaPricePoint, returns undefined if either of the two
+ * assets in the price point are not fungible, or if the provided price point
+ * is undefined.
  */
 export function unitPricePointForPricePoint(
-  assetPricePoint: PricePoint
+  assetPricePoint: PricePoint | undefined
 ): UnitPricePoint<FungibleAsset> | undefined {
+  if (typeof assetPricePoint === "undefined") {
+    return undefined
+  }
+
   const sourceAsset = assetPricePoint.pair[0]
 
   const unitPrice = convertAssetAmountViaPricePoint(

--- a/background/constants/networks.ts
+++ b/background/constants/networks.ts
@@ -44,4 +44,33 @@ export const BITCOIN: Network = {
   family: "BTC",
 }
 
-export const NETWORKS = [ETHEREUM, BITCOIN]
+export const EVM_MAIN_NETWORKS = [ETHEREUM]
+
+export const EVM_TEST_NETWORKS = [ROPSTEN, RINKEBY, GOERLI, KOVAN]
+
+const EVM_NETWORKS: EVMNetwork[] = EVM_MAIN_NETWORKS.concat(EVM_TEST_NETWORKS)
+
+// A lot of code currently relies on chain id uniqueness per EVM network;
+// explode if that is not maintained.
+if (
+  new Set(EVM_NETWORKS.map(({ chainID }) => chainID)).size < EVM_NETWORKS.length
+) {
+  throw new Error("Duplicate chain ID in EVM networks.")
+}
+
+export const EVM_NETWORKS_BY_CHAIN_ID: { [chainID: string]: EVMNetwork } =
+  EVM_NETWORKS.reduce(
+    (agg, network) => ({
+      ...agg,
+      [network.chainID]: network,
+    }),
+    {}
+  )
+
+export const NETWORKS = [BITCOIN].concat(EVM_NETWORKS)
+
+// A lot of code currently relies on network name uniqueness; explode if that
+// is not maintained.
+if (new Set(NETWORKS.map(({ name }) => name)).size < NETWORKS.length) {
+  throw new Error("Duplicate chain name in networks.")
+}

--- a/background/lib/erc20.ts
+++ b/background/lib/erc20.ts
@@ -1,6 +1,5 @@
 import { AlchemyProvider, BaseProvider } from "@ethersproject/providers"
 import { BigNumber, ethers, logger } from "ethers"
-import { getNetwork } from "@ethersproject/networks"
 import {
   EventFragment,
   Fragment,
@@ -8,7 +7,6 @@ import {
   TransactionDescription,
 } from "ethers/lib/utils"
 import { getTokenBalances, getTokenMetadata } from "./alchemy"
-import { getEthereumNetwork } from "./utils"
 import { AccountBalance, AddressOnNetwork } from "../accounts"
 import { SmartContractFungibleAsset } from "../assets"
 import { EVMLog } from "../networks"
@@ -62,13 +60,6 @@ export const ERC2612_FUNCTIONS = {
 export const ERC2612_ABI = ERC20_ABI.concat(Object.values(ERC2612_FUNCTIONS))
 
 export const ERC2612_INTERFACE = new ethers.utils.Interface(ERC2612_ABI)
-
-const ALCHEMY_KEY = process.env.ALCHEMY_KEY // eslint-disable-line prefer-destructuring
-
-const alchemyProvider = new AlchemyProvider(
-  getNetwork(Number(getEthereumNetwork().chainID)),
-  ALCHEMY_KEY
-)
 
 /*
  * Get an account's balance from an ERC20-compliant contract.
@@ -199,21 +190,6 @@ export function parseLogsForERC20Transfers(logs: EVMLog[]): ERC20TransferLog[] {
       }
     })
     .filter((info): info is ERC20TransferLog => typeof info !== "undefined")
-}
-
-export const getERC20TokenMetadata = async (
-  addressOnNetwork: AddressOnNetwork
-): Promise<SmartContractFungibleAsset | null> => {
-  try {
-    const tokenMetadata = await getTokenMetadata(
-      alchemyProvider,
-      addressOnNetwork
-    )
-    return tokenMetadata
-  } catch (err) {
-    logger.warn("Couldn't find token with specified address", addressOnNetwork)
-  }
-  return null
 }
 
 // TODO get token balances of a many token contracts for a particular account the slow way, cache

--- a/background/lib/erc20.ts
+++ b/background/lib/erc20.ts
@@ -14,7 +14,7 @@ import { SmartContractFungibleAsset } from "../assets"
 import { EVMLog } from "../networks"
 import { HexString } from "../types"
 
-const ERC20_FUNCTIONS = {
+export const ERC20_FUNCTIONS = {
   allowance: FunctionFragment.from(
     "allowance(address owner, address spender) view returns (uint256)"
   ),

--- a/background/lib/prices.ts
+++ b/background/lib/prices.ts
@@ -4,6 +4,7 @@ import {
   AnyAsset,
   CoinGeckoAsset,
   FiatCurrency,
+  FungibleAsset,
   PricePoint,
   UnitPricePoint,
 } from "../assets"
@@ -99,7 +100,9 @@ export async function getPrices(
 export async function getEthereumTokenPrices(
   tokenAddresses: string[],
   fiatCurrency: FiatCurrency
-): Promise<{ [contractAddress: string]: UnitPricePoint }> {
+): Promise<{
+  [contractAddress: string]: UnitPricePoint<FungibleAsset>
+}> {
   const fiatSymbol = fiatCurrency.symbol
 
   // TODO cover failed schema validation and http & network errors
@@ -109,7 +112,7 @@ export async function getEthereumTokenPrices(
   const json = await fetchJson(url)
 
   const prices: {
-    [index: string]: UnitPricePoint
+    [index: string]: UnitPricePoint<FungibleAsset>
   } = {}
   // TODO Improve typing with Ajv validation.
   Object.entries(

--- a/background/lib/tokenList.ts
+++ b/background/lib/tokenList.ts
@@ -1,8 +1,7 @@
 import { TokenList } from "@uniswap/token-lists"
 
-import { getEthereumNetwork, normalizeEVMAddress } from "./utils"
+import { normalizeEVMAddress } from "./utils"
 import {
-  AssetMetadata,
   FungibleAsset,
   isSmartContractFungibleAsset,
   SmartContractFungibleAsset,
@@ -59,7 +58,7 @@ function tokenListToFungibleAssetsForNetwork(
         name: tokenMetadata.name,
         symbol: tokenMetadata.symbol,
         decimals: tokenMetadata.decimals,
-        homeNetwork: getEthereumNetwork(),
+        homeNetwork: network,
         contractAddress: tokenMetadata.address,
       }
     })

--- a/background/lib/utils/index.ts
+++ b/background/lib/utils/index.ts
@@ -24,10 +24,15 @@ export function truncateDecimalAmount(
 }
 
 export function sameEVMAddress(
-  address1: string | Buffer | undefined,
-  address2: string | Buffer | undefined
+  address1: string | Buffer | undefined | null,
+  address2: string | Buffer | undefined | null
 ): boolean {
-  if (typeof address1 === "undefined" || typeof address2 === "undefined") {
+  if (
+    typeof address1 === "undefined" ||
+    typeof address2 === "undefined" ||
+    address1 === null ||
+    address2 === null
+  ) {
     return false
   }
   return normalizeHexAddress(address1) === normalizeHexAddress(address2)

--- a/background/main.ts
+++ b/background/main.ts
@@ -613,7 +613,10 @@ export default class Main extends BaseService<never> {
 
           try {
             const signedTx = await this.keyringService.signTransaction(
-              transaction.from,
+              {
+                address: transaction.from,
+                network: this.chainService.ethereumNetwork,
+              },
               transactionWithNonce
             )
             this.store.dispatch(signed(signedTx))
@@ -627,6 +630,7 @@ export default class Main extends BaseService<never> {
         } else {
           try {
             const signedTx = await this.signingService.signTransaction(
+              this.chainService.ethereumNetwork,
               transaction,
               method
             )

--- a/background/main.ts
+++ b/background/main.ts
@@ -24,7 +24,7 @@ import {
 
 import { EIP712TypedData, HexString, KeyringTypes } from "./types"
 import { SignedEVMTransaction } from "./networks"
-import { AddressNetwork, NameNetwork } from "./accounts"
+import { AddressOnNetwork, NameOnNetwork } from "./accounts"
 
 import rootReducer from "./redux-slices"
 import {
@@ -485,11 +485,11 @@ export default class Main extends BaseService<never> {
     )
   }
 
-  async addAccount(addressNetwork: AddressNetwork): Promise<void> {
+  async addAccount(addressNetwork: AddressOnNetwork): Promise<void> {
     await this.chainService.addAccountToTrack(addressNetwork)
   }
 
-  async addAccountByName(nameNetwork: NameNetwork): Promise<void> {
+  async addAccountByName(nameNetwork: NameOnNetwork): Promise<void> {
     try {
       const address = await this.nameService.lookUpEthereumAddress(
         nameNetwork.name
@@ -964,7 +964,7 @@ export default class Main extends BaseService<never> {
 
     this.preferenceService.emitter.on(
       "initializeSelectedAccount",
-      async (dbAddressNetwork: AddressNetwork) => {
+      async (dbAddressNetwork: AddressOnNetwork) => {
         if (dbAddressNetwork) {
           // TBD: naming the normal reducer and async thunks
           // Initialize redux from the db

--- a/background/main.ts
+++ b/background/main.ts
@@ -4,7 +4,7 @@ import { configureStore, isPlain, Middleware } from "@reduxjs/toolkit"
 import devToolsEnhancer from "remote-redux-devtools"
 import { PermissionRequest } from "@tallyho/provider-bridge-shared"
 
-import { decodeJSON, encodeJSON, getEthereumNetwork } from "./lib/utils"
+import { decodeJSON, encodeJSON } from "./lib/utils"
 
 import {
   BaseService,
@@ -571,7 +571,7 @@ export default class Main extends BaseService<never> {
 
       const { transactionRequest: populatedRequest, gasEstimationError } =
         await this.chainService.populatePartialEVMTransactionRequest(
-          getEthereumNetwork(),
+          this.chainService.ethereumNetwork,
           {
             ...options,
             maxFeePerGas: options.maxFeePerGas ?? maxFeePerGas,
@@ -778,7 +778,7 @@ export default class Main extends BaseService<never> {
       this.chainService.addAccountToTrack({
         address,
         // TODO support other networks
-        network: getEthereumNetwork(),
+        network: this.chainService.ethereumNetwork,
       })
     })
 

--- a/background/main.ts
+++ b/background/main.ts
@@ -839,6 +839,7 @@ export default class Main extends BaseService<never> {
           clearTransactionState(TransactionConstructionStatus.Pending)
         )
         this.enrichmentService.enrichTransactionSignature(
+          this.chainService.ethereumNetwork,
           payload,
           2 /* TODO desiredDecimals should be configurable */
         )

--- a/background/redux-slices/accounts.ts
+++ b/background/redux-slices/accounts.ts
@@ -61,19 +61,21 @@ export type CombinedAccountData = {
   assets: AnyAssetAmount[]
 }
 
-/**
- * An asset amount including localized and numeric main currency and decimal
- * equivalents, where applicable.
- */
-export type CompleteAssetAmount<
+// Utility type, wrapped in CompleteAssetAmount<T>.
+type InternalCompleteAssetAmount<
   E extends AnyAsset = AnyAsset,
   T extends AnyAssetAmount<E> = AnyAssetAmount<E>
 > = T & AssetMainCurrencyAmount & AssetDecimalAmount
 
-export type CompleteSmartContractFungibleAssetAmount = CompleteAssetAmount<
-  SmartContractFungibleAsset,
-  AnyAssetAmount<SmartContractFungibleAsset>
->
+/**
+ * An asset amount including localized and numeric main currency and decimal
+ * equivalents, where applicable.
+ */
+export type CompleteAssetAmount<T extends AnyAsset = AnyAsset> =
+  InternalCompleteAssetAmount<T, AnyAssetAmount<T>>
+
+export type CompleteSmartContractFungibleAssetAmount =
+  CompleteAssetAmount<SmartContractFungibleAsset>
 
 export const initialState = {
   accountsData: {},

--- a/background/redux-slices/accounts.ts
+++ b/background/redux-slices/accounts.ts
@@ -1,6 +1,6 @@
 import { createSlice } from "@reduxjs/toolkit"
 import { createBackgroundAsyncThunk } from "./utils"
-import { AccountBalance, AddressNetwork, NameNetwork } from "../accounts"
+import { AccountBalance, AddressOnNetwork, NameOnNetwork } from "../accounts"
 import { AnyEVMBlock, Network } from "../networks"
 import { AnyAsset, AnyAssetAmount, SmartContractFungibleAsset } from "../assets"
 import {
@@ -45,7 +45,7 @@ type AccountData = {
 }
 
 export type AccountState = {
-  account?: AddressNetwork
+  account?: AddressOnNetwork
   accountLoading?: string
   hasAccountError?: boolean
   // TODO Adapt to use AccountNetwork, probably via a Map and custom serialization/deserialization.
@@ -210,7 +210,7 @@ const accountSlice = createSlice({
       immerState,
       {
         payload: addressNetworkName,
-      }: { payload: AddressNetwork & { name: DomainName } }
+      }: { payload: AddressOnNetwork & { name: DomainName } }
     ) => {
       // TODO Refactor when accounts are also keyed per network.
       const address = addressNetworkName.address.toLowerCase()
@@ -230,7 +230,7 @@ const accountSlice = createSlice({
       immerState,
       {
         payload: addressNetworkAvatar,
-      }: { payload: AddressNetwork & { avatar: URI } }
+      }: { payload: AddressOnNetwork & { avatar: URI } }
     ) => {
       // TODO Refactor when accounts are also keyed per network.
       const address = addressNetworkAvatar.address.toLowerCase()
@@ -269,7 +269,7 @@ export default accountSlice.reducer
  */
 export const addAddressNetwork = createBackgroundAsyncThunk(
   "account/addAccount",
-  async (addressNetwork: AddressNetwork, { dispatch, extra: { main } }) => {
+  async (addressNetwork: AddressOnNetwork, { dispatch, extra: { main } }) => {
     const normalizedAddressNetwork = {
       address: addressNetwork.address.toLowerCase(),
       network: addressNetwork.network,
@@ -286,7 +286,7 @@ export const addAddressNetwork = createBackgroundAsyncThunk(
  */
 export const addAccountByName = createBackgroundAsyncThunk(
   "account/addAccountByName",
-  async (nameNetwork: NameNetwork, { extra: { main } }) => {
+  async (nameNetwork: NameOnNetwork, { extra: { main } }) => {
     await main.addAccountByName(nameNetwork)
   }
 )

--- a/background/redux-slices/earn.ts
+++ b/background/redux-slices/earn.ts
@@ -3,7 +3,6 @@ import { createSlice, createSelector } from "@reduxjs/toolkit"
 import { BigNumber, ethers } from "ethers"
 import { HOUR } from "../constants"
 import { ERC20_ABI } from "../lib/erc20"
-import { getEthereumNetwork } from "../lib/utils"
 import VAULT_ABI from "../lib/vault"
 import { EIP712TypedData, HexString } from "../types"
 import { createBackgroundAsyncThunk } from "./utils"
@@ -260,6 +259,7 @@ export const permitVaultDeposit = createBackgroundAsyncThunk(
     const provider = getProvider()
     const signer = provider.getSigner()
     const signerAddress = await getSignerAddress()
+    const chainID = await signer.getChainId()
 
     const types = {
       Message: [
@@ -289,7 +289,7 @@ export const permitVaultDeposit = createBackgroundAsyncThunk(
       name: "Spend assets with ApprovalTarget",
       version: "1",
       verifyingContract: vaultContractAddress,
-      chainId: Number(getEthereumNetwork().chainID),
+      chainId: chainID,
     }
     const message = {
       owner: signerAddress,

--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -7,6 +7,7 @@ import {
   enrichAssetAmountWithDecimalValues,
   enrichAssetAmountWithMainCurrencyValues,
   formatCurrencyAmount,
+  heuristicDesiredDecimalsForUnitPrice,
 } from "../utils/asset-utils"
 import {
   AnyAsset,
@@ -59,23 +60,12 @@ const computeCombinedAssetAmountsData = (
             desiredDecimals
           )
 
-        // Heuristically add decimal places to high-unit-price assets, `
-        // 1 decimal place per order of magnitude in the unit price; e.g.
-        // if USD is the main currency and the asset unit price is $100,
-        // 2 decimal points, $1000, 3 decimal points, $10000, 4 decimal
-        // points, etc. `desiredDecimals` is treated as the minimum, and
-        // order of magnitude is rounded up (e.g. $2000 = >3 orders of
-        // magnitude, so 4 decimal points).
-        const decimalValuePlaces = Math.max(
-          // Using ?? 0, safely handle cases where no main currency is
-          // available.
-          Math.ceil(Math.log10(mainCurrencyEnrichedAssetAmount.unitPrice ?? 0)),
-          desiredDecimals
-        )
-
         const fullyEnrichedAssetAmount = enrichAssetAmountWithDecimalValues(
           mainCurrencyEnrichedAssetAmount,
-          decimalValuePlaces
+          heuristicDesiredDecimalsForUnitPrice(
+            desiredDecimals,
+            mainCurrencyEnrichedAssetAmount.unitPrice
+          )
         )
 
         if (

--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -32,10 +32,7 @@ const computeCombinedAssetAmountsData = (
   mainCurrencySymbol: string,
   hideDust: boolean
 ): {
-  combinedAssetAmounts: CompleteAssetAmount<
-    AnyAsset,
-    AnyAssetAmount<AnyAsset>
-  >[]
+  combinedAssetAmounts: CompleteAssetAmount[]
   totalMainCurrencyAmount: number | undefined
 } => {
   // Keep a tally of the total user value; undefined if no main currency data

--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -49,33 +49,27 @@ const computeCombinedAssetAmountsData = (
         mainCurrencySymbol
       )
 
-      if (assetPricePoint) {
-        const mainCurrencyEnrichedAssetAmount =
-          enrichAssetAmountWithMainCurrencyValues(
-            assetAmount,
-            assetPricePoint,
-            desiredDecimals
-          )
-
-        const fullyEnrichedAssetAmount = enrichAssetAmountWithDecimalValues(
-          mainCurrencyEnrichedAssetAmount,
-          heuristicDesiredDecimalsForUnitPrice(
-            desiredDecimals,
-            mainCurrencyEnrichedAssetAmount.unitPrice
-          )
+      const mainCurrencyEnrichedAssetAmount =
+        enrichAssetAmountWithMainCurrencyValues(
+          assetAmount,
+          assetPricePoint,
+          desiredDecimals
         )
 
-        if (
-          typeof fullyEnrichedAssetAmount.mainCurrencyAmount !== "undefined"
-        ) {
-          totalMainCurrencyAmount ??= 0 // initialize if needed
-          totalMainCurrencyAmount += fullyEnrichedAssetAmount.mainCurrencyAmount
-        }
+      const fullyEnrichedAssetAmount = enrichAssetAmountWithDecimalValues(
+        mainCurrencyEnrichedAssetAmount,
+        heuristicDesiredDecimalsForUnitPrice(
+          desiredDecimals,
+          mainCurrencyEnrichedAssetAmount.unitPrice
+        )
+      )
 
-        return fullyEnrichedAssetAmount
+      if (typeof fullyEnrichedAssetAmount.mainCurrencyAmount !== "undefined") {
+        totalMainCurrencyAmount ??= 0 // initialize if needed
+        totalMainCurrencyAmount += fullyEnrichedAssetAmount.mainCurrencyAmount
       }
 
-      return enrichAssetAmountWithDecimalValues(assetAmount, desiredDecimals)
+      return fullyEnrichedAssetAmount
     })
     .filter((assetAmount) => {
       const isNotDust =

--- a/background/redux-slices/selectors/uiSelectors.ts
+++ b/background/redux-slices/selectors/uiSelectors.ts
@@ -2,7 +2,8 @@ import { createSelector } from "@reduxjs/toolkit"
 import { RootState } from ".."
 import { ActivityItem } from "../activities"
 
-const mainCurrencySymbol = "USD"
+// FIXME Make this configurable.
+const hardcodedMainCurrencySymbol = "USD"
 
 export const selectShowingActivityDetail = createSelector(
   (state: RootState) => state.activities,
@@ -46,8 +47,15 @@ export const selectCurrentAddressNetwork = createSelector(
   (selectedAccount) => selectedAccount
 )
 
+export const selectMainCurrencySymbol = createSelector(
+  () => null,
+  () => hardcodedMainCurrencySymbol
+)
+
 export const selectMainCurrency = createSelector(
   (state: RootState) => state.ui,
   (state: RootState) => state.assets,
-  (_, assets) => assets.find((asset) => asset.symbol === mainCurrencySymbol)
+  (state: RootState) => selectMainCurrencySymbol(state),
+  (_, assets, mainCurrencySymbol) =>
+    assets.find((asset) => asset.symbol === mainCurrencySymbol)
 )

--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -1,7 +1,7 @@
 import { createSlice, createSelector } from "@reduxjs/toolkit"
 import Emittery from "emittery"
-import { getEthereumNetwork } from "../lib/utils"
 import { AddressOnNetwork } from "../accounts"
+import { ETHEREUM } from "../constants"
 import { createBackgroundAsyncThunk } from "./utils"
 
 const defaultSettings = {
@@ -36,7 +36,7 @@ export const initialState: UIState = {
   showingActivityDetailID: null,
   selectedAccount: {
     address: "",
-    network: getEthereumNetwork(),
+    network: ETHEREUM,
   },
   initializationLoadingTimeExpired: false,
   settings: defaultSettings,

--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -1,7 +1,7 @@
 import { createSlice, createSelector } from "@reduxjs/toolkit"
 import Emittery from "emittery"
-import { AddressNetwork } from "../accounts"
 import { getEthereumNetwork } from "../lib/utils"
+import { AddressOnNetwork } from "../accounts"
 import { createBackgroundAsyncThunk } from "./utils"
 
 const defaultSettings = {
@@ -16,7 +16,7 @@ export interface Location {
 }
 
 export type UIState = {
-  selectedAccount: AddressNetwork
+  selectedAccount: AddressOnNetwork
   showingActivityDetailID: string | null
   initializationLoadingTimeExpired: boolean
   settings: { hideDust: boolean; defaultWallet: boolean }
@@ -27,7 +27,7 @@ export type UIState = {
 export type Events = {
   snackbarMessage: string
   newDefaultWalletValue: boolean
-  newSelectedAccount: AddressNetwork
+  newSelectedAccount: AddressOnNetwork
 }
 
 export const emitter = new Emittery<Events>()
@@ -129,7 +129,7 @@ export const setNewDefaultWalletValue = createBackgroundAsyncThunk(
 // TBD @Antonio: It would be good to have a consistent naming strategy
 export const setNewSelectedAccount = createBackgroundAsyncThunk(
   "ui/setNewCurrentAddressValue",
-  async (addressNetwork: AddressNetwork, { dispatch }) => {
+  async (addressNetwork: AddressOnNetwork, { dispatch }) => {
     await emitter.emit("newSelectedAccount", addressNetwork)
     // Once the default value has persisted, propagate to the store.
     dispatch(uiSlice.actions.setSelectedAccount(addressNetwork))

--- a/background/redux-slices/utils/asset-utils.ts
+++ b/background/redux-slices/utils/asset-utils.ts
@@ -76,7 +76,7 @@ export function formatCurrencyAmount(
  *        main currency will be given by the price point.
  * @param assetPricePoint The price of the asset in `assetAmount` in terms of
  *        the main currency. The main currency should be second in the price
- *        point pair.
+ *        point pair. If undefined, the main currency data will not be populated.
  * @param desiredDecimals The number of floating point decimals to keep when
  *        converting from fixed point to floating point. Also the number of
  *        decimals rendered in the localized form.
@@ -95,7 +95,7 @@ export function enrichAssetAmountWithMainCurrencyValues<
   T extends AnyAssetAmount
 >(
   assetAmount: T,
-  assetPricePoint: PricePoint,
+  assetPricePoint: PricePoint | undefined,
   desiredDecimals: number
 ): T & AssetMainCurrencyAmount {
   const convertedAssetAmount = convertAssetAmountViaPricePoint(

--- a/background/services/chain/db.ts
+++ b/background/services/chain/db.ts
@@ -1,7 +1,7 @@
 import Dexie from "dexie"
 
 import { UNIXTime } from "../../types"
-import { AccountBalance, AddressNetwork } from "../../accounts"
+import { AccountBalance, AddressOnNetwork } from "../../accounts"
 import { AnyEVMBlock, AnyEVMTransaction, Network } from "../../networks"
 import { FungibleAsset } from "../../assets"
 
@@ -11,7 +11,7 @@ type Transaction = AnyEVMTransaction & {
 }
 
 type AccountAssetTransferLookup = {
-  addressNetwork: AddressNetwork
+  addressNetwork: AddressOnNetwork
   retrievedAt: UNIXTime
   startBlock: bigint
   endBlock: bigint
@@ -33,7 +33,7 @@ export class ChainDatabase extends Dexie {
    * Keyed by the [address, network name, network chain ID] triplet.
    */
   private accountsToTrack!: Dexie.Table<
-    AddressNetwork,
+    AddressOnNetwork,
     [string, string, string]
   >
 
@@ -204,12 +204,12 @@ export class ChainDatabase extends Dexie {
     return balanceCandidates.length > 0 ? balanceCandidates[0] : null
   }
 
-  async addAccountToTrack(addressNetwork: AddressNetwork): Promise<void> {
+  async addAccountToTrack(addressNetwork: AddressOnNetwork): Promise<void> {
     await this.accountsToTrack.put(addressNetwork)
   }
 
   async setAccountsToTrack(
-    addressesAndNetworks: Set<AddressNetwork>
+    addressesAndNetworks: Set<AddressOnNetwork>
   ): Promise<void> {
     await this.transaction("rw", this.accountsToTrack, () => {
       this.accountsToTrack.clear()
@@ -218,7 +218,7 @@ export class ChainDatabase extends Dexie {
   }
 
   async getOldestAccountAssetTransferLookup(
-    addressNetwork: AddressNetwork
+    addressNetwork: AddressOnNetwork
   ): Promise<bigint | null> {
     // TODO this is inefficient, make proper use of indexing
     const lookups = await this.accountAssetTransferLookups
@@ -235,7 +235,7 @@ export class ChainDatabase extends Dexie {
   }
 
   async getNewestAccountAssetTransferLookup(
-    addressNetwork: AddressNetwork
+    addressNetwork: AddressOnNetwork
   ): Promise<bigint | null> {
     // TODO this is inefficient, make proper use of indexing
     const lookups = await this.accountAssetTransferLookups
@@ -252,7 +252,7 @@ export class ChainDatabase extends Dexie {
   }
 
   async recordAccountAssetTransferLookup(
-    addressNetwork: AddressNetwork,
+    addressNetwork: AddressOnNetwork,
     startBlock: bigint,
     endBlock: bigint
   ): Promise<void> {
@@ -274,7 +274,7 @@ export class ChainDatabase extends Dexie {
     await this.balances.add(accountBalance)
   }
 
-  async getAccountsToTrack(): Promise<AddressNetwork[]> {
+  async getAccountsToTrack(): Promise<AddressOnNetwork[]> {
     return this.accountsToTrack.toArray()
   }
 

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -490,7 +490,7 @@ export default class ChainService extends BaseService<Events> {
    * @param blockHash the hash of the block we're interested in
    */
   async getBlockData(
-    network: Network,
+    network: EVMNetwork,
     blockHash: string
   ): Promise<AnyEVMBlock> {
     // TODO make this multi network

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -764,7 +764,7 @@ export default class ChainService extends BaseService<Events> {
     // TODO only works on Ethereum today
     const assetTransfers = await getAssetTransfers(
       this.pollingProviders.ethereum,
-      addressOnNetwork.address,
+      addressOnNetwork,
       Number(startBlock),
       Number(endBlock)
     )

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -443,6 +443,8 @@ export default class ChainService extends BaseService<Events> {
   async getLatestBaseAccountBalance(
     addressNetwork: AddressOnNetwork
   ): Promise<AccountBalance> {
+    this.checkNetwork(addressNetwork.network)
+
     // TODO look up provider network properly
     const balance = await this.pollingProviders.ethereum.getBalance(
       addressNetwork.address
@@ -656,6 +658,20 @@ export default class ChainService extends BaseService<Events> {
    * **************** */
 
   /**
+   * Ensure the given network is supported; otherwise, log and throw.
+   */
+  private checkNetwork(network: EVMNetwork): void {
+    if (network.name !== this.ethereumNetwork.name) {
+      logger.error(
+        "Request received for operation on unsupported network",
+        network,
+        "expected",
+        this.ethereumNetwork
+      )
+    }
+  }
+
+  /**
    * Load recent asset transfers from an account on a particular network. Backs
    * off exponentially (in block range, not in time) on failure.
    *
@@ -760,6 +776,8 @@ export default class ChainService extends BaseService<Events> {
     startBlock: bigint,
     endBlock: bigint
   ): Promise<void> {
+    this.checkNetwork(addressOnNetwork.network)
+
     // TODO only works on Ethereum today
     const assetTransfers = await getAssetTransfers(
       this.pollingProviders.ethereum,
@@ -988,6 +1006,8 @@ export default class ChainService extends BaseService<Events> {
     address,
     network,
   }: AddressOnNetwork): Promise<void> {
+    this.checkNetwork(network)
+
     // TODO look up provider network properly
     const provider = this.websocketProviders.ethereum
     // eslint-disable-next-line no-underscore-dangle
@@ -1050,6 +1070,8 @@ export default class ChainService extends BaseService<Events> {
     network: EVMNetwork,
     transaction: AnyEVMTransaction
   ): Promise<void> {
+    this.checkNetwork(network)
+
     // TODO make proper use of the network
     this.websocketProviders.ethereum.once(
       transaction.hash,
@@ -1072,6 +1094,8 @@ export default class ChainService extends BaseService<Events> {
     network: EVMNetwork,
     transaction: AnyEVMTransaction
   ): Promise<void> {
+    this.checkNetwork(network)
+
     // TODO make proper use of the network
     const receipt = await this.pollingProviders.ethereum.getTransactionReceipt(
       transaction.hash

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -224,7 +224,7 @@ export default class ChainService extends BaseService<Events> {
       // TODO get the latest block for other networks
       ethProvider.getBlockNumber().then(async (n) => {
         const result = await ethProvider.getBlock(n)
-        const block = blockFromEthersBlock(result)
+        const block = blockFromEthersBlock(network, result)
         await this.db.addBlock(block)
       }),
 
@@ -501,7 +501,7 @@ export default class ChainService extends BaseService<Events> {
     // Looking for new block
     const resultBlock = await this.pollingProviders.ethereum.getBlock(blockHash)
 
-    const block = blockFromEthersBlock(resultBlock)
+    const block = blockFromEthersBlock(network, resultBlock)
 
     await this.db.addBlock(block)
     this.emitter.emit("block", block)
@@ -963,7 +963,7 @@ export default class ChainService extends BaseService<Events> {
       ["newHeads"],
       async (result: unknown) => {
         // add new head to database
-        const block = blockFromWebsocketBlock(result)
+        const block = blockFromWebsocketBlock(network, result)
         await this.db.addBlock(block)
         // emit the new block, don't wait to settle
         this.emitter.emit("block", block)

--- a/background/services/chain/utils.ts
+++ b/background/services/chain/utils.ts
@@ -15,12 +15,14 @@ import {
   ConfirmedEVMTransaction,
 } from "../../networks"
 import { FungibleAsset } from "../../assets"
-import { getEthereumNetwork } from "../../lib/utils"
 
 /**
  * Parse a block as returned by a polling provider.
  */
-export function blockFromEthersBlock(gethResult: EthersBlock): AnyEVMBlock {
+export function blockFromEthersBlock(
+  network: EVMNetwork,
+  gethResult: EthersBlock
+): AnyEVMBlock {
   return {
     hash: gethResult.hash,
     blockHeight: gethResult.number,
@@ -34,7 +36,7 @@ export function blockFromEthersBlock(gethResult: EthersBlock): AnyEVMBlock {
     difficulty: 0n,
     timestamp: gethResult.timestamp,
     baseFeePerGas: gethResult.baseFeePerGas?.toBigInt(),
-    network: getEthereumNetwork(), // TODO the network should be passed as an argument to this function instead
+    network,
   }
 }
 
@@ -42,6 +44,7 @@ export function blockFromEthersBlock(gethResult: EthersBlock): AnyEVMBlock {
  * Parse a block as returned by a websocket provider subscription.
  */
 export function blockFromWebsocketBlock(
+  network: EVMNetwork,
   incomingGethResult: unknown
 ): AnyEVMBlock {
   const gethResult = incomingGethResult as {
@@ -62,7 +65,7 @@ export function blockFromWebsocketBlock(
     baseFeePerGas: gethResult.baseFeePerGas
       ? BigInt(gethResult.baseFeePerGas)
       : undefined,
-    network: getEthereumNetwork(), // TODO the network should be passed as an argument to this function instead
+    network,
   }
 }
 

--- a/background/services/enrichment/index.ts
+++ b/background/services/enrichment/index.ts
@@ -116,7 +116,7 @@ export default class EnrichmentService extends BaseService<Events> {
       // categorizing activities.
       // TODO We can do more here by checking how much gas was spent. Anything
       // over the 21k required to send ETH is a more complex contract interaction
-      if (transaction.value) {
+      if (typeof transaction.value !== "undefined") {
         txAnnotation = {
           timestamp: resolvedTime,
           type: "asset-transfer",
@@ -124,7 +124,7 @@ export default class EnrichmentService extends BaseService<Events> {
           recipientAddress: transaction.to, // TODO ingest address
           assetAmount: enrichAssetAmountWithDecimalValues(
             {
-              asset: ETH,
+              asset: network.baseAsset,
               amount: transaction.value,
             },
             desiredDecimals

--- a/background/services/enrichment/index.ts
+++ b/background/services/enrichment/index.ts
@@ -1,9 +1,12 @@
-import { BigNumber } from "ethers"
 import {
   SmartContractFungibleAsset,
   isSmartContractFungibleAsset,
 } from "../../assets"
-import { AnyEVMTransaction, EIP1559TransactionRequest } from "../../networks"
+import {
+  AnyEVMTransaction,
+  EIP1559TransactionRequest,
+  EVMNetwork,
+} from "../../networks"
 import { enrichAssetAmountWithDecimalValues } from "../../redux-slices/utils/asset-utils"
 
 import { ETH } from "../../constants"
@@ -85,6 +88,7 @@ export default class EnrichmentService extends BaseService<Events> {
   }
 
   async resolveTransactionAnnotation(
+    network: EVMNetwork,
     transaction:
       | AnyEVMTransaction
       | (Partial<EIP1559TransactionRequest> & { from: string }),
@@ -134,7 +138,7 @@ export default class EnrichmentService extends BaseService<Events> {
         }
       }
     } else {
-      const assets = await this.indexingService.getCachedAssets()
+      const assets = await this.indexingService.getCachedAssets(network)
 
       // See if the address matches a fungible asset.
       const matchingFungibleAsset = assets.find(
@@ -201,7 +205,7 @@ export default class EnrichmentService extends BaseService<Events> {
 
     // Look up logs and resolve subannotations, if available.
     if ("logs" in transaction && typeof transaction.logs !== "undefined") {
-      const assets = await this.indexingService.getCachedAssets()
+      const assets = await this.indexingService.getCachedAssets(network)
 
       const subannotations = parseLogsForERC20Transfers(
         transaction.logs
@@ -243,12 +247,14 @@ export default class EnrichmentService extends BaseService<Events> {
   }
 
   async enrichTransactionSignature(
+    network: EVMNetwork,
     transaction: Partial<EIP1559TransactionRequest> & { from: string },
     desiredDecimals: number
   ): Promise<EnrichedEVMTransactionSignatureRequest> {
     const enrichedTxSignatureRequest = {
       ...transaction,
       annotation: await this.resolveTransactionAnnotation(
+        network,
         transaction,
         desiredDecimals
       ),
@@ -269,6 +275,7 @@ export default class EnrichmentService extends BaseService<Events> {
     const enrichedTx = {
       ...transaction,
       annotation: await this.resolveTransactionAnnotation(
+        transaction.network,
         transaction,
         desiredDecimals
       ),

--- a/background/services/enrichment/types.ts
+++ b/background/services/enrichment/types.ts
@@ -1,5 +1,5 @@
 import { Network } from "@ethersproject/networks"
-import { AnyAssetAmount } from "../../assets"
+import { AnyAssetAmount, SmartContractFungibleAsset } from "../../assets"
 import { AnyEVMTransaction, EIP1559TransactionRequest } from "../../networks"
 import { AssetDecimalAmount } from "../../redux-slices/utils/asset-utils"
 import { HexString, UNIXTime } from "../../types"
@@ -33,7 +33,7 @@ export type ContractInteraction = BaseTransactionAnnotation & {
 
 export type AssetApproval = BaseTransactionAnnotation & {
   type: "asset-approval"
-  assetAmount: AnyAssetAmount & AssetDecimalAmount
+  assetAmount: AnyAssetAmount<SmartContractFungibleAsset> & AssetDecimalAmount
   spenderAddress: HexString
 }
 

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -20,7 +20,6 @@ import {
   mergeAssets,
   networkAssetsFromLists,
 } from "../../lib/tokenList"
-import { normalizeEVMAddress } from "../../lib/utils"
 import PreferenceService from "../preferences"
 import ChainService from "../chain"
 import { ServiceCreatorFunction, ServiceLifecycleEvents } from "../types"

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -112,7 +112,10 @@ export default class IndexingService extends BaseService<Events> {
     this.connectChainServiceEvents()
 
     // on launch, push any assets we have cached
-    this.emitter.emit("assets", await this.getCachedAssets())
+    this.emitter.emit(
+      "assets",
+      await this.getCachedAssets(this.chainService.ethereumNetwork)
+    )
 
     // ... and kick off token list fetching
     await this.fetchAndCacheTokenLists()
@@ -163,11 +166,9 @@ export default class IndexingService extends BaseService<Events> {
    * @returns An array of assets, including base assets that are "built in" to
    *          the codebase. Fiat currencies are not included.
    */
-  async getCachedAssets(): Promise<AnyAsset[]> {
+  async getCachedAssets(network: EVMNetwork): Promise<AnyAsset[]> {
     const baseAssets = [BTC, ETH]
-    const customAssets = await this.db.getCustomAssetsByNetwork(
-      getEthereumNetwork()
-    )
+    const customAssets = await this.db.getCustomAssetsByNetwork(network)
     const tokenListPrefs =
       await this.preferenceService.getTokenListPreferences()
     const tokenLists = await this.db.getLatestTokenLists(tokenListPrefs.urls)
@@ -175,7 +176,7 @@ export default class IndexingService extends BaseService<Events> {
     return mergeAssets(
       baseAssets,
       customAssets,
-      networkAssetsFromLists(getEthereumNetwork(), tokenLists)
+      networkAssetsFromLists(network, tokenLists)
     )
   }
 
@@ -190,7 +191,7 @@ export default class IndexingService extends BaseService<Events> {
     network: EVMNetwork,
     contractAddress: HexString
   ): Promise<SmartContractFungibleAsset> {
-    const knownAssets = await this.getCachedAssets()
+    const knownAssets = await this.getCachedAssets(network)
     const found = knownAssets.find(
       (asset) =>
         "decimals" in asset &&
@@ -279,7 +280,9 @@ export default class IndexingService extends BaseService<Events> {
         const checkedContractAddresses = new Set(
           balances.map((b) => b.contractAddress).filter(Boolean)
         )
-        const cachedAssets = await this.getCachedAssets()
+        const cachedAssets = await this.getCachedAssets(
+          addressOnNetwork.network
+        )
         const otherActiveAssets = cachedAssets
           .filter(isSmartContractFungibleAsset)
           .filter(
@@ -393,8 +396,8 @@ export default class IndexingService extends BaseService<Events> {
     addressOnNetwork: AddressOnNetwork,
     contractAddress: string
   ): Promise<void> {
-    const knownAssets = await this.getCachedAssets()
     const { network } = addressOnNetwork
+    const knownAssets = await this.getCachedAssets(network)
     const found = knownAssets.find(
       (asset) =>
         "decimals" in asset &&
@@ -547,7 +550,10 @@ export default class IndexingService extends BaseService<Events> {
             )
           }
         }
-        this.emitter.emit("assets", await this.getCachedAssets())
+        this.emitter.emit(
+          "assets",
+          await this.getCachedAssets(this.chainService.ethereumNetwork)
+        )
       })
     )
 

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -415,7 +415,10 @@ export default class IndexingService extends BaseService<Events> {
         const provider = this.chainService.pollingProviders.ethereum
         // pull metadata from Alchemy
         customAsset =
-          (await getTokenMetadata(provider, contractAddress)) || undefined
+          (await getTokenMetadata(provider, {
+            address: contractAddress,
+            network,
+          })) || undefined
 
         if (customAsset) {
           await this.db.addCustomAsset(customAsset)
@@ -574,12 +577,12 @@ export default class IndexingService extends BaseService<Events> {
     await Promise.allSettled(
       (
         await this.chainService.getAccountsToTrack()
-      ).map(async ({ address: account }) => {
+      ).map(async (addressOnNetwork) => {
         // TODO hardcoded to Ethereum
         const balances = await getAssetBalances(
           this.chainService.pollingProviders.ethereum,
           activeAssetsToTrack,
-          account
+          addressOnNetwork
         )
         balances.forEach((ab) => this.emitter.emit("accountBalance", ab))
         await this.db.addBalances(balances)

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -2,7 +2,7 @@ import logger from "../../lib/logger"
 
 import { HexString } from "../../types"
 import { AccountBalance, AddressNetwork } from "../../accounts"
-import { Network } from "../../networks"
+import { EVMNetwork } from "../../networks"
 import {
   AnyAsset,
   CoinGeckoAsset,
@@ -150,7 +150,7 @@ export default class IndexingService extends BaseService<Events> {
    */
   async getLatestAccountBalance(
     account: string,
-    network: Network,
+    network: EVMNetwork,
     asset: FungibleAsset
   ): Promise<AccountBalance | null> {
     return this.db.getLatestAccountBalance(account, network, asset)
@@ -187,7 +187,7 @@ export default class IndexingService extends BaseService<Events> {
    * @param contractAddress - the address of the asset on its home network
    */
   async getKnownSmartContractAsset(
-    network: Network,
+    network: EVMNetwork,
     contractAddress: HexString
   ): Promise<SmartContractFungibleAsset> {
     const knownAssets = await this.getCachedAssets()

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -20,7 +20,7 @@ import {
   mergeAssets,
   networkAssetsFromLists,
 } from "../../lib/tokenList"
-import { getEthereumNetwork, normalizeEVMAddress } from "../../lib/utils"
+import { normalizeEVMAddress } from "../../lib/utils"
 import PreferenceService from "../preferences"
 import ChainService from "../chain"
 import { ServiceCreatorFunction, ServiceLifecycleEvents } from "../types"
@@ -474,7 +474,7 @@ export default class IndexingService extends BaseService<Events> {
     const activeAssetsToTrack = assetsToTrack.filter(
       (asset) =>
         asset.symbol === "ETH" ||
-        asset.homeNetwork.chainID === getEthereumNetwork().chainID
+        asset.homeNetwork.chainID === this.chainService.ethereumNetwork.chainID
     )
 
     try {
@@ -576,7 +576,8 @@ export default class IndexingService extends BaseService<Events> {
     // TODO doesn't support multi-network assets
     // like USDC or CREATE2-based contracts on L1/L2
     const activeAssetsToTrack = assetsToTrack.filter(
-      (asset) => asset.homeNetwork.chainID === getEthereumNetwork().chainID
+      (asset) =>
+        asset.homeNetwork.chainID === this.chainService.ethereumNetwork.chainID
     )
 
     // wait on balances being written to the db, don't wait on event emission

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -284,7 +284,7 @@ export default class IndexingService extends BaseService<Events> {
           .filter(isSmartContractFungibleAsset)
           .filter(
             (a) =>
-              a.homeNetwork.chainID === getEthereumNetwork().chainID &&
+              a.homeNetwork.chainID === addressOnNetwork.network.chainID &&
               !checkedContractAddresses.has(a.contractAddress)
           )
 
@@ -312,11 +312,10 @@ export default class IndexingService extends BaseService<Events> {
           (transaction.status === 1 || transaction.status === 0)
         ) {
           forAccounts.forEach((accountAddress) => {
-            const addressNetwork = {
-              address: normalizeEVMAddress(accountAddress),
-              network: getEthereumNetwork(),
-            }
-            this.chainService.getLatestBaseAccountBalance(addressNetwork)
+            this.chainService.getLatestBaseAccountBalance({
+              address: accountAddress,
+              network: transaction.network,
+            })
           })
         }
       }

--- a/background/services/internal-ethereum-provider/index.ts
+++ b/background/services/internal-ethereum-provider/index.ts
@@ -19,7 +19,6 @@ import {
 import PreferenceService from "../preferences"
 import { internalProviderPort } from "../../redux-slices/utils/contract-utils"
 import { SignTypedDataRequest } from "../../redux-slices/signing"
-import { getEthereumNetwork } from "../../lib/utils"
 
 // A type representing the transaction requests that come in over JSON-RPC
 // requests like eth_sendTransaction and eth_signTransaction. These are very
@@ -111,7 +110,7 @@ export default class InternalEthereumProviderService extends BaseService<Events>
           typedData: JSON.parse(params[1] as string),
         } as SignTypedDataRequest)
       case "eth_chainId":
-        return getEthereumNetwork().chainID
+        return this.chainService.ethereumNetwork.chainID
 
       case "eth_blockNumber":
       case "eth_call":

--- a/background/services/ledger/index.ts
+++ b/background/services/ledger/index.ts
@@ -10,7 +10,11 @@ import {
 } from "@ethersproject/transactions"
 import { TypedDataUtils } from "eth-sig-util"
 import { bufferToHex } from "ethereumjs-util"
-import { EIP1559TransactionRequest, SignedEVMTransaction } from "../../networks"
+import {
+  EIP1559TransactionRequest,
+  EVMNetwork,
+  SignedEVMTransaction,
+} from "../../networks"
 import { EIP712TypedData, HexString } from "../../types"
 import BaseService from "../base"
 import { ServiceCreatorFunction, ServiceLifecycleEvents } from "../types"
@@ -18,8 +22,7 @@ import logger from "../../lib/logger"
 import { getOrCreateDB, LedgerDatabase } from "./db"
 import { ethersTransactionRequestFromEIP1559TransactionRequest } from "../chain/utils"
 import { ETH } from "../../constants"
-import { getEthereumNetwork, normalizeEVMAddress } from "../../lib/utils"
-import { SigningMethod } from "../../redux-slices/signing"
+import { normalizeEVMAddress } from "../../lib/utils"
 
 enum LedgerType {
   UNKNOWN,
@@ -286,6 +289,7 @@ export default class LedgerService extends BaseService<Events> {
   }
 
   async signTransaction(
+    network: EVMNetwork,
     transactionRequest: EIP1559TransactionRequest & { nonce: number },
     deviceID: string,
     path: string
@@ -372,7 +376,7 @@ export default class LedgerService extends BaseService<Events> {
           blockHash: null,
           blockHeight: null,
           asset: ETH,
-          network: getEthereumNetwork(),
+          network,
         }
 
         return signedTx

--- a/background/services/name/index.ts
+++ b/background/services/name/index.ts
@@ -8,7 +8,7 @@ import { ServiceCreatorFunction, ServiceLifecycleEvents } from "../types"
 import BaseService from "../base"
 import ChainService from "../chain"
 import logger from "../../lib/logger"
-import { AddressNetwork } from "../../accounts"
+import { AddressOnNetwork } from "../../accounts"
 import { SECOND } from "../../constants"
 
 type ResolvedAddressRecord = {
@@ -16,14 +16,14 @@ type ResolvedAddressRecord = {
     name: DomainName
   }
   resolved: {
-    addressNetwork: AddressNetwork
+    addressNetwork: AddressOnNetwork
   }
   system: "ENS" | "UNS"
 }
 
 type ResolvedNameRecord = {
   from: {
-    addressNetwork: AddressNetwork
+    addressNetwork: AddressOnNetwork
   }
   resolved: {
     name: DomainName
@@ -34,7 +34,7 @@ type ResolvedNameRecord = {
 
 type ResolvedAvatarRecord = {
   from: {
-    addressNetwork: AddressNetwork
+    addressNetwork: AddressOnNetwork
   }
   resolved: {
     avatar: URL

--- a/background/services/name/index.ts
+++ b/background/services/name/index.ts
@@ -1,5 +1,5 @@
 import { DomainName, HexString, UNIXTime } from "../../types"
-import { Network } from "../../networks"
+import { EVMNetwork } from "../../networks"
 import { normalizeEVMAddress, sameEVMAddress } from "../../lib/utils"
 import { ETHEREUM } from "../../constants/networks"
 import { getTokenMetadata } from "../../lib/erc721"
@@ -180,7 +180,7 @@ export default class NameService extends BaseService<Events> {
 
   async lookUpName(
     address: HexString,
-    network: Network,
+    network: EVMNetwork,
     checkCache = true
   ): Promise<DomainName | undefined> {
     // TODO ENS lookups should work on a few testnets as well
@@ -237,7 +237,7 @@ export default class NameService extends BaseService<Events> {
 
   async lookUpAvatar(
     address: HexString,
-    network: Network
+    network: EVMNetwork
   ): Promise<URL | undefined> {
     // TODO ENS lookups should work on a few testnets as well
     if (network.chainID !== "1") {

--- a/background/services/preferences/db.ts
+++ b/background/services/preferences/db.ts
@@ -1,7 +1,7 @@
 import Dexie, { Transaction } from "dexie"
 
 import { FiatCurrency } from "../../assets"
-import { AddressNetwork } from "../../accounts"
+import { AddressOnNetwork } from "../../accounts"
 
 import DEFAULT_PREFERENCES from "./defaults"
 
@@ -14,7 +14,7 @@ export interface Preferences {
   currency: FiatCurrency
   defaultWallet: boolean
   currentAddress?: string
-  selectedAccount: AddressNetwork
+  selectedAccount: AddressOnNetwork
 }
 
 export class PreferenceDatabase extends Dexie {
@@ -104,7 +104,7 @@ export class PreferenceDatabase extends Dexie {
     await this.preferences.toCollection().modify({ defaultWallet })
   }
 
-  async setSelectedAccount(addressNetwork: AddressNetwork): Promise<void> {
+  async setSelectedAccount(addressNetwork: AddressOnNetwork): Promise<void> {
     await this.preferences
       .toCollection()
       .modify({ selectedAccount: addressNetwork })

--- a/background/services/preferences/index.ts
+++ b/background/services/preferences/index.ts
@@ -1,5 +1,5 @@
 import { FiatCurrency } from "../../assets"
-import { AddressNetwork } from "../../accounts"
+import { AddressOnNetwork } from "../../accounts"
 import { ServiceLifecycleEvents, ServiceCreatorFunction } from "../types"
 
 import { Preferences, TokenListPreferences } from "./types"
@@ -9,7 +9,7 @@ import BaseService from "../base"
 interface Events extends ServiceLifecycleEvents {
   preferencesChanges: Preferences
   initializeDefaultWallet: boolean
-  initializeSelectedAccount: AddressNetwork
+  initializeSelectedAccount: AddressOnNetwork
 }
 
 /*
@@ -64,11 +64,11 @@ export default class PreferenceService extends BaseService<Events> {
     return this.db.setDefaultWalletValue(newDefaultWalletValue)
   }
 
-  async getSelectedAccount(): Promise<AddressNetwork> {
+  async getSelectedAccount(): Promise<AddressOnNetwork> {
     return (await this.db.getPreferences())?.selectedAccount
   }
 
-  async setSelectedAccount(addressNetwork: AddressNetwork): Promise<void> {
+  async setSelectedAccount(addressNetwork: AddressOnNetwork): Promise<void> {
     return this.db.setSelectedAccount(addressNetwork)
   }
 }

--- a/background/services/preferences/types.ts
+++ b/background/services/preferences/types.ts
@@ -1,5 +1,5 @@
 import { FiatCurrency } from "../../assets"
-import { AddressNetwork } from "../../accounts"
+import { AddressOnNetwork } from "../../accounts"
 
 export interface TokenListPreferences {
   autoUpdate: boolean
@@ -10,5 +10,5 @@ export interface Preferences {
   tokenLists: TokenListPreferences
   currency: FiatCurrency
   defaultWallet: boolean
-  selectedAccount: AddressNetwork
+  selectedAccount: AddressOnNetwork
 }

--- a/background/tests/keyring-integration.test.ts
+++ b/background/tests/keyring-integration.test.ts
@@ -10,6 +10,7 @@ import KeyringService, {
 } from "../services/keyring"
 import { KeyringTypes } from "../types"
 import { EIP1559TransactionRequest } from "../networks"
+import { ETHEREUM } from "../constants"
 
 const originalCrypto = global.crypto
 beforeEach(() => {
@@ -108,7 +109,10 @@ describe("KeyringService when uninitialized", () => {
 
     it("won't sign transactions", async () => {
       await expect(
-        service.signTransaction("0x0", validTransactionRequests.simple)
+        service.signTransaction(
+          { address: "0x0", network: ETHEREUM },
+          validTransactionRequests.simple
+        )
       ).rejects.toThrow("KeyringService must be unlocked.")
     })
   })
@@ -227,7 +231,10 @@ describe("KeyringService when initialized", () => {
     }
 
     await expect(
-      service.signTransaction(address, transactionWithFrom)
+      service.signTransaction(
+        { address, network: ETHEREUM },
+        transactionWithFrom
+      )
     ).resolves.toMatchObject({
       from: expect.stringMatching(new RegExp(address, "i")), // case insensitive match
       r: expect.anything(),
@@ -252,7 +259,10 @@ describe("KeyringService when initialized", () => {
     expect(goodUnlockResult).toEqual(true)
 
     await expect(
-      service.signTransaction(address, transactionWithFrom)
+      service.signTransaction(
+        { address, network: ETHEREUM },
+        transactionWithFrom
+      )
     ).resolves.toBeDefined()
   })
 })
@@ -441,7 +451,10 @@ describe("Keyring service when autolocking", () => {
           from: address,
         }
 
-        await service.signTransaction(address, transactionWithFrom)
+        await service.signTransaction(
+          { address, network: ETHEREUM },
+          transactionWithFrom
+        )
       },
     },
     {

--- a/ui/components/NetworkFees/NetworkSettingsSelect.tsx
+++ b/ui/components/NetworkFees/NetworkSettingsSelect.tsx
@@ -51,7 +51,6 @@ const gasOptionFromEstimate = (
   }
 
   const feeAssetAmount =
-    typeof mainCurrencyPricePoint !== "undefined" &&
     typeof gasLimit !== "undefined"
       ? enrichAssetAmountWithMainCurrencyValues(
           {

--- a/ui/components/SignTransaction/SignTransactionInfoBaseProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionInfoBaseProvider.tsx
@@ -1,5 +1,5 @@
 import { EIP1559TransactionRequest } from "@tallyho/tally-background/networks"
-import { TransactionDescription } from "ethers/lib/utils"
+import { TransactionAnnotation } from "@tallyho/tally-background/services/enrichment"
 import { ReactElement, ReactNode } from "react"
 
 export interface SignTransactionInfo {
@@ -9,9 +9,13 @@ export interface SignTransactionInfo {
   confirmButtonLabel: ReactNode
 }
 
-export interface SignTransactionInfoProviderProps {
+export interface SignTransactionInfoProviderProps<
+  T extends TransactionAnnotation | undefined =
+    | TransactionAnnotation
+    | undefined
+> {
   transactionDetails: EIP1559TransactionRequest
-  parsedTx: TransactionDescription | undefined
+  annotation: T
   inner: (info: SignTransactionInfo) => ReactElement
 }
 

--- a/ui/components/SignTransaction/SignTransactionSpendAssetInfoProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionSpendAssetInfoProvider.tsx
@@ -4,6 +4,7 @@ import {
   getERC20TokenMetadata,
 } from "@tallyho/tally-background/lib/erc20"
 import {
+  getEthereumNetwork,
   getNumericStringValueFromBigNumber,
   isMaxUint256,
   numberTo32BytesHex,
@@ -36,9 +37,10 @@ export default function SignTransactionSpendAssetInfoProvider({
 
   useEffect(() => {
     const getTokenData = async () => {
-      const tokenMetadata = await getERC20TokenMetadata(
-        transactionDetails.to || ""
-      )
+      const tokenMetadata = await getERC20TokenMetadata({
+        address: transactionDetails.to || "",
+        network: getEthereumNetwork(),
+      })
       setAsset(tokenMetadata)
     }
     getTokenData()

--- a/ui/components/SignTransaction/SignTransactionSpendAssetInfoProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionSpendAssetInfoProvider.tsx
@@ -1,16 +1,20 @@
-import { SmartContractFungibleAsset } from "@tallyho/tally-background/assets"
 import {
+  ERC20_FUNCTIONS,
   ERC20_INTERFACE,
-  getERC20TokenMetadata,
 } from "@tallyho/tally-background/lib/erc20"
 import {
-  getEthereumNetwork,
-  getNumericStringValueFromBigNumber,
+  convertFixedPointNumber,
+  fixedPointNumberToString,
+  parseToFixedPointNumber,
+} from "@tallyho/tally-background/lib/fixed-point"
+import {
   isMaxUint256,
-  numberTo32BytesHex,
   truncateAddress,
 } from "@tallyho/tally-background/lib/utils"
 import { updateTransactionOptions } from "@tallyho/tally-background/redux-slices/transaction-construction"
+import { AssetApproval } from "@tallyho/tally-background/services/enrichment"
+import { ethers } from "ethers"
+import { hexlify } from "ethers/lib/utils"
 import React, { ReactElement, useEffect, useState } from "react"
 import { useDispatch } from "react-redux"
 import FeeSettingsText from "../NetworkFees/FeeSettingsText"
@@ -27,47 +31,64 @@ import SignTransactionBaseInfoProvider, {
 
 export default function SignTransactionSpendAssetInfoProvider({
   transactionDetails,
-  parsedTx,
+  annotation,
   inner,
-}: SignTransactionInfoProviderProps): ReactElement {
+}: SignTransactionInfoProviderProps<AssetApproval>): ReactElement {
   const [approvalLimit, setApprovalLimit] = useState("")
   const dispatch = useDispatch()
-  const [asset, setAsset] = useState<SmartContractFungibleAsset | null>()
+  const {
+    assetAmount: { asset, amount: approveAmount },
+    spenderAddress,
+  } = annotation
   const [changing, setChanging] = useState(false)
-
-  useEffect(() => {
-    const getTokenData = async () => {
-      const tokenMetadata = await getERC20TokenMetadata({
-        address: transactionDetails.to || "",
-        network: getEthereumNetwork(),
-      })
-      setAsset(tokenMetadata)
-    }
-    getTokenData()
-  }, [transactionDetails.to])
-
-  const approveAmount = parsedTx?.args[1]
 
   const infiniteApproval = isMaxUint256(approveAmount ?? 0n)
 
   useEffect(() => {
-    if (approveAmount && asset?.decimals) {
-      setApprovalLimit(
-        getNumericStringValueFromBigNumber(approveAmount, asset?.decimals)
-      )
-    }
+    setApprovalLimit(
+      isMaxUint256(approveAmount)
+        ? "Infinite"
+        : fixedPointNumberToString({
+            amount: approveAmount,
+            decimals: asset.decimals,
+          })
+    )
   }, [approveAmount, asset?.decimals])
 
   const handleUpdateClick = () => {
     setChanging(!changing)
-    if (changing && transactionDetails && parsedTx && asset?.decimals) {
-      const updatedInput = ERC20_INTERFACE.encodeFunctionData(parsedTx?.name, [
-        parsedTx.args[0],
-        numberTo32BytesHex(approvalLimit, asset?.decimals),
-      ])
-      const newTxDetails = { ...transactionDetails }
-      newTxDetails.input = updatedInput
-      dispatch(updateTransactionOptions(newTxDetails))
+    if (changing) {
+      const parsedApprovalAmount = parseToFixedPointNumber(approvalLimit) ?? {
+        amount: 0n,
+        decimals: 0,
+      }
+      const assetMatchedApprovalAmount = convertFixedPointNumber(
+        parsedApprovalAmount,
+        asset.decimals
+      )
+      const approvalLimitBigInt =
+        approvalLimit.match(/infinit[ey]/i) ||
+        (parsedApprovalAmount.decimals === 0 &&
+          isMaxUint256(parsedApprovalAmount.amount))
+          ? ethers.constants.MaxUint256.toBigInt()
+          : assetMatchedApprovalAmount.amount
+
+      // This will replace any bad inputs with the parsed number that is sent
+      // to the backend. Mostly useful if the approval amount was 0 and becomes
+      // 0 again due to bad input, since otherwise the amount is considered
+      // "unchanged".
+      setApprovalLimit(fixedPointNumberToString(assetMatchedApprovalAmount))
+
+      const updatedInput = ERC20_INTERFACE.encodeFunctionData(
+        ERC20_FUNCTIONS.approve,
+        [spenderAddress, hexlify(approvalLimitBigInt)]
+      )
+      dispatch(
+        updateTransactionOptions({
+          ...transactionDetails,
+          input: updatedInput,
+        })
+      )
     }
   }
 
@@ -80,46 +101,44 @@ export default function SignTransactionSpendAssetInfoProvider({
           <div className="spend_destination_icons">
             <div className="site_icon" />
             <div className="asset_icon_wrap">
-              <SharedAssetIcon size="large" symbol={asset?.symbol ?? ""} />
+              <SharedAssetIcon size="large" symbol={asset.symbol} />
             </div>
           </div>
           <span className="site">Smart Contract Interaction</span>
           <span className="spending_label">
-            {asset?.symbol ? (
+            {asset.symbol ? (
               `Spend ${
-                asset?.symbol ?? truncateAddress(transactionDetails.to ?? "")
+                asset.symbol ?? truncateAddress(transactionDetails.to ?? "")
               } tokens`
             ) : (
               <SharedSkeletonLoader />
             )}
           </span>
-          <span className="speed_limit_label">Spend limit</span>
-          {changing ? (
-            <div>
-              <SharedInput
-                label=""
-                value={approvalLimit}
-                onChange={setApprovalLimit}
-              />
-            </div>
-          ) : (
-            <span className="spend_amount">
-              {asset?.symbol ? (
-                `${
-                  infiniteApproval ? "Infinite" : approvalLimit
-                } ${asset?.symbol.toUpperCase()}`
-              ) : (
-                <SharedSkeletonLoader />
-              )}
-            </span>
-          )}
-          <SharedButton
-            size="small"
-            type="tertiary"
-            onClick={handleUpdateClick}
-          >
-            {changing ? "Update spend limit" : "Change limit"}
-          </SharedButton>
+          <form onSubmit={(event) => event.preventDefault()}>
+            <span className="speed_limit_label">Spend limit</span>
+            {changing ? (
+              <div>
+                <SharedInput
+                  label=""
+                  value={approvalLimit}
+                  onChange={setApprovalLimit}
+                />
+              </div>
+            ) : (
+              <span className="spend_amount">
+                {infiniteApproval ? "Infinite" : approvalLimit}{" "}
+                {asset?.symbol.toUpperCase()}
+              </span>
+            )}
+            <SharedButton
+              size="small"
+              isFormSubmit
+              type="tertiary"
+              onClick={handleUpdateClick}
+            >
+              {changing ? "Update spend limit" : "Change limit"}
+            </SharedButton>
+          </form>
           <div className="spacer" />
           <style jsx>
             {`

--- a/ui/components/SignTransaction/SignTransactionTransferInfoProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionTransferInfoProvider.tsx
@@ -2,7 +2,15 @@ import {
   truncateAddress,
   truncateDecimalAmount,
 } from "@tallyho/tally-background/lib/utils"
+import { selectAssetPricePoint } from "@tallyho/tally-background/redux-slices/assets"
+import {
+  getAssetsState,
+  selectMainCurrencySymbol,
+} from "@tallyho/tally-background/redux-slices/selectors"
+import { enrichAssetAmountWithMainCurrencyValues } from "@tallyho/tally-background/redux-slices/utils/asset-utils"
+import { TransactionAnnotation } from "@tallyho/tally-background/services/enrichment"
 import React, { ReactElement } from "react"
+import { useBackgroundSelector } from "../../hooks"
 import FeeSettingsText from "../NetworkFees/FeeSettingsText"
 import TransactionDetailAddressValue from "../TransactionDetail/TransactionDetailAddressValue"
 import TransactionDetailContainer from "../TransactionDetail/TransactionDetailContainer"
@@ -12,17 +20,23 @@ import SignTransactionBaseInfoProvider, {
 } from "./SignTransactionInfoBaseProvider"
 
 export default function SignTransactionTransferInfoProvider({
-  token,
-  amount,
-  destination,
-  localizedValue,
+  transactionDetails,
+  annotation: { assetAmount, recipientAddress },
   inner,
 }: SignTransactionInfoProviderProps & {
-  token: string
-  amount: number
-  destination: string
-  localizedValue: string | number
+  annotation: TransactionAnnotation & { type: "asset-transfer" }
 }): ReactElement {
+  const assets = useBackgroundSelector(getAssetsState)
+  const mainCurrencySymbol = useBackgroundSelector(selectMainCurrencySymbol)
+  const assetPricePoint = selectAssetPricePoint(
+    assets,
+    assetAmount.asset.symbol,
+    mainCurrencySymbol
+  )
+  const localizedMainCurrencyAmount =
+    enrichAssetAmountWithMainCurrencyValues(assetAmount, assetPricePoint, 2)
+      .localizedMainCurrencyAmount ?? "-"
+
   return (
     <SignTransactionBaseInfoProvider
       title="Sign Transfer"
@@ -31,15 +45,15 @@ export default function SignTransactionTransferInfoProvider({
         <div className="sign_block">
           <div className="container">
             <div className="label">Send to</div>
-            <div className="send_to">{truncateAddress(destination)}</div>
+            <div className="send_to">{truncateAddress(recipientAddress)}</div>
           </div>
           <div className="divider" />
           <div className="container">
             <span className="label">Spend Amount</span>
             <span className="spend_amount">
-              {truncateDecimalAmount(amount, 4)} {token}
+              {assetAmount.localizedDecimalAmount} {assetAmount.asset.symbol}
             </span>
-            <span className="label">{`$${localizedValue}`}</span>
+            <span className="label">${`${localizedMainCurrencyAmount}`}</span>
           </div>
 
           <style jsx>
@@ -95,13 +109,18 @@ export default function SignTransactionTransferInfoProvider({
             name="Spend amount"
             value={
               <>
-                {truncateDecimalAmount(amount, 4)} {token}
+                {truncateDecimalAmount(assetAmount.decimalAmount, 4)}{" "}
+                {assetAmount.asset.symbol}
               </>
             }
           />
           <TransactionDetailItem
             name="To:"
-            value={<TransactionDetailAddressValue address={destination} />}
+            value={
+              <TransactionDetailAddressValue
+                address={transactionDetails.to ?? "-"}
+              />
+            }
           />
         </TransactionDetailContainer>
       }

--- a/ui/pages/Send.tsx
+++ b/ui/pages/Send.tsx
@@ -3,6 +3,7 @@ import { isAddress } from "@ethersproject/address"
 import {
   selectCurrentAccount,
   selectCurrentAccountBalances,
+  selectMainCurrencySymbol,
 } from "@tallyho/tally-background/redux-slices/selectors"
 import {
   broadcastOnSign,
@@ -39,10 +40,9 @@ export default function Send(): ReactElement {
   const estimatedFeesPerGas = useBackgroundSelector(selectEstimatedFeesPerGas)
 
   const dispatch = useBackgroundDispatch()
-
   const currentAccount = useBackgroundSelector(selectCurrentAccount)
-
   const balanceData = useBackgroundSelector(selectCurrentAccountBalances)
+  const mainCurrencySymbol = useBackgroundSelector(selectMainCurrencySymbol)
 
   const { assetAmounts } = balanceData ?? {
     assetAmounts: [],

--- a/ui/pages/Send.tsx
+++ b/ui/pages/Send.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useState } from "react"
+import React, { ReactElement, useState } from "react"
 import { isAddress } from "@ethersproject/address"
 import {
   selectCurrentAccount,
@@ -13,23 +13,28 @@ import {
   updateTransactionOptions,
 } from "@tallyho/tally-background/redux-slices/transaction-construction"
 import { utils } from "ethers"
-import { useLocation } from "react-router-dom"
+import {
+  FungibleAsset,
+  isFungibleAssetAmount,
+} from "@tallyho/tally-background/assets"
+import { ETH } from "@tallyho/tally-background/constants"
+import {
+  convertFixedPointNumber,
+  parseToFixedPointNumber,
+} from "@tallyho/tally-background/lib/fixed-point"
+import { selectAssetPricePoint } from "@tallyho/tally-background/redux-slices/assets"
+import { CompleteAssetAmount } from "@tallyho/tally-background/redux-slices/accounts"
+import { enrichAssetAmountWithMainCurrencyValues } from "@tallyho/tally-background/redux-slices/utils/asset-utils"
 import NetworkSettingsChooser from "../components/NetworkFees/NetworkSettingsChooser"
 import SharedAssetInput from "../components/Shared/SharedAssetInput"
 import SharedBackButton from "../components/Shared/SharedBackButton"
 import SharedButton from "../components/Shared/SharedButton"
 import { useBackgroundDispatch, useBackgroundSelector } from "../hooks"
-import { SignType } from "./SignTransaction"
 import SharedSlideUpMenu from "../components/Shared/SharedSlideUpMenu"
 import FeeSettingsButton from "../components/NetworkFees/FeeSettingsButton"
 
 export default function Send(): ReactElement {
-  const location = useLocation<{ symbol: string }>()
-
-  const [assetSymbol, setAssetSymbol] = useState(
-    location?.state?.symbol || "ETH"
-  )
-  const [selectedCount, setSelectedCount] = useState(0)
+  const [selectedAsset, setSelectedAsset] = useState<FungibleAsset>(ETH)
   const [destinationAddress, setDestinationAddress] = useState("")
   const [amount, setAmount] = useState("")
   const [gasLimit, setGasLimit] = useState("")
@@ -44,21 +49,42 @@ export default function Send(): ReactElement {
   const balanceData = useBackgroundSelector(selectCurrentAccountBalances)
   const mainCurrencySymbol = useBackgroundSelector(selectMainCurrencySymbol)
 
-  const { assetAmounts } = balanceData ?? {
-    assetAmounts: [],
+  const fungibleAssetAmounts =
+    // Only look at fungible assets.
+    balanceData?.assetAmounts?.filter(
+      (assetAmount): assetAmount is CompleteAssetAmount<FungibleAsset> =>
+        isFungibleAssetAmount(assetAmount)
+    )
+  const assetPricePoint = useBackgroundSelector((state) =>
+    selectAssetPricePoint(
+      state.assets,
+      selectedAsset.symbol,
+      mainCurrencySymbol
+    )
+  )
+
+  const assetAmountFromForm = () => {
+    const fixedPointAmount = parseToFixedPointNumber(amount.toString())
+    if (typeof fixedPointAmount === "undefined") {
+      return undefined
+    }
+
+    const decimalMatched = convertFixedPointNumber(
+      fixedPointAmount,
+      selectedAsset.decimals
+    )
+
+    return enrichAssetAmountWithMainCurrencyValues(
+      {
+        asset: selectedAsset,
+        amount: decimalMatched.amount,
+      },
+      assetPricePoint,
+      2
+    )
   }
 
-  // FIXME Rework this to use selectAssetPricePoint and
-  // FIXME convertAssetAmountViaPricePoint.
-  const getTotalLocalizedValue = () => {
-    const pricePerUnit = assetAmounts.find(
-      (el) => el.asset.symbol === assetSymbol
-    )?.unitPrice
-    if (pricePerUnit) {
-      return (Number(amount) * pricePerUnit).toFixed(2)
-    }
-    return 0
-  }
+  const assetAmount = assetAmountFromForm()
 
   const sendTransactionRequest = async () => {
     dispatch(broadcastOnSign(true))
@@ -71,12 +97,6 @@ export default function Send(): ReactElement {
     }
     return dispatch(updateTransactionOptions(transaction))
   }
-
-  useEffect(() => {
-    if (assetSymbol) {
-      setSelectedCount(1)
-    }
-  }, [assetSymbol])
 
   const networkSettingsSaved = (networkSetting: NetworkFeeSettings) => {
     setGasLimit(networkSetting.gasLimit)
@@ -98,10 +118,8 @@ export default function Send(): ReactElement {
           <div className="form_input">
             <SharedAssetInput
               label="Asset / Amount"
-              onAssetSelect={(token) => {
-                setAssetSymbol(token.symbol)
-              }}
-              assetsAndAmounts={assetAmounts}
+              onAssetSelect={setSelectedAsset}
+              assetsAndAmounts={fungibleAssetAmounts}
               onAmountChange={(value, errorMessage) => {
                 setAmount(value)
                 if (errorMessage) {
@@ -110,11 +128,13 @@ export default function Send(): ReactElement {
                   setHasError(false)
                 }
               }}
-              selectedAsset={{ symbol: assetSymbol, name: assetSymbol }}
+              selectedAsset={selectedAsset}
               amount={amount}
               disableDropdown
             />
-            <div className="value">${getTotalLocalizedValue()}</div>
+            <div className="value">
+              ${assetAmount?.localizedMainCurrencyAmount ?? "-"}
+            </div>
           </div>
           <div className="form_input send_to_field">
             <label htmlFor="send_address">Send To:</label>
@@ -149,7 +169,6 @@ export default function Send(): ReactElement {
               type="primary"
               size="large"
               isDisabled={
-                selectedCount <= 0 ||
                 Number(amount) === 0 ||
                 !isAddress(destinationAddress) ||
                 hasError
@@ -157,11 +176,10 @@ export default function Send(): ReactElement {
               linkTo={{
                 pathname: "/signTransaction",
                 state: {
-                  assetSymbol,
-                  amount,
-                  to: destinationAddress,
-                  signType: SignType.SignTransfer,
-                  value: getTotalLocalizedValue(),
+                  redirectTo: {
+                    path: "/singleAsset",
+                    state: { symbol: selectedAsset.symbol },
+                  },
                 },
               }}
               onClick={sendTransactionRequest}

--- a/ui/pages/SignTransaction.tsx
+++ b/ui/pages/SignTransaction.tsx
@@ -16,17 +16,17 @@ import {
   useAreKeyringsUnlocked,
 } from "../hooks"
 import SignTransactionContainer from "../components/SignTransaction/SignTransactionContainer"
-import SignTransactionInfoProvider, {
-  SignLocationState,
-} from "../components/SignTransaction/SignTransactionInfoProvider"
+import SignTransactionInfoProvider from "../components/SignTransaction/SignTransactionInfoProvider"
 import { useSigningLedgerState } from "../components/SignTransaction/useSigningLedgerState"
-
-export { SignType } from "../components/SignTransaction/SignTransactionInfoProvider"
 
 export default function SignTransaction({
   location,
 }: {
-  location: { key?: string; pathname: string; state?: SignLocationState }
+  location: {
+    key?: string
+    pathname: string
+    state?: { redirectTo: { path: string; state: unknown } }
+  }
 }): ReactElement {
   const history = useHistory()
   const dispatch = useBackgroundDispatch()
@@ -70,10 +70,12 @@ export default function SignTransaction({
         dispatch(broadcastSignedTransaction(signedTransaction))
       }
 
-      const assetSymbol = location.state?.assetSymbol
       // Request broadcast if not dApp...
-      if (typeof assetSymbol !== "undefined") {
-        history.push("/singleAsset", { symbol: assetSymbol })
+      if (typeof location.state !== "undefined") {
+        history.push(
+          location.state.redirectTo.path,
+          location.state.redirectTo.state
+        )
       } else {
         history.goBack()
       }
@@ -84,7 +86,7 @@ export default function SignTransaction({
     isTransactionSigned,
     isTransactionSigning,
     isWaitingForKeyrings,
-    location.state?.assetSymbol,
+    location.state,
     shouldBroadcastOnSign,
     signedTransaction,
   ])
@@ -134,7 +136,7 @@ export default function SignTransaction({
   const isWaitingForHardware = isLedgerSigning && isTransactionSigning
 
   return (
-    <SignTransactionInfoProvider location={location}>
+    <SignTransactionInfoProvider>
       {({ title, infoBlock, textualInfoBlock, confirmButtonLabel }) => (
         <SignTransactionContainer
           signerAccountTotal={signerAccountTotal}


### PR DESCRIPTION
The refactors here are light and shouldn't change any behavior;
instead, they push most of the current-network management into
`ChainService`, where it can be refactored from a central location
rather than having a global `getEthereumNetwork` function that has
to be targeted piecewise. Based extensively on work in #732.

### Testing

Testing here should just be that everything works roughly as expected
across the board. Again, behavioral changes are expected to be minimal.