### PR TITLE
Immutably Update this.#keyringMetadata to prevent exception.

### DIFF
--- a/background/services/keyring/index.ts
+++ b/background/services/keyring/index.ts
@@ -320,13 +320,15 @@ export default class KeyringService extends BaseService<Events> {
       ? new HDKeyring({ mnemonic, path })
       : new HDKeyring({ mnemonic })
     this.#keyrings.push(newKeyring)
-    this.#keyringMetadata[newKeyring.id] = { source }
+    this.#keyringMetadata = {
+      ...this.#keyringMetadata,
+      [newKeyring.id]: { source },
+    }
     newKeyring.addAddressesSync(1)
     await this.persistKeyrings()
 
     this.emitter.emit("address", newKeyring.getAddressesSync()[0])
     this.emitKeyrings()
-
     return newKeyring.id
   }
 


### PR DESCRIPTION
Without this fix - attempting to import a wallet after first creating a new Tally wallet resulted in an exception being thrown in the background thread and the importing `status` in the Keyring Redux Slice being stuck at `pending`.

Not sure why this did not show up until after `main` was merged into #1001 - but this should fix the issue of not being able to add multiple separate `Tally` and `Import` keyrings.

To Test:

- Add a `Tally` wallet from a new Seed.
- Import a wallet from a metamask seed.
- You should see both wallets in the Account List.
- Any combination of Tally / Imported wallets should be supported.