### PR TITLE
Remove .only's and fix broken integration tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
     "plugin:@typescript-eslint/recommended",
     "plugin:prettier/recommended",
   ],
+  plugins: ["no-only-tests"],
   globals: {
     document: "readonly",
     window: "readonly",
@@ -52,6 +53,8 @@ module.exports = {
       "error",
       { devDependencies: ["!+(src/api|ui)/**/*.+(ts|js)"] },
     ],
+    // dissalow it.only, assert.only, etc..
+    "no-only-tests/no-only-tests": ["error"],
     // Add known-safe exceptions to no-param-reassign.
     "no-param-reassign": [
       airbnbNoParamReassignRules[0],

--- a/background/services/keyring/index.ts
+++ b/background/services/keyring/index.ts
@@ -299,6 +299,8 @@ export default class KeyringService extends BaseService<Events> {
    * used outside the extension.
    */
   getKeyrings(): Keyring[] {
+    this.requireUnlocked()
+
     return this.#keyrings.map((kr) => ({
       // TODO this type is meanlingless from the library's perspective.
       // Reconsider, or explicitly track which keyrings have been generated vs
@@ -449,8 +451,12 @@ export default class KeyringService extends BaseService<Events> {
   // //////////////////
 
   private emitKeyrings() {
-    const keyrings = this.getKeyrings()
-    this.emitter.emit("keyrings", keyrings)
+    if (this.locked()) {
+      this.emitter.emit("keyrings", [])
+    } else {
+      const keyrings = this.getKeyrings()
+      this.emitter.emit("keyrings", keyrings)
+    }
   }
 
   /**

--- a/background/services/keyring/index.ts
+++ b/background/services/keyring/index.ts
@@ -131,7 +131,7 @@ export default class KeyringService extends BaseService<Events> {
     password: string,
     ignoreExistingVaults = false
   ): Promise<boolean> {
-    if (this.locked() === false) {
+    if (!this.locked()) {
       throw new Error("KeyringService is already unlocked!")
     }
 

--- a/background/tests/keyring-integration.test.ts
+++ b/background/tests/keyring-integration.test.ts
@@ -196,7 +196,7 @@ describe("KeyringService when initialized", () => {
     })
   })
 
-  it.only("will derive a new address", async () => {
+  it("will derive a new address", async () => {
     const [
       {
         id,
@@ -334,7 +334,7 @@ describe("KeyringService when saving keyrings", () => {
     })
   })
 
-  it.only("loads encrypted data at instantiation time", async () => {
+  it("loads encrypted data at instantiation time", async () => {
     localStorage = {
       tallyVaults: {
         version: 1,

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "dotenv-defaults": "^2.0.2",
     "dotenv-webpack": "^7.0.3",
     "eslint": "^7.28.0",
+    "eslint-plugin-no-only-tests": "^2.6.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-airbnb-typescript": "^14.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5161,6 +5161,11 @@ eslint-plugin-jsx-a11y@^6.4.1:
     jsx-ast-utils "^3.1.0"
     language-tags "^1.0.5"
 
+eslint-plugin-no-only-tests@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz#19f6c9620bda02b9b9221b436c5f070e42628d76"
+  integrity sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==
+
 eslint-plugin-prettier@^3.4.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz#e9ddb200efb6f3d05ffe83b1665a716af4a387e5"


### PR DESCRIPTION
This PR remotes two `it.only`'s from keyring-integration.test.ts and configured our linter to throw an error if it detects a `.only` test block.  I went into this PR with the assumption that the inactive tests were written correctly but underlying behavior had changed while they were inactive - so went with the route of changing the code to match the tests although it is certainly possible that the tests themselves need to change as well.