### PR TITLE
Balance in All Things: Show Address-specific balances in Swap page

### DIFF
--- a/background/redux-slices/accounts.ts
+++ b/background/redux-slices/accounts.ts
@@ -70,7 +70,7 @@ export type CompleteAssetAmount<
   T extends AnyAssetAmount<E> = AnyAssetAmount<E>
 > = T & AssetMainCurrencyAmount & AssetDecimalAmount
 
-export type SmartContractFungibleCompleteAssetAmount = CompleteAssetAmount<
+export type CompleteSmartContractFungibleAssetAmount = CompleteAssetAmount<
   SmartContractFungibleAsset,
   AnyAssetAmount<SmartContractFungibleAsset>
 >

--- a/background/redux-slices/accounts.ts
+++ b/background/redux-slices/accounts.ts
@@ -2,7 +2,7 @@ import { createSlice } from "@reduxjs/toolkit"
 import { createBackgroundAsyncThunk } from "./utils"
 import { AccountBalance, AddressNetwork, NameNetwork } from "../accounts"
 import { AnyEVMBlock, Network } from "../networks"
-import { AnyAsset, AnyAssetAmount } from "../assets"
+import { AnyAsset, AnyAssetAmount, SmartContractFungibleAsset } from "../assets"
 import {
   AssetMainCurrencyAmount,
   AssetDecimalAmount,
@@ -69,6 +69,11 @@ export type CompleteAssetAmount<
   E extends AnyAsset = AnyAsset,
   T extends AnyAssetAmount<E> = AnyAssetAmount<E>
 > = T & AssetMainCurrencyAmount & AssetDecimalAmount
+
+export type SmartContractFungibleCompleteAssetAmount = CompleteAssetAmount<
+  SmartContractFungibleAsset,
+  AnyAssetAmount<SmartContractFungibleAsset>
+>
 
 export const initialState = {
   accountsData: {},

--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -25,7 +25,7 @@ import { AsyncThunkFulfillmentType } from "@tallyho/tally-background/redux-slice
 import logger from "@tallyho/tally-background/lib/logger"
 import { useHistory, useLocation } from "react-router-dom"
 import { normalizeEVMAddress } from "@tallyho/tally-background/lib/utils"
-import { SmartContractFungibleCompleteAssetAmount } from "@tallyho/tally-background/redux-slices/accounts"
+import { CompleteSmartContractFungibleAssetAmount } from "@tallyho/tally-background/redux-slices/accounts"
 import {
   clearTransactionState,
   selectDefaultNetworkFeeSettings,
@@ -77,14 +77,13 @@ export default function Swap(): ReactElement {
 
   // TODO Expand these to fungible assets by supporting direct ETH swaps,
   // TODO then filter by the current chain.
-  let ownedSellAssetAmounts: SmartContractFungibleCompleteAssetAmount[] = []
 
-  if (typeof accountBalances !== "undefined") {
-    ownedSellAssetAmounts = accountBalances.assetAmounts.filter(
-      (assetAmount): assetAmount is SmartContractFungibleCompleteAssetAmount =>
+  const ownedSellAssetAmounts =
+    accountBalances?.assetAmounts.filter(
+      (assetAmount): assetAmount is CompleteSmartContractFungibleAssetAmount =>
         isSmartContractFungibleAsset(assetAmount.asset)
-    )
-  }
+    ) ?? []
+
   const buyAssets = useBackgroundSelector((state) => {
     // Some type massaging needed to remind TypeScript how these types fit
     // together.

--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -14,10 +14,9 @@ import {
   SwapQuoteRequest,
   fetchSwapQuote,
 } from "@tallyho/tally-background/redux-slices/0x-swap"
-import { selectAccountAndTimestampedActivities } from "@tallyho/tally-background/redux-slices/selectors"
+import { selectCurrentAccountBalances } from "@tallyho/tally-background/redux-slices/selectors"
 import {
   AnyAsset,
-  AnyAssetAmount,
   isSmartContractFungibleAsset,
   SmartContractFungibleAsset,
 } from "@tallyho/tally-background/assets"
@@ -26,7 +25,7 @@ import { AsyncThunkFulfillmentType } from "@tallyho/tally-background/redux-slice
 import logger from "@tallyho/tally-background/lib/logger"
 import { useHistory, useLocation } from "react-router-dom"
 import { normalizeEVMAddress } from "@tallyho/tally-background/lib/utils"
-import { CompleteAssetAmount } from "@tallyho/tally-background/redux-slices/accounts"
+import { SmartContractFungibleCompleteAssetAmount } from "@tallyho/tally-background/redux-slices/accounts"
 import {
   clearTransactionState,
   selectDefaultNetworkFeeSettings,
@@ -74,25 +73,18 @@ export default function Swap(): ReactElement {
     { symbol: string; contractAddress?: string } | undefined
   >()
 
-  const { combinedData } = useBackgroundSelector(
-    selectAccountAndTimestampedActivities
-  )
+  const accountBalances = useBackgroundSelector(selectCurrentAccountBalances)
 
   // TODO Expand these to fungible assets by supporting direct ETH swaps,
   // TODO then filter by the current chain.
-  const ownedSellAssetAmounts = combinedData.assets.filter<
-    CompleteAssetAmount<
-      SmartContractFungibleAsset,
-      AnyAssetAmount<SmartContractFungibleAsset>
-    >
-  >(
-    (
-      assetAmount
-    ): assetAmount is CompleteAssetAmount<
-      SmartContractFungibleAsset,
-      AnyAssetAmount<SmartContractFungibleAsset>
-    > => isSmartContractFungibleAsset(assetAmount.asset)
-  )
+  let ownedSellAssetAmounts: SmartContractFungibleCompleteAssetAmount[] = []
+
+  if (typeof accountBalances !== "undefined") {
+    ownedSellAssetAmounts = accountBalances.assetAmounts.filter(
+      (assetAmount): assetAmount is SmartContractFungibleCompleteAssetAmount =>
+        isSmartContractFungibleAsset(assetAmount.asset)
+    )
+  }
   const buyAssets = useBackgroundSelector((state) => {
     // Some type massaging needed to remind TypeScript how these types fit
     // together.


### PR DESCRIPTION
This PR fixes a bug where the balance showed at the top of the Swap page was showing the balance of a given token across all addresses imported to the wallet.

https://user-images.githubusercontent.com/94649004/154405873-deee7460-fb63-4db4-9c84-17d333863a2a.mov

Closes #1005
