### PR TITLE
Enable hiding non `read-only` addresses.

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -171,7 +171,6 @@ function migrateReduxState(
 const reduxCache: Middleware = (store) => (next) => (action) => {
   const result = next(action)
   const state = store.getState()
-  ;(window as any).store = store
 
   if (process.env.WRITE_REDUX_CACHE === "true") {
     // Browser extension storage supports JSON natively, despite that we have

--- a/background/main.ts
+++ b/background/main.ts
@@ -490,8 +490,8 @@ export default class Main extends BaseService<never> {
     await this.chainService.addAccountToTrack(addressNetwork)
   }
 
-  hideAddress(address: HexString): void {
-    this.keyringService.hideAddress(address)
+  hideAccount(address: HexString): void {
+    this.keyringService.hideAccount(address)
   }
 
   async addAccountByName(nameNetwork: NameOnNetwork): Promise<void> {

--- a/background/main.ts
+++ b/background/main.ts
@@ -171,6 +171,7 @@ function migrateReduxState(
 const reduxCache: Middleware = (store) => (next) => (action) => {
   const result = next(action)
   const state = store.getState()
+  ;(window as any).store = store
 
   if (process.env.WRITE_REDUX_CACHE === "true") {
     // Browser extension storage supports JSON natively, despite that we have
@@ -487,6 +488,10 @@ export default class Main extends BaseService<never> {
 
   async addAccount(addressNetwork: AddressOnNetwork): Promise<void> {
     await this.chainService.addAccountToTrack(addressNetwork)
+  }
+
+  hideAddress(address: HexString): void {
+    this.keyringService.hideAddress(address)
   }
 
   async addAccountByName(nameNetwork: NameOnNetwork): Promise<void> {

--- a/background/redux-slices/accounts.ts
+++ b/background/redux-slices/accounts.ts
@@ -310,3 +310,12 @@ export const addAccountByName = createBackgroundAsyncThunk(
     await main.addAccountByName(nameNetwork)
   }
 )
+
+// @TODO Normalize `address` to `account` throughout everything I've touched
+export const hideAddress = createBackgroundAsyncThunk(
+  "account/hideAddress",
+  async (address: HexString, { dispatch, extra: { main } }) => {
+    dispatch(removeAccount(address))
+    main.hideAddress(address)
+  }
+)

--- a/background/redux-slices/accounts.ts
+++ b/background/redux-slices/accounts.ts
@@ -312,10 +312,10 @@ export const addAccountByName = createBackgroundAsyncThunk(
 )
 
 // @TODO Normalize `address` to `account` throughout everything I've touched
-export const hideAddress = createBackgroundAsyncThunk(
-  "account/hideAddress",
+export const hideAccount = createBackgroundAsyncThunk(
+  "account/hideAccount",
   async (address: HexString, { dispatch, extra: { main } }) => {
     dispatch(removeAccount(address))
-    main.hideAddress(address)
+    main.hideAccount(address)
   }
 )

--- a/background/redux-slices/accounts.ts
+++ b/background/redux-slices/accounts.ts
@@ -311,7 +311,6 @@ export const addAccountByName = createBackgroundAsyncThunk(
   }
 )
 
-// @TODO Normalize `address` to `account` throughout everything I've touched
 export const hideAccount = createBackgroundAsyncThunk(
   "account/hideAccount",
   async (address: HexString, { dispatch, extra: { main } }) => {

--- a/background/services/keyring/index.ts
+++ b/background/services/keyring/index.ts
@@ -71,7 +71,7 @@ export default class KeyringService extends BaseService<Events> {
 
   #keyringMetadata: { [keyringId: string]: KeyringMetadata } = {}
 
-  #hiddenAddresses: { [address: HexString]: boolean } = {}
+  #hiddenAccounts: { [address: HexString]: boolean } = {}
 
   /**
    * The last time a keyring took an action that required the service to be
@@ -318,8 +318,8 @@ export default class KeyringService extends BaseService<Events> {
     this.#keyrings.push(newKeyring)
     newKeyring.addAddressesSync(1)
     const [address] = newKeyring.getAddressesSync()
-    if (this.#hiddenAddresses[address]) {
-      this.#hiddenAddresses[address] = false
+    if (this.#hiddenAccounts[address]) {
+      this.#hiddenAccounts[address] = false
     }
     await this.persistKeyrings()
     this.emitter.emit("address", address)
@@ -343,7 +343,7 @@ export default class KeyringService extends BaseService<Events> {
       addresses: [
         ...kr
           .getAddressesSync()
-          .filter((address) => this.#hiddenAddresses[address] !== true),
+          .filter((address) => this.#hiddenAccounts[address] !== true),
       ],
       id: kr.id,
     }))
@@ -372,8 +372,8 @@ export default class KeyringService extends BaseService<Events> {
     return newAddress
   }
 
-  hideAddress(address: HexString): void {
-    this.#hiddenAddresses[address] = true
+  hideAccount(address: HexString): void {
+    this.#hiddenAccounts[address] = true
     this.emitKeyrings()
   }
 

--- a/background/services/keyring/index.ts
+++ b/background/services/keyring/index.ts
@@ -318,6 +318,9 @@ export default class KeyringService extends BaseService<Events> {
     this.#keyrings.push(newKeyring)
     newKeyring.addAddressesSync(1)
     const [address] = newKeyring.getAddressesSync()
+    if (this.#hiddenAddresses[address]) {
+      this.#hiddenAddresses[address] = false
+    }
     await this.persistKeyrings()
     this.emitter.emit("address", address)
     this.emitKeyrings()

--- a/background/services/keyring/index.ts
+++ b/background/services/keyring/index.ts
@@ -71,6 +71,8 @@ export default class KeyringService extends BaseService<Events> {
 
   #keyringMetadata: { [keyringId: string]: KeyringMetadata } = {}
 
+  #hiddenAddresses: { [address: HexString]: boolean } = {}
+
   /**
    * The last time a keyring took an action that required the service to be
    * unlocked (signing, adding a keyring, etc).
@@ -314,11 +316,10 @@ export default class KeyringService extends BaseService<Events> {
       ? new HDKeyring({ mnemonic, path })
       : new HDKeyring({ mnemonic })
     this.#keyrings.push(newKeyring)
-    this.#keyringMetadata[newKeyring.id] = { source }
     newKeyring.addAddressesSync(1)
+    const [address] = newKeyring.getAddressesSync()
     await this.persistKeyrings()
-
-    this.emitter.emit("address", newKeyring.getAddressesSync()[0])
+    this.emitter.emit("address", address)
     this.emitKeyrings()
 
     return newKeyring.id
@@ -336,7 +337,11 @@ export default class KeyringService extends BaseService<Events> {
       // Reconsider, or explicitly track which keyrings have been generated vs
       // imported as well as their strength
       type: KeyringTypes.mnemonicBIP39S256,
-      addresses: [...kr.getAddressesSync()],
+      addresses: [
+        ...kr
+          .getAddressesSync()
+          .filter((address) => this.#hiddenAddresses[address] !== true),
+      ],
       id: kr.id,
     }))
   }
@@ -362,6 +367,11 @@ export default class KeyringService extends BaseService<Events> {
     this.emitKeyrings()
 
     return newAddress
+  }
+
+  hideAddress(address: HexString): void {
+    this.#hiddenAddresses[address] = true
+    this.emitKeyrings()
   }
 
   /**

--- a/ui/components/AccountItem/AccountItemRemovalConfirm.tsx
+++ b/ui/components/AccountItem/AccountItemRemovalConfirm.tsx
@@ -34,11 +34,8 @@ const AccountItemRemovalConfirm: React.FC<AccountItemRemovalConfirmProps> = ({
       <div className="remove_address_details">
         <span>
           Removing this address doesn&apos;t delete your recovery phrase or any
-          private keys.
-        </span>
-        <span>
-          Instead it just hides it from the extension and you won&apos;t be able
-          to use it until you add it back
+          private keys. Instead it just hides it from the extension and you
+          won&apos;t be able to use it until you add it back.
         </span>
       </div>
       <div className="button_container">

--- a/ui/components/AccountItem/AccountItemRemovalConfirm.tsx
+++ b/ui/components/AccountItem/AccountItemRemovalConfirm.tsx
@@ -1,5 +1,5 @@
 import {
-  hideAddress,
+  hideAccount,
   removeAccount,
 } from "@tallyho/tally-background/redux-slices/accounts"
 import { AccountTotal } from "@tallyho/tally-background/redux-slices/selectors"
@@ -57,7 +57,7 @@ const AccountItemRemovalConfirm: React.FC<AccountItemRemovalConfirmProps> = ({
           size="medium"
           onClick={(e) => {
             e.stopPropagation()
-            dispatch(hideAddress(address))
+            dispatch(hideAccount(address))
             close()
           }}
         >

--- a/ui/components/AccountItem/AccountItemRemovalConfirm.tsx
+++ b/ui/components/AccountItem/AccountItemRemovalConfirm.tsx
@@ -1,4 +1,7 @@
-import { removeAccount } from "@tallyho/tally-background/redux-slices/accounts"
+import {
+  hideAddress,
+  removeAccount,
+} from "@tallyho/tally-background/redux-slices/accounts"
 import { AccountTotal } from "@tallyho/tally-background/redux-slices/selectors"
 import { HexString } from "@tallyho/tally-background/types"
 import React from "react"
@@ -54,7 +57,7 @@ const AccountItemRemovalConfirm: React.FC<AccountItemRemovalConfirmProps> = ({
           size="medium"
           onClick={(e) => {
             e.stopPropagation()
-            dispatch(removeAccount(address))
+            dispatch(hideAddress(address))
             close()
           }}
         >

--- a/ui/components/AccountItem/AccountItemSummary.tsx
+++ b/ui/components/AccountItem/AccountItemSummary.tsx
@@ -78,6 +78,7 @@ const AccountItemSummary: React.FC<Props> = (props: Props) => {
         .left {
           display: flex;
           align-items: center;
+          padding-left: 4px;
         }
         .address_name {
           color: #fff;
@@ -109,6 +110,7 @@ const AccountItemSummary: React.FC<Props> = (props: Props) => {
         .right {
           display: flex;
           align-items: center;
+          padding-right: 4px;
         }
       `}</style>
     </>

--- a/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
+++ b/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
@@ -243,10 +243,7 @@ export default function AccountsNotificationPanelAccounts({
                                 key={lowerCaseAddress}
                                 accountTotal={accountTotal}
                                 isSelected={isSelected}
-                                hideMenu={
-                                  isSelected ||
-                                  accountType !== AccountType.ReadOnly
-                                }
+                                hideMenu={isSelected}
                               />
                             </li>
                           </button>

--- a/ui/components/Shared/SharedPanelAccountItem.tsx
+++ b/ui/components/Shared/SharedPanelAccountItem.tsx
@@ -16,7 +16,7 @@ export default function SharedPanelAccountItem(props: Props): ReactElement {
   const { isSelected, hideMenu, accountTotal: account } = props
 
   return (
-    <li className="standard_width">
+    <div className="standard_width container">
       <AccountItemSummary isSelected={isSelected} account={account} />
       <AccountItemOptionsMenu
         hideMenu={hideMenu}
@@ -26,7 +26,7 @@ export default function SharedPanelAccountItem(props: Props): ReactElement {
       />
 
       <style jsx>{`
-        li {
+        .container {
           display: flex;
           justify-content: space-between;
           align-items: center;
@@ -35,7 +35,7 @@ export default function SharedPanelAccountItem(props: Props): ReactElement {
           height: 52px;
         }
       `}</style>
-    </li>
+    </div>
   )
 }
 


### PR DESCRIPTION
This PR introduces the ability to remove non read-only addresses from the accounts list.  This is done through a new `#hiddenAccounts` property inside of `keyringService` that acts as a filter for what addresses to emit with keyrings when emitting via the `emitKeyrings` method.

Removed addresses are easily able to be re-added with the `+ Address` button - and addresses are not removed from `accountsToTrack` when they are removed so that users have the UX of being able to immediately see the current state of addresses they have previously hidden when unhiding them.

This PR is blocked until #1060 is merged.

https://user-images.githubusercontent.com/94649004/156622214-21e56318-0bdc-441b-ab77-a09c6fa58aad.mov


