### PR TITLE
Use Ledger signing UI for typed data signing and reduce code duplication

### DIFF
--- a/ui/components/SignTransaction/SignTransactionContainer.tsx
+++ b/ui/components/SignTransaction/SignTransactionContainer.tsx
@@ -6,30 +6,36 @@ import SignTransactionLedgerBusy from "./SignTransactionLedgerBusy"
 import SignTransactionLedgerNotConnected from "./SignTransactionLedgerNotConnected"
 import SignTransactionNetworkAccountInfoTopBar from "./SignTransactionNetworkAccountInfoTopBar"
 import SignTransactionWrongLedgerConnected from "./SignTransactionWrongLedgerConnected"
-import { SigningLedgerState } from "./useSigningLedgerState"
+import { useSigningLedgerState } from "./useSigningLedgerState"
 
 export default function SignTransactionContainer({
   signerAccountTotal,
   title,
   detailPanel,
+  reviewPanel,
   extraPanel,
-  signingLedgerState,
-  isWaitingForHardware,
   confirmButtonLabel,
   handleConfirm,
   handleReject,
+  isTransactionSigning,
 }: {
   signerAccountTotal: AccountTotal
   title: ReactNode
   detailPanel: ReactNode
+  reviewPanel: ReactNode
   extraPanel: ReactNode
-  signingLedgerState: SigningLedgerState | null
-  isWaitingForHardware: boolean
   confirmButtonLabel: ReactNode
   handleConfirm: () => void
   handleReject: () => void
+  isTransactionSigning: boolean
 }): ReactElement {
+  const { signingMethod } = signerAccountTotal
   const [isSlideUpOpen, setSlideUpOpen] = useState(false)
+
+  const signingLedgerState = useSigningLedgerState(signingMethod ?? null)
+
+  const isLedgerSigning = signingMethod?.type === "ledger"
+  const isWaitingForHardware = isLedgerSigning && isTransactionSigning
 
   return (
     <section>
@@ -39,7 +45,9 @@ export default function SignTransactionContainer({
       <h1 className="serif_header title">
         {isWaitingForHardware ? "Awaiting hardware wallet signature" : title}
       </h1>
-      <div className="primary_info_card standard_width">{detailPanel}</div>
+      <div className="primary_info_card standard_width">
+        {isWaitingForHardware ? reviewPanel : detailPanel}
+      </div>
       {isWaitingForHardware ? (
         <div className="cannot_reject_warning">
           <span className="block_icon" />

--- a/ui/components/SignTransaction/SignTransactionContainer.tsx
+++ b/ui/components/SignTransaction/SignTransactionContainer.tsx
@@ -1,9 +1,7 @@
 import { AccountTotal } from "@tallyho/tally-background/redux-slices/selectors"
 import React, { ReactElement, ReactNode, useState } from "react"
 import SharedButton from "../Shared/SharedButton"
-import SharedPanelSwitcher from "../Shared/SharedPanelSwitcher"
 import SharedSlideUpMenu from "../Shared/SharedSlideUpMenu"
-import SignTransactionDetailPanel from "./SignTransactionDetailPanel"
 import SignTransactionLedgerBusy from "./SignTransactionLedgerBusy"
 import SignTransactionLedgerNotConnected from "./SignTransactionLedgerNotConnected"
 import SignTransactionNetworkAccountInfoTopBar from "./SignTransactionNetworkAccountInfoTopBar"
@@ -13,7 +11,8 @@ import { SigningLedgerState } from "./useSigningLedgerState"
 export default function SignTransactionContainer({
   signerAccountTotal,
   title,
-  children,
+  detailPanel,
+  extraPanel,
   signingLedgerState,
   isWaitingForHardware,
   confirmButtonLabel,
@@ -22,7 +21,8 @@ export default function SignTransactionContainer({
 }: {
   signerAccountTotal: AccountTotal
   title: ReactNode
-  children: ReactNode
+  detailPanel: ReactNode
+  extraPanel: ReactNode
   signingLedgerState: SigningLedgerState | null
   isWaitingForHardware: boolean
   confirmButtonLabel: ReactNode
@@ -30,7 +30,6 @@ export default function SignTransactionContainer({
   handleReject: () => void
 }): ReactElement {
   const [isSlideUpOpen, setSlideUpOpen] = useState(false)
-  const [panelNumber, setPanelNumber] = useState(0)
 
   return (
     <section>
@@ -40,7 +39,7 @@ export default function SignTransactionContainer({
       <h1 className="serif_header title">
         {isWaitingForHardware ? "Awaiting hardware wallet signature" : title}
       </h1>
-      <div className="primary_info_card standard_width">{children}</div>
+      <div className="primary_info_card standard_width">{detailPanel}</div>
       {isWaitingForHardware ? (
         <div className="cannot_reject_warning">
           <span className="block_icon" />
@@ -48,12 +47,7 @@ export default function SignTransactionContainer({
         </div>
       ) : (
         <>
-          <SharedPanelSwitcher
-            setPanelNumber={setPanelNumber}
-            panelNumber={panelNumber}
-            panelNames={["Details"]}
-          />
-          {panelNumber === 0 ? <SignTransactionDetailPanel /> : null}
+          {extraPanel}
           <div className="footer_actions">
             <SharedButton
               iconSize="large"

--- a/ui/components/SignTransaction/SignTransactionPanelSwitcher.tsx
+++ b/ui/components/SignTransaction/SignTransactionPanelSwitcher.tsx
@@ -1,0 +1,18 @@
+import React, { ReactElement, useState } from "react"
+import SharedPanelSwitcher from "../Shared/SharedPanelSwitcher"
+import SignTransactionDetailPanel from "./SignTransactionDetailPanel"
+
+export default function SignTransactionPanelSwitcher(): ReactElement {
+  const [panelNumber, setPanelNumber] = useState(0)
+
+  return (
+    <>
+      <SharedPanelSwitcher
+        setPanelNumber={setPanelNumber}
+        panelNumber={panelNumber}
+        panelNames={["Details"]}
+      />
+      {panelNumber === 0 ? <SignTransactionDetailPanel /> : null}
+    </>
+  )
+}

--- a/ui/pages/SignData.tsx
+++ b/ui/pages/SignData.tsx
@@ -1,7 +1,6 @@
 import { AccountType } from "@tallyho/tally-background/redux-slices/accounts"
 import {
   getAccountTotal,
-  selectAddressSigningMethods,
   selectCurrentAccountSigningMethod,
 } from "@tallyho/tally-background/redux-slices/selectors"
 import {
@@ -11,8 +10,7 @@ import {
 } from "@tallyho/tally-background/redux-slices/signing"
 import React, { ReactElement } from "react"
 import { useHistory } from "react-router-dom"
-import SharedButton from "../components/Shared/SharedButton"
-import SignTransactionNetworkAccountInfoTopBar from "../components/SignTransaction/SignTransactionNetworkAccountInfoTopBar"
+import SignTransactionContainer from "../components/SignTransaction/SignTransactionContainer"
 import {
   useAreKeyringsUnlocked,
   useBackgroundDispatch,
@@ -82,173 +80,115 @@ export default function SignData({
     await dispatch(rejectDataSignature())
     history.goBack()
   }
+
   return (
-    <section>
-      <SignTransactionNetworkAccountInfoTopBar
-        accountTotal={signerAccountTotal}
-      />
-      <h1 className="serif_header title">{`Sign ${
-        primaryType ?? "Message"
-      }`}</h1>
-      <div className="primary_info_card standard_width">
-        <div className="sign_block">
-          <div className="container">
-            <div className="label header">
-              {internal
-                ? "Your signature is required"
-                : "A dapp is requesting your signature"}
-            </div>
-            <div className="divider" />
-            <div className="header">{domain.name}</div>
-            <div className="divider" />
-            {keys.length > 2 ? (
-              <div className="messages">
-                {keys.map((key) => (
-                  <div key={key} className="message">
-                    <div className="key">{capitalize(key)}</div>
-                    <div className="value light">{`${message[key]}`}</div>
-                  </div>
-                ))}
+    <SignTransactionContainer
+      signerAccountTotal={signerAccountTotal}
+      confirmButtonLabel="Sign"
+      handleConfirm={handleConfirm}
+      handleReject={handleReject}
+      isWaitingForHardware={false}
+      signingLedgerState="available"
+      title={`Sign ${primaryType ?? "Message"}`}
+      detailPanel={
+        <>
+          <div className="sign_block">
+            <div className="container">
+              <div className="label header">
+                {internal
+                  ? "Your signature is required"
+                  : "A dapp is requesting your signature"}
               </div>
-            ) : (
-              <>
-                {keys.map((key) => (
-                  <div className="single_message">
-                    <div className="key">{capitalize(key)}</div>
-                    <div className="light">{`${message[key]}`}</div>
-                  </div>
-                ))}
-              </>
-            )}
+              <div className="divider" />
+              <div className="header">{domain.name}</div>
+              <div className="divider" />
+              {keys.length > 2 ? (
+                <div className="messages">
+                  {keys.map((key) => (
+                    <div key={key} className="message">
+                      <div className="key">{capitalize(key)}</div>
+                      <div className="value light">{`${message[key]}`}</div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <>
+                  {keys.map((key) => (
+                    <div className="single_message">
+                      <div className="key">{capitalize(key)}</div>
+                      <div className="light">{`${message[key]}`}</div>
+                    </div>
+                  ))}
+                </>
+              )}
+            </div>
           </div>
-        </div>
-      </div>
-      <div className="footer_actions">
-        <SharedButton
-          iconSize="large"
-          size="large"
-          type="secondary"
-          onClick={handleReject}
-        >
-          Reject
-        </SharedButton>
-        {signerAccountTotal.accountType === AccountType.ReadOnly ? (
-          <span className="no-signing">Read-only accounts cannot sign</span>
-        ) : (
-          <SharedButton
-            type="primary"
-            iconSize="large"
-            size="large"
-            onClick={handleConfirm}
-            showLoadingOnClick
-          >
-            Sign
-          </SharedButton>
-        )}
-      </div>
-      <style jsx>
-        {`
-          section {
-            width: 100%;
-            height: 100%;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            background-color: var(--green-95);
-            z-index: 5;
-          }
-          .title {
-            color: var(--trophy-gold);
-            font-size: 36px;
-            font-weight: 500;
-            line-height: 42px;
-            text-align: center;
-          }
-          .primary_info_card {
-            display: block;
-            height: fit-content;
-            border-radius: 16px;
-            background-color: var(--hunter-green);
-            margin: 16px 0px;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-          }
-          .footer_actions {
-            position: fixed;
-            bottom: 0px;
-            display: flex;
-            width: 100%;
-            padding: 0px 16px;
-            box-sizing: border-box;
-            align-items: center;
-            height: 80px;
-            justify-content: space-between;
-            box-shadow: 0 0 5px rgba(0, 20, 19, 0.5);
-            background-color: var(--green-95);
-          }
-          .sign_block {
-            display: flex;
-            width: 100%;
-            flex-direction: column;
-            justify-content: space-between;
-          }
-          .label {
-            color: var(--green-40);
-          }
-          .header {
-            padding: 16px 0;
-          }
-          .messages {
-            display: flex;
-            flex-flow: column;
-            width: 100%;
-            padding-top: 16px;
-          }
-          .message {
-            display: flex;
-            justify-content: space-between;
-            padding: 6px 16px;
-          }
-          .value {
-            overflow-wrap: anywhere;
-            max-width: 220px;
-            text-align: right;
-          }
-          .light {
-            color: #ccd3d3;
-          }
-          .key {
-            color: var(--green-40);
-          }
-          .divider {
-            width: 80%;
-            height: 2px;
-            opacity: 60%;
-            background-color: var(--green-120);
-          }
-          .single_message {
-            display: flex;
-            flex-direction: column;
-            gap: 24px;
-            text-align: left;
-            padding: 16px;
-            width: 80%;
-          }
-          .divider {
-            width: 80%;
-            height: 2px;
-            opacity: 60%;
-            background-color: var(--green-120);
-          }
-          .container {
-            display: flex;
-            margin: 20px 0;
-            flex-direction: column;
-            align-items: center;
-          }
-        `}
-      </style>
-    </section>
+
+          <style jsx>{`
+            .sign_block {
+              display: flex;
+              width: 100%;
+              flex-direction: column;
+              justify-content: space-between;
+            }
+            .label {
+              color: var(--green-40);
+            }
+            .header {
+              padding: 16px 0;
+            }
+            .messages {
+              display: flex;
+              flex-flow: column;
+              width: 100%;
+              padding-top: 16px;
+            }
+            .message {
+              display: flex;
+              justify-content: space-between;
+              padding: 6px 16px;
+            }
+            .value {
+              overflow-wrap: anywhere;
+              max-width: 220px;
+              text-align: right;
+            }
+            .light {
+              color: #ccd3d3;
+            }
+            .key {
+              color: var(--green-40);
+            }
+            .divider {
+              width: 80%;
+              height: 2px;
+              opacity: 60%;
+              background-color: var(--green-120);
+            }
+            .single_message {
+              display: flex;
+              flex-direction: column;
+              gap: 24px;
+              text-align: left;
+              padding: 16px;
+              width: 80%;
+            }
+            .divider {
+              width: 80%;
+              height: 2px;
+              opacity: 60%;
+              background-color: var(--green-120);
+            }
+            .container {
+              display: flex;
+              margin: 20px 0;
+              flex-direction: column;
+              align-items: center;
+            }
+          `}</style>
+        </>
+      }
+      extraPanel={null}
+    />
   )
 }

--- a/ui/pages/SignData.tsx
+++ b/ui/pages/SignData.tsx
@@ -16,29 +16,17 @@ import {
   useBackgroundDispatch,
   useBackgroundSelector,
 } from "../hooks"
-import capitalize from "../utils/capitalize"
+import SignDataDetailPanel from "./SignDataDetailPanel"
 
 export enum SignDataType {
   TypedData = "sign-typed-data",
 }
 
-interface SignDataLocationState {
-  internal: boolean
-}
-
-export default function SignData({
-  location,
-}: {
-  location: { state?: SignDataLocationState }
-}): ReactElement {
+export default function SignData(): ReactElement {
   const dispatch = useBackgroundDispatch()
   const typedDataRequest = useBackgroundSelector(selectTypedData)
 
   const history = useHistory()
-
-  const { internal } = location.state ?? {
-    internal: false,
-  }
 
   const signerAccountTotal = useBackgroundSelector((state) => {
     if (typeof typedDataRequest !== "undefined") {
@@ -63,10 +51,6 @@ export default function SignData({
     return <></>
   }
 
-  const { domain, message, primaryType } = typedDataRequest.typedData
-
-  const keys = Object.keys(message)
-
   const handleConfirm = () => {
     if (typedDataRequest !== undefined) {
       if (currentAddressSigner) {
@@ -89,105 +73,8 @@ export default function SignData({
       handleReject={handleReject}
       isWaitingForHardware={false}
       signingLedgerState="available"
-      title={`Sign ${primaryType ?? "Message"}`}
-      detailPanel={
-        <>
-          <div className="sign_block">
-            <div className="container">
-              <div className="label header">
-                {internal
-                  ? "Your signature is required"
-                  : "A dapp is requesting your signature"}
-              </div>
-              <div className="divider" />
-              <div className="header">{domain.name}</div>
-              <div className="divider" />
-              {keys.length > 2 ? (
-                <div className="messages">
-                  {keys.map((key) => (
-                    <div key={key} className="message">
-                      <div className="key">{capitalize(key)}</div>
-                      <div className="value light">{`${message[key]}`}</div>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <>
-                  {keys.map((key) => (
-                    <div className="single_message">
-                      <div className="key">{capitalize(key)}</div>
-                      <div className="light">{`${message[key]}`}</div>
-                    </div>
-                  ))}
-                </>
-              )}
-            </div>
-          </div>
-
-          <style jsx>{`
-            .sign_block {
-              display: flex;
-              width: 100%;
-              flex-direction: column;
-              justify-content: space-between;
-            }
-            .label {
-              color: var(--green-40);
-            }
-            .header {
-              padding: 16px 0;
-            }
-            .messages {
-              display: flex;
-              flex-flow: column;
-              width: 100%;
-              padding-top: 16px;
-            }
-            .message {
-              display: flex;
-              justify-content: space-between;
-              padding: 6px 16px;
-            }
-            .value {
-              overflow-wrap: anywhere;
-              max-width: 220px;
-              text-align: right;
-            }
-            .light {
-              color: #ccd3d3;
-            }
-            .key {
-              color: var(--green-40);
-            }
-            .divider {
-              width: 80%;
-              height: 2px;
-              opacity: 60%;
-              background-color: var(--green-120);
-            }
-            .single_message {
-              display: flex;
-              flex-direction: column;
-              gap: 24px;
-              text-align: left;
-              padding: 16px;
-              width: 80%;
-            }
-            .divider {
-              width: 80%;
-              height: 2px;
-              opacity: 60%;
-              background-color: var(--green-120);
-            }
-            .container {
-              display: flex;
-              margin: 20px 0;
-              flex-direction: column;
-              align-items: center;
-            }
-          `}</style>
-        </>
-      }
+      title={`Sign ${typedDataRequest.typedData.primaryType ?? "Message"}`}
+      detailPanel={<SignDataDetailPanel />}
       extraPanel={null}
     />
   )

--- a/ui/pages/SignData.tsx
+++ b/ui/pages/SignData.tsx
@@ -8,7 +8,7 @@ import {
   selectTypedData,
   signTypedData,
 } from "@tallyho/tally-background/redux-slices/signing"
-import React, { ReactElement } from "react"
+import React, { ReactElement, useState } from "react"
 import { useHistory } from "react-router-dom"
 import SignTransactionContainer from "../components/SignTransaction/SignTransactionContainer"
 import {
@@ -42,6 +42,8 @@ export default function SignData(): ReactElement {
     selectCurrentAccountSigningMethod
   )
 
+  const [isTransactionSigning, setIsTransactionSigning] = useState(false)
+
   if (
     (signerAccountTotal?.accountType === AccountType.Imported &&
       !areKeyringsUnlocked) ||
@@ -56,6 +58,7 @@ export default function SignData(): ReactElement {
       if (currentAddressSigner) {
         typedDataRequest.signingMethod = currentAddressSigner
         dispatch(signTypedData(typedDataRequest))
+        setIsTransactionSigning(true)
       }
     }
   }
@@ -71,10 +74,10 @@ export default function SignData(): ReactElement {
       confirmButtonLabel="Sign"
       handleConfirm={handleConfirm}
       handleReject={handleReject}
-      isWaitingForHardware={false}
-      signingLedgerState="available"
       title={`Sign ${typedDataRequest.typedData.primaryType ?? "Message"}`}
       detailPanel={<SignDataDetailPanel />}
+      reviewPanel={<SignDataDetailPanel />}
+      isTransactionSigning={isTransactionSigning}
       extraPanel={null}
     />
   )

--- a/ui/pages/SignDataDetailPanel.tsx
+++ b/ui/pages/SignDataDetailPanel.tsx
@@ -1,0 +1,115 @@
+import { selectTypedData } from "@tallyho/tally-background/redux-slices/signing"
+import React, { ReactElement } from "react"
+import { useBackgroundSelector } from "../hooks"
+import capitalize from "../utils/capitalize"
+
+export default function SignDataDetailPanel(): ReactElement {
+  const typedDataRequest = useBackgroundSelector(selectTypedData)
+  if (typeof typedDataRequest === "undefined") return <></>
+
+  const { domain, message } = typedDataRequest.typedData
+
+  const keys = Object.keys(message)
+
+  /* TODO: should be `true` if the request originates from within the wallet */
+  const isInternal = false
+
+  return (
+    <>
+      <div className="sign_block">
+        <div className="container">
+          <div className="label header">
+            {isInternal
+              ? "Your signature is required"
+              : "A dapp is requesting your signature"}
+          </div>
+          <div className="divider" />
+          <div className="header">{domain.name}</div>
+          <div className="divider" />
+          {keys.length > 2 ? (
+            <div className="messages">
+              {keys.map((key) => (
+                <div key={key} className="message">
+                  <div className="key">{capitalize(key)}</div>
+                  <div className="value light">{`${message[key]}`}</div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <>
+              {keys.map((key) => (
+                <div className="single_message">
+                  <div className="key">{capitalize(key)}</div>
+                  <div className="light">{`${message[key]}`}</div>
+                </div>
+              ))}
+            </>
+          )}
+        </div>
+      </div>
+
+      <style jsx>{`
+        .sign_block {
+          display: flex;
+          width: 100%;
+          flex-direction: column;
+          justify-content: space-between;
+        }
+        .label {
+          color: var(--green-40);
+        }
+        .header {
+          padding: 16px 0;
+        }
+        .messages {
+          display: flex;
+          flex-flow: column;
+          width: 100%;
+          padding-top: 16px;
+        }
+        .message {
+          display: flex;
+          justify-content: space-between;
+          padding: 6px 16px;
+        }
+        .value {
+          overflow-wrap: anywhere;
+          max-width: 220px;
+          text-align: right;
+        }
+        .light {
+          color: #ccd3d3;
+        }
+        .key {
+          color: var(--green-40);
+        }
+        .divider {
+          width: 80%;
+          height: 2px;
+          opacity: 60%;
+          background-color: var(--green-120);
+        }
+        .single_message {
+          display: flex;
+          flex-direction: column;
+          gap: 24px;
+          text-align: left;
+          padding: 16px;
+          width: 80%;
+        }
+        .divider {
+          width: 80%;
+          height: 2px;
+          opacity: 60%;
+          background-color: var(--green-120);
+        }
+        .container {
+          display: flex;
+          margin: 20px 0;
+          flex-direction: column;
+          align-items: center;
+        }
+      `}</style>
+    </>
+  )
+}

--- a/ui/pages/SignTransaction.tsx
+++ b/ui/pages/SignTransaction.tsx
@@ -18,6 +18,7 @@ import {
 import SignTransactionContainer from "../components/SignTransaction/SignTransactionContainer"
 import SignTransactionInfoProvider from "../components/SignTransaction/SignTransactionInfoProvider"
 import { useSigningLedgerState } from "../components/SignTransaction/useSigningLedgerState"
+import SignTransactionPanelSwitcher from "../components/SignTransaction/SignTransactionPanelSwitcher"
 
 export default function SignTransaction({
   location,
@@ -149,9 +150,9 @@ export default function SignTransaction({
           confirmButtonLabel={confirmButtonLabel}
           handleConfirm={handleConfirm}
           handleReject={handleReject}
-        >
-          {isWaitingForHardware ? textualInfoBlock : infoBlock}
-        </SignTransactionContainer>
+          detailPanel={isWaitingForHardware ? textualInfoBlock : infoBlock}
+          extraPanel={<SignTransactionPanelSwitcher />}
+        />
       )}
     </SignTransactionInfoProvider>
   )

--- a/ui/pages/SignTransaction.tsx
+++ b/ui/pages/SignTransaction.tsx
@@ -17,7 +17,6 @@ import {
 } from "../hooks"
 import SignTransactionContainer from "../components/SignTransaction/SignTransactionContainer"
 import SignTransactionInfoProvider from "../components/SignTransaction/SignTransactionInfoProvider"
-import { useSigningLedgerState } from "../components/SignTransaction/useSigningLedgerState"
 import SignTransactionPanelSwitcher from "../components/SignTransaction/SignTransactionPanelSwitcher"
 
 export default function SignTransaction({
@@ -59,11 +58,13 @@ export default function SignTransaction({
     return undefined
   })
 
-  const needsKeyrings = signerAccountTotal?.signingMethod?.type === "keyring"
+  const [isTransactionSigning, setIsTransactionSigning] = useState(false)
+
+  const signingMethod = signerAccountTotal?.signingMethod ?? null
+
+  const needsKeyrings = signingMethod?.type === "keyring"
   const areKeyringsUnlocked = useAreKeyringsUnlocked(needsKeyrings)
   const isWaitingForKeyrings = needsKeyrings && !areKeyringsUnlocked
-
-  const [isTransactionSigning, setIsTransactionSigning] = useState(false)
 
   useEffect(() => {
     if (!isWaitingForKeyrings && isTransactionSigned && isTransactionSigning) {
@@ -98,17 +99,10 @@ export default function SignTransaction({
     }
   }, [history, isTransactionMissingOrRejected])
 
-  const isLedgerSigning = signerAccountTotal?.signingMethod?.type === "ledger"
-
-  const signingLedgerState = useSigningLedgerState(
-    signerAccountTotal?.signingMethod ?? null
-  )
-
   if (isWaitingForKeyrings) {
     return <></>
   }
 
-  const signingMethod = signerAccountTotal?.signingMethod ?? null
   if (
     typeof transactionDetails === "undefined" ||
     typeof signerAccountTotal === "undefined"
@@ -137,21 +131,19 @@ export default function SignTransaction({
     }
   }
 
-  const isWaitingForHardware = isLedgerSigning && isTransactionSigning
-
   return (
     <SignTransactionInfoProvider>
       {({ title, infoBlock, textualInfoBlock, confirmButtonLabel }) => (
         <SignTransactionContainer
           signerAccountTotal={signerAccountTotal}
-          signingLedgerState={signingLedgerState}
           title={title}
-          isWaitingForHardware={isWaitingForHardware}
           confirmButtonLabel={confirmButtonLabel}
           handleConfirm={handleConfirm}
           handleReject={handleReject}
-          detailPanel={isWaitingForHardware ? textualInfoBlock : infoBlock}
+          detailPanel={infoBlock}
+          reviewPanel={textualInfoBlock}
           extraPanel={<SignTransactionPanelSwitcher />}
+          isTransactionSigning={isTransactionSigning}
         />
       )}
     </SignTransactionInfoProvider>


### PR DESCRIPTION
This PR:

- reduces duplicated code between sign transaction and sign typed data (fixes #903), and
- makes sign typed data flow use all the Ledger-related UI elements when signing with a Ledger (as a consequence).

The following screens were not shown when signing typed data with Ledger.
![Screenshot from 2022-03-02 15-22-06](https://user-images.githubusercontent.com/4115717/156369779-bc5a9c22-e87b-4659-b7ed-4446d96de984.png)
![Screenshot from 2022-03-02 15-21-10](https://user-images.githubusercontent.com/4115717/156369782-05cc3014-8e3e-4a80-b5d1-b1942b9afa7e.png)
![Screenshot from 2022-03-02 15-21-04](https://user-images.githubusercontent.com/4115717/156369786-0b973f93-e319-4449-9f58-49b3dbc18a52.png)
