### PR TITLE
Fix flash of unsized popup

### DIFF
--- a/ui/pages/Popup.tsx
+++ b/ui/pages/Popup.tsx
@@ -187,12 +187,6 @@ export function Main(): ReactElement {
       <>
         <style jsx global>
           {`
-            body {
-              width: 384px;
-              height: 594px;
-              scrollbar-width: none;
-            }
-
             ::-webkit-scrollbar {
               width: 0px;
               background: transparent;

--- a/ui/public/index.css
+++ b/ui/public/index.css
@@ -46,6 +46,12 @@ body {
   background-color: var(--hunter-green);
 }
 
+body.popup {
+  width: 384px;
+  height: 594px;
+  scrollbar-width: none;
+}
+
 a {
   text-decoration: none;
 }
@@ -132,4 +138,3 @@ label {
   opacity: 60%;
   background-color: var(--green-120);
 }
-

--- a/ui/public/popup.html
+++ b/ui/public/popup.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" href="./fonts.css" />
     <link rel="stylesheet" href="./index.css" />
   </head>
-  <body>
+  <body class="popup">
     <div id="tally-root" />
     <script src="../ui.js" type="text/javascript"></script>
   </body>


### PR DESCRIPTION
Fixes #924.

Flash was caused by dynamic loading of CSS.
This commit restores the popup sizing as part the static, global CSS,
but uses a popup-specific class applied to `<body>`, to avoid poisoning
the style of full-page UIs.