### PR TITLE
Make current Ledger error handling more robust

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -81,6 +81,7 @@ import {
 import {
   resetLedgerState,
   setDeviceConnectionStatus,
+  setUsbDeviceCount,
 } from "./redux-slices/ledger"
 import { ETHEREUM } from "./constants"
 import { HIDE_IMPORT_LEDGER } from "./features/features"
@@ -852,6 +853,10 @@ export default class Main extends BaseService<never> {
       this.store.dispatch(
         setDeviceConnectionStatus({ deviceID: id, status: "disconnected" })
       )
+    })
+
+    this.ledgerService.emitter.on("usbDeviceCount", (usbDeviceCount) => {
+      this.store.dispatch(setUsbDeviceCount({ usbDeviceCount }))
     })
   }
 

--- a/background/redux-slices/ledger.ts
+++ b/background/redux-slices/ledger.ts
@@ -25,6 +25,7 @@ export type LedgerState = {
   currentDeviceID: string | null
   /** Devices by ID */
   devices: Record<string, LedgerDeviceState>
+  usbDeviceCount: number
 }
 
 export type Events = {
@@ -51,6 +52,7 @@ export type Events = {
 export const initialState: LedgerState = {
   currentDeviceID: null,
   devices: {},
+  usbDeviceCount: 0,
 }
 
 const ledgerSlice = createSlice({
@@ -172,11 +174,21 @@ const ledgerSlice = createSlice({
       if (!account) return
       if (account.balance === null) account.balance = balance
     },
+    setUsbDeviceCount: (
+      immerState,
+      { payload: { usbDeviceCount } }: { payload: { usbDeviceCount: number } }
+    ) => {
+      immerState.usbDeviceCount = usbDeviceCount
+    },
   },
 })
 
-export const { resetLedgerState, setDeviceConnectionStatus, addLedgerAccount } =
-  ledgerSlice.actions
+export const {
+  resetLedgerState,
+  setDeviceConnectionStatus,
+  addLedgerAccount,
+  setUsbDeviceCount,
+} = ledgerSlice.actions
 
 export default ledgerSlice.reducer
 

--- a/background/redux-slices/ledger.ts
+++ b/background/redux-slices/ledger.ts
@@ -199,9 +199,13 @@ export const fetchAddress = createBackgroundAsyncThunk(
     { deviceID, path }: { deviceID: string; path: string },
     { dispatch, extra: { main } }
   ) => {
-    dispatch(ledgerSlice.actions.setFetchingAddress({ deviceID, path }))
-    const address = await main.deriveLedgerAddress(path) // FIXME: deviceID is ignored
-    dispatch(ledgerSlice.actions.resolveAddress({ deviceID, path, address }))
+    try {
+      dispatch(ledgerSlice.actions.setFetchingAddress({ deviceID, path }))
+      const address = await main.deriveLedgerAddress(path) // FIXME: deviceID is ignored
+      dispatch(ledgerSlice.actions.resolveAddress({ deviceID, path, address }))
+    } catch (err) {
+      dispatch(ledgerSlice.actions.resetLedgerState())
+    }
   }
 )
 

--- a/ui/pages/Ledger/Ledger.tsx
+++ b/ui/pages/Ledger/Ledger.tsx
@@ -29,6 +29,10 @@ export default function Ledger(): ReactElement {
   const devices = useBackgroundSelector((state) => state.ledger.devices)
   const device = deviceID === null ? null : devices[deviceID] ?? null
 
+  const usbDeviceCount = useBackgroundSelector(
+    (state) => state.ledger.usbDeviceCount
+  )
+
   const dispatch = useBackgroundDispatch()
   const connectionError = phase === "2-connect" && !device && !connecting
   return (
@@ -36,6 +40,7 @@ export default function Ledger(): ReactElement {
       {(phase === "0-prepare" || connectionError) && (
         <LedgerPrepare
           initialScreen={phase === "0-prepare"}
+          deviceCount={usbDeviceCount}
           onContinue={async () => {
             setPhase("1-request")
             try {

--- a/ui/pages/Ledger/Ledger.tsx
+++ b/ui/pages/Ledger/Ledger.tsx
@@ -35,7 +35,7 @@ export default function Ledger(): ReactElement {
     <BrowserTabContainer>
       {(phase === "0-prepare" || connectionError) && (
         <LedgerPrepare
-          showWarning={connectionError}
+          initialScreen={phase === "0-prepare"}
           onContinue={async () => {
             setPhase("1-request")
             try {

--- a/ui/pages/Ledger/LedgerPrepare.tsx
+++ b/ui/pages/Ledger/LedgerPrepare.tsx
@@ -3,20 +3,21 @@ import LedgerContinueButton from "../../components/Ledger/LedgerContinueButton"
 import LedgerPanelContainer from "../../components/Ledger/LedgerPanelContainer"
 
 export default function LedgerPrepare({
-  showWarning,
   onContinue,
+  initialScreen,
 }: {
-  showWarning: boolean
   onContinue: () => void
+  initialScreen: boolean
 }): ReactElement {
-  const buttonLabel = showWarning ? "Try Again" : "Continue"
+  const buttonLabel = initialScreen ? "Continue" : "Try Again"
+  const subHeadingVerb = initialScreen ? "start" : "retry"
   return (
     <LedgerPanelContainer
       indicatorImageSrc="/images/connect_ledger_indicator_disconnected.svg"
-      heading="Before we get started"
-      subHeading="Make sure you take these 3 steps before we start"
+      heading={initialScreen ? "Before we get started" : "Check your Ledger"}
+      subHeading={`Make sure you take these 3 steps before we ${subHeadingVerb}`}
     >
-      {showWarning ? (
+      {!initialScreen ? (
         <div className="steps">
           <div className="warning error">
             <span className="block_icon" />

--- a/ui/pages/Ledger/LedgerPrepare.tsx
+++ b/ui/pages/Ledger/LedgerPrepare.tsx
@@ -5,12 +5,18 @@ import LedgerPanelContainer from "../../components/Ledger/LedgerPanelContainer"
 export default function LedgerPrepare({
   onContinue,
   initialScreen,
+  deviceCount,
 }: {
   onContinue: () => void
   initialScreen: boolean
+  deviceCount: number
 }): ReactElement {
   const buttonLabel = initialScreen ? "Continue" : "Try Again"
   const subHeadingVerb = initialScreen ? "start" : "retry"
+  const warningText =
+    deviceCount === 0
+      ? "No Ledger device is connected"
+      : "Multiple Ledgers are connected"
   return (
     <LedgerPanelContainer
       indicatorImageSrc="/images/connect_ledger_indicator_disconnected.svg"
@@ -21,7 +27,7 @@ export default function LedgerPrepare({
         <div className="steps">
           <div className="warning error">
             <span className="block_icon" />
-            No Ledger device is connected
+            {warningText}
           </div>
           <div className="warning">
             Please follow the steps below and <br /> click on Try Again!
@@ -31,7 +37,7 @@ export default function LedgerPrepare({
         <></>
       )}
       <ol className="steps">
-        <li>Plug in Ledger</li>
+        <li>Plug in a single Ledger</li>
         <li>Enter pin to unlock</li>
         <li>Open Ethereum App</li>
       </ol>


### PR DESCRIPTION
Resolves #1051

User have many ingenious way to shoot themselves in the foot, we try to protect them from themselves.

#QA

- During onboarding we never show the address selection screen, if the user tries to reach that with locked Ledger.
  - Test1: Wait for Ledger locking, when the USB selector screen becomes active, then proceed with connect
  - Test2: Wait for Ledger locking, when the addresses are shown, then try to navigate to the next page
- During onboarding we always notify the user if more than one Ledgers are connected.
  - Connect more than one Ledger with active Ethereum apps to the system during onboarding