### PR TITLE
Hide option to connect to a Ledger if WebUSB is not supported

### DIFF
--- a/background/services/ledger/index.ts
+++ b/background/services/ledger/index.ts
@@ -23,6 +23,7 @@ import { getOrCreateDB, LedgerDatabase } from "./db"
 import { ethersTransactionRequestFromEIP1559TransactionRequest } from "../chain/utils"
 import { ETH } from "../../constants"
 import { normalizeEVMAddress } from "../../lib/utils"
+import { HIDE_IMPORT_LEDGER } from "../../features/features"
 
 enum LedgerType {
   UNKNOWN,
@@ -36,6 +37,9 @@ export const LedgerProductDatabase = {
   LEDGER_NANO_S: { productId: 0x1015 },
   LEDGER_NANO_X: { productId: 0x4015 },
 }
+
+export const isLedgerSupported =
+  !HIDE_IMPORT_LEDGER && typeof navigator.usb === "object"
 
 const TestedProductId = (productId: number): boolean => {
   return Object.values(LedgerProductDatabase).some(

--- a/ui/pages/Onboarding/OnboardingAddWallet.tsx
+++ b/ui/pages/Onboarding/OnboardingAddWallet.tsx
@@ -2,8 +2,8 @@ import React, { ReactElement } from "react"
 import {
   HIDE_ADD_SEED,
   HIDE_CREATE_PHRASE,
-  HIDE_IMPORT_LEDGER,
 } from "@tallyho/tally-background/features/features"
+import { isLedgerSupported } from "@tallyho/tally-background/services/ledger"
 import SharedBackButton from "../../components/Shared/SharedBackButton"
 import SharedButton from "../../components/Shared/SharedButton"
 
@@ -45,9 +45,7 @@ export default function OnboardingStartTheHunt(): ReactElement {
             </SharedButton>
           </li>
         )}
-        {HIDE_IMPORT_LEDGER ? (
-          <></>
-        ) : (
+        {isLedgerSupported && (
           <li className="option standard_width">
             <div className="icon ledger_icon" />
             <SharedButton


### PR DESCRIPTION
Fixes #1035.

Hides the "Connect to a Ledger" option if `navigator.usb` is not available (or the Ledger feature flag is disabled).