### PR TITLE
Token Immutability: Include a custom token list via IPFS

### DIFF
--- a/background/services/preferences/db.ts
+++ b/background/services/preferences/db.ts
@@ -84,6 +84,27 @@ export class PreferenceDatabase extends Dexie {
           })
       })
 
+    // Add the new default token list
+    this.version(5)
+      .stores({
+        preferences: "++id",
+      })
+      .upgrade((tx) => {
+        return tx
+          .table("preferences")
+          .toCollection()
+          .modify((storedPreferences: Preferences) => {
+            // eslint-disable-next-line no-param-reassign
+            storedPreferences.tokenLists = {
+              ...storedPreferences.tokenLists,
+              urls: [
+                "https://ipfs.fleek.co/ipfs/bafybeid6yf4wa52cz3dkblqykktvfofvmqq2jiwfnyxtz4ypkafmthtqzi",
+                ...storedPreferences.tokenLists.urls,
+              ],
+            }
+          })
+      })
+
     // This is the old version for populate
     // https://dexie.org/docs/Dexie/Dexie.on.populate-(old-version)
     // The this does not behave according the new docs, but works

--- a/background/services/preferences/defaults.ts
+++ b/background/services/preferences/defaults.ts
@@ -5,6 +5,7 @@ const defaultPreferences: Preferences = {
   tokenLists: {
     autoUpdate: false,
     urls: [
+      "https://ipfs.fleek.co/ipfs/bafybeid6yf4wa52cz3dkblqykktvfofvmqq2jiwfnyxtz4ypkafmthtqzi", // the Tally community-curated list
       "https://gateway.ipfs.io/ipns/tokens.uniswap.org", // the Uniswap default list
       "https://yearn.science/static/tokenlist.json", // the Yearn list
       "https://messari.io/tokenlist/messari-verified", // Messari-verified projects


### PR DESCRIPTION
The list *should* make it easy to tweak token display. Eventually, we can make sure that it's given priority over other lists.

Unfortunately, though the list validates against the same schema in its generating repo, our validation setup tosses it out. @greg-nagy I'm hoping this is something you immediately know how to fix, as I believe this list will fix many of our issues with WETH.