### PR TITLE
Fix blank signing page if read-only account

### DIFF
--- a/ui/pages/SignTransaction.tsx
+++ b/ui/pages/SignTransaction.tsx
@@ -110,8 +110,7 @@ export default function SignTransaction({
   const signingMethod = signerAccountTotal?.signingMethod ?? null
   if (
     typeof transactionDetails === "undefined" ||
-    typeof signerAccountTotal === "undefined" ||
-    signingMethod === null
+    typeof signerAccountTotal === "undefined"
   ) {
     // TODO Some sort of unexpected state error if we end up here... Or do we
     // go back in history? That won't work for dApp popovers though.
@@ -122,7 +121,11 @@ export default function SignTransaction({
     await dispatch(rejectTransactionSignature())
   }
   const handleConfirm = async () => {
-    if (isTransactionDataReady && transactionDetails) {
+    if (
+      isTransactionDataReady &&
+      transactionDetails &&
+      signingMethod !== null
+    ) {
       dispatch(
         signTransaction({
           transaction: transactionDetails,


### PR DESCRIPTION
dApp requests for signatures caused blank screen if the current account is read-only (see below). Fixed.
![Screenshot from 2022-02-25 15-19-18](https://user-images.githubusercontent.com/4115717/155721957-de17a7e0-30bf-4dc4-9c74-cb4c6140e284.png)
