### PR TITLE
Rename "NewSeed" accounts to "Internal"

### DIFF
--- a/background/redux-slices/accounts.ts
+++ b/background/redux-slices/accounts.ts
@@ -17,7 +17,7 @@ export const enum AccountType {
   ReadOnly = "read-only",
   Imported = "imported",
   Ledger = "ledger",
-  NewSeed = "newSeed",
+  Internal = "internal",
 }
 
 const availableDefaultNames = [

--- a/background/redux-slices/keyrings.ts
+++ b/background/redux-slices/keyrings.ts
@@ -7,7 +7,7 @@ import { Keyring, KeyringMetadata } from "../services/keyring/index"
 
 type KeyringsState = {
   keyrings: Keyring[]
-  keyringMetadata: { [keyringId: string]: { source: "import" | "newSeed" } }
+  keyringMetadata: { [keyringId: string]: { source: "import" | "internal" } }
   importing: false | "pending" | "done"
   status: "locked" | "unlocked" | "uninitialized"
   keyringToVerify: {
@@ -36,7 +36,7 @@ export const emitter = new Emittery<Events>()
 
 interface ImportKeyring {
   mnemonic: string
-  source: "newSeed" | "import"
+  source: "internal" | "import"
   path?: string
 }
 

--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -196,7 +196,7 @@ const getAccountType = (
   address: string,
   signingMethod: SigningMethod,
   addressSources: {
-    [address: string]: "import" | "newSeed"
+    [address: string]: "import" | "internal"
   }
 ): AccountType => {
   if (signingMethod == null) {
@@ -208,7 +208,7 @@ const getAccountType = (
   if (addressSources[address] === "import") {
     return AccountType.Imported
   }
-  return AccountType.NewSeed
+  return AccountType.Internal
 }
 
 export const selectAccountTotalsByCategory = createSelector(

--- a/background/redux-slices/selectors/keyringsSelectors.ts
+++ b/background/redux-slices/selectors/keyringsSelectors.ts
@@ -33,7 +33,7 @@ export const selectSourcesByAddress = createSelector(
     keyrings,
     keyringMetadata
   ): {
-    [keyringId: string]: "import" | "newSeed"
+    [keyringId: string]: "import" | "internal"
   } =>
     Object.fromEntries(
       keyrings

--- a/background/services/keyring/index.ts
+++ b/background/services/keyring/index.ts
@@ -35,7 +35,7 @@ export type Keyring = {
 }
 
 export interface KeyringMetadata {
-  source: "import" | "newSeed"
+  source: "import" | "internal"
 }
 
 interface SerializedKeyringData {
@@ -311,7 +311,7 @@ export default class KeyringService extends BaseService<Events> {
    */
   async importKeyring(
     mnemonic: string,
-    source: "import" | "newSeed",
+    source: "import" | "internal",
     path?: string
   ): Promise<string> {
     this.requireUnlocked()

--- a/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
+++ b/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
@@ -32,7 +32,7 @@ const walletTypeDetails: { [key in AccountType]: WalletTypeInfo } = {
     title: "Import",
     icon: "./images/imported@2x.png",
   },
-  [AccountType.NewSeed]: {
+  [AccountType.Internal]: {
     title: "Tally",
     icon: "./images/tally_reward@2x.png", // FIXME: Icon is cut off - we should get a better one
   },
@@ -171,7 +171,7 @@ export default function AccountsNotificationPanelAccounts({
   }, [onCurrentAddressChange, pendingSelectedAddress, selectedAccountAddress])
 
   const accountTypes = [
-    AccountType.NewSeed,
+    AccountType.Internal,
     AccountType.Imported,
     AccountType.ReadOnly,
   ]
@@ -211,7 +211,7 @@ export default function AccountsNotificationPanelAccounts({
                     accountType={accountType}
                     walletNumber={idx + 1}
                     onClickAddAddress={
-                      accountType === "imported" || accountType === "newSeed"
+                      accountType === "imported" || accountType === "internal"
                         ? () => {
                             if (accountTotalsByKeyringId[0].keyringId) {
                               dispatch(

--- a/ui/pages/Onboarding/OnboardingVerifySeed.tsx
+++ b/ui/pages/Onboarding/OnboardingVerifySeed.tsx
@@ -20,7 +20,10 @@ function SuccessMessage({ mnemonic }: { mnemonic: string[] }) {
           type="primary"
           onClick={async () => {
             await dispatch(
-              importKeyring({ mnemonic: mnemonic.join(" "), source: "newSeed" })
+              importKeyring({
+                mnemonic: mnemonic.join(" "),
+                source: "internal",
+              })
             )
             history.push("/")
           }}


### PR DESCRIPTION
Per discussion in https://github.com/tallycash/extension/pull/1001.  We want to avoid using the `new seed` nomenclature.