### PR TITLE
Do not spam Blocknative

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -85,6 +85,7 @@ import {
 import { ETHEREUM } from "./constants"
 import { HIDE_IMPORT_LEDGER } from "./features/features"
 import { SignatureResponse, TXSignatureResponse } from "./services/signing"
+import { PollingPeriod } from "./services/chain"
 
 // This sanitizer runs on store and action data before serializing for remote
 // redux devtools. The goal is to end up with an object that is directly
@@ -1146,6 +1147,12 @@ export default class Main extends BaseService<never> {
         )
       }
     )
+
+    uiSliceEmitter.on("setUiVisibility", async (visibility: boolean) => {
+      this.chainService.setBlockPollingPeriod(
+        visibility ? PollingPeriod.SHORT : PollingPeriod.LONG
+      )
+    })
   }
 
   connectTelemetryService(): void {

--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -28,6 +28,7 @@ export type Events = {
   snackbarMessage: string
   newDefaultWalletValue: boolean
   newSelectedAccount: AddressOnNetwork
+  setUiVisibility: boolean
 }
 
 export const emitter = new Emittery<Events>()
@@ -133,6 +134,13 @@ export const setNewSelectedAccount = createBackgroundAsyncThunk(
     await emitter.emit("newSelectedAccount", addressNetwork)
     // Once the default value has persisted, propagate to the store.
     dispatch(uiSlice.actions.setSelectedAccount(addressNetwork))
+  }
+)
+
+export const setUiVisibility = createBackgroundAsyncThunk(
+  "ui/setUiVisibility",
+  async (visible: boolean) => {
+    await emitter.emit("setUiVisibility", visible)
   }
 )
 

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -1,7 +1,6 @@
 import {
   AlchemyProvider,
   AlchemyWebSocketProvider,
-  BaseProvider,
   TransactionReceipt,
 } from "@ethersproject/providers"
 import { getNetwork } from "@ethersproject/networks"
@@ -50,6 +49,11 @@ import type {
 } from "../enrichment"
 import { HOUR } from "../../constants"
 import SerialFallbackProvider from "./serial-fallback-provider"
+
+export enum PollingPeriod {
+  SHORT = 1,
+  LONG = 30,
+}
 
 // We can't use destructuring because webpack has to replace all instances of
 // `process.env` variables in the bundled output
@@ -185,6 +189,10 @@ export default class ChainService extends BaseService<Events> {
         schedule: {
           periodInMinutes:
             Number(process.env.GAS_PRICE_POLLING_FREQUENCY ?? "120") / 60,
+        },
+        multiTickBased: {
+          tickCounter: 0,
+          extendedPeriodMultiplier: PollingPeriod.SHORT,
         },
         handler: () => {
           this.pollBlockPrices()
@@ -659,6 +667,10 @@ export default class ChainService extends BaseService<Events> {
 
   async send(method: string, params: unknown[]): Promise<unknown> {
     return this.providers.ethereum.send(method, params)
+  }
+
+  setBlockPollingPeriod(ticks: PollingPeriod): void {
+    this.setPollingPeriod("blockPrices", ticks)
   }
 
   /* *****************

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -181,7 +181,7 @@ export default class ChainService extends BaseService<Events> {
         runAtStart: true,
       },
       blockPrices: {
-        runAtStart: false,
+        runAtStart: true,
         schedule: {
           periodInMinutes:
             Number(process.env.GAS_PRICE_POLLING_FREQUENCY ?? "120") / 60,

--- a/ui/pages/Popup.tsx
+++ b/ui/pages/Popup.tsx
@@ -6,6 +6,7 @@ import classNames from "classnames"
 import {
   setRouteHistoryEntries,
   Location,
+  setUiVisibility,
 } from "@tallyho/tally-background/redux-slices/ui"
 
 import { Store } from "webext-redux"
@@ -95,6 +96,11 @@ export function Main(): ReactElement {
 
       dispatch(setRouteHistoryEntries(entries))
     }
+  }
+
+  if (renderCount.current === 1) {
+    window.addEventListener("blur", () => dispatch(setUiVisibility(false)))
+    window.addEventListener("focus", () => dispatch(setUiVisibility(true)))
   }
 
   return (


### PR DESCRIPTION
Fixes #949

Waiting for #1041 to be merged to have a proper event trigger

Now we can configure integer multiples for selected alarms and 

Current implementation polls Blocknative on:
  - startup,
  - every 2 minutes when the Wallet is shown,
  - every 60 minutes when the Wallet is hidden,
  - and every time when the Wallet appears and more than 2 minutes elapsed since the last poll

# QA
If the event trigger is finalized, then one can check
- if the prices are updated correctly,
- no traffic goes to Blocknative if the Wallet is hidden