### PR TITLE
Remove /slices in UI readme

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -50,7 +50,4 @@ by the folder they're in.
 
 /public
 # Static assets like fonts and images
-
-/slices
-# Reducers and actions consolidated as files here. Interacting with the project's background.js api and using its data to populate frontend's state happens here
 ```


### PR DESCRIPTION
Tracing source and found inaccurate file structure in [ui/README.md](ui/README.md)
I guess the /slices is moved into background [background/redux-slices/ui.ts](background/redux-slices/ui.ts)