### PR TITLE
Fix swap list searchbox to the top

### DIFF
--- a/ui/components/Shared/SharedAssetInput.tsx
+++ b/ui/components/Shared/SharedAssetInput.tsx
@@ -125,7 +125,7 @@ function SelectAssetMenuContent<T extends AnyAsset>(
         </div>
       </div>
       <div className="divider" />
-      <ul>
+      <ul className="assets_list">
         {sortedFilteredAssets.map((assetWithOptionalAmount) => {
           const { asset } = assetWithOptionalAmount
           return (
@@ -181,6 +181,12 @@ function SelectAssetMenuContent<T extends AnyAsset>(
             border-bottom: 1px solid var(--hunter-green);
             margin-top: 15px;
             margin-bottom: 8.5px;
+          }
+          .assets_list {
+            display: block;
+            overflow: scroll;
+            height: calc(100% - 106px);
+            width: 100%;
           }
         `}
       </style>

--- a/ui/components/Shared/SharedAssetInput.tsx
+++ b/ui/components/Shared/SharedAssetInput.tsx
@@ -180,12 +180,11 @@ function SelectAssetMenuContent<T extends AnyAsset>(
             width: 384px;
             border-bottom: 1px solid var(--hunter-green);
             margin-top: 15px;
-            margin-bottom: 8.5px;
           }
           .assets_list {
             display: block;
             overflow: scroll;
-            height: calc(100% - 106px);
+            height: calc(100% - 98px);
             width: 100%;
           }
         `}


### PR DESCRIPTION
Fixes #1038

Fixed problem with tokens list searchbox that was scrolling with the list.
Now the list is scrolling but the searchbox stays on the top.