### PR TITLE
Typed signing on Ledger error handling + serialization

### DIFF
--- a/background/services/signing/index.ts
+++ b/background/services/signing/index.ts
@@ -181,7 +181,12 @@ export default class SigningService extends BaseService<Events> {
     let signedData: string
     switch (signingMethod.type) {
       case "ledger":
-        signedData = await this.ledgerService.signTypedData(typedData, account)
+        signedData = await this.ledgerService.signTypedData(
+          typedData,
+          account,
+          signingMethod.deviceID,
+          signingMethod.path
+        )
         break
       case "keyring":
         signedData = await this.keyringService.signTypedData({


### PR DESCRIPTION
The happy path was already merged but users tend to alter from the intended use cases :)

- Serialize typed signing with other Ledger operations
- Bubble up errors for further processing when we use typed data signing
- Match Redux and LedgerService state before attempting typed signing