### PR TITLE
🌒 Update slide up menu to always have clickable backdrop

### DIFF
--- a/ui/components/Shared/SharedSlideUpMenu.tsx
+++ b/ui/components/Shared/SharedSlideUpMenu.tsx
@@ -1,6 +1,6 @@
+import React, { ReactElement, CSSProperties, useRef } from "react"
 import classNames from "classnames"
-import React, { ReactElement, useState, useEffect, CSSProperties } from "react"
-import { useDelayContentChange } from "../../hooks"
+import { useDelayContentChange, useOnClickOutside } from "../../hooks"
 
 export type SharedSlideUpMenuSize =
   | "auto"
@@ -17,7 +17,6 @@ interface Props {
   children: React.ReactNode
   customSize?: string
   size: SharedSlideUpMenuSize
-  showOverlay?: boolean
   alwaysRenderChildren?: boolean
 }
 
@@ -30,15 +29,12 @@ const menuHeights: Record<SharedSlideUpMenuSize, string | null> = {
 }
 
 export default function SharedSlideUpMenu(props: Props): ReactElement {
-  const {
-    isOpen,
-    close,
-    size,
-    children,
-    customSize,
-    showOverlay,
-    alwaysRenderChildren,
-  } = props
+  const { isOpen, close, size, children, customSize, alwaysRenderChildren } =
+    props
+
+  const ref = useRef(null)
+
+  useOnClickOutside(ref, close)
 
   // Continue showing children during the close transition.
   const visibleChildren = isOpen || alwaysRenderChildren ? children : <></>
@@ -52,15 +48,14 @@ export default function SharedSlideUpMenu(props: Props): ReactElement {
 
   return (
     <>
-      {showOverlay && (
-        <div className={classNames("overlay", { closed: !isOpen })} />
-      )}
+      <div className={classNames("overlay", { closed: !isOpen })} />
       <div
         className={classNames("slide_up_menu", {
           large: size === "large",
           closed: !isOpen,
         })}
         style={{ "--menu-height": menuHeight } as CSSProperties}
+        ref={isOpen ? ref : null}
       >
         <button
           type="button"
@@ -97,9 +92,10 @@ export default function SharedSlideUpMenu(props: Props): ReactElement {
             right: 0;
             bottom: 0;
             top: 0;
+            cursor: pointer;
             z-index: 998;
-            background: var(--hunter-green);
-            opacity: 0.8;
+            background: var(--green-120);
+            opacity: 0.7;
             transition: opacity cubic-bezier(0.19, 1, 0.22, 1) 0.445s,
               visiblity 0.445s;
           }

--- a/ui/components/Shared/SharedSlideUpMenu.tsx
+++ b/ui/components/Shared/SharedSlideUpMenu.tsx
@@ -32,9 +32,9 @@ export default function SharedSlideUpMenu(props: Props): ReactElement {
   const { isOpen, close, size, children, customSize, alwaysRenderChildren } =
     props
 
-  const ref = useRef(null)
+  const slideUpMenuRef = useRef(null)
 
-  useOnClickOutside(ref, close)
+  useOnClickOutside(slideUpMenuRef, close)
 
   // Continue showing children during the close transition.
   const visibleChildren = isOpen || alwaysRenderChildren ? children : <></>
@@ -55,7 +55,7 @@ export default function SharedSlideUpMenu(props: Props): ReactElement {
           closed: !isOpen,
         })}
         style={{ "--menu-height": menuHeight } as CSSProperties}
-        ref={isOpen ? ref : null}
+        ref={isOpen ? slideUpMenuRef : null}
       >
         <button
           type="button"

--- a/ui/components/SignTransaction/SignTransactionContainer.tsx
+++ b/ui/components/SignTransaction/SignTransactionContainer.tsx
@@ -84,7 +84,6 @@ export default function SignTransactionContainer({
         close={() => {
           setSlideUpOpen(false)
         }}
-        showOverlay
         alwaysRenderChildren
         size="auto"
       >


### PR DESCRIPTION
Per Vlad's instructions during our UI sync

<img width="302" alt="slide_menu" src="https://user-images.githubusercontent.com/1918798/154173093-d9b4612f-5b32-4b69-a547-89a0dad45c78.gif">

Closes #999

⚠️ Haven't written a proper description here yet