### PR TITLE
AAAVEE AAVEE AAVE - Add prioritized asset sorting to SharedAssetInput

### DIFF
--- a/ui/components/Shared/SharedAssetInput.tsx
+++ b/ui/components/Shared/SharedAssetInput.tsx
@@ -20,6 +20,32 @@ import SharedAssetItem, {
 } from "./SharedAssetItem"
 import SharedAssetIcon from "./SharedAssetIcon"
 
+// List of symbols we want to display first.  Lower array index === higher priority.
+// For now we just prioritize somewhat popular assets that we are able to load an icon for.
+const SYMBOL_PRIORITY_LIST = [
+  "UST",
+  "KEEP",
+  "ENS",
+  "CRV",
+  "FTM",
+  "GRT",
+  "BAL",
+  "MATIC",
+  "NU",
+  "AMP",
+  "BNT",
+  "COMP",
+  "UMA",
+  "WLTC",
+  "CVC",
+]
+
+const symbolPriority = Object.fromEntries(
+  SYMBOL_PRIORITY_LIST.map((symbol, idx) => [
+    symbol,
+    SYMBOL_PRIORITY_LIST.length - idx,
+  ])
+)
 interface SelectAssetMenuContentProps<AssetType extends AnyAsset> {
   assets: AnyAssetWithOptionalAmount<AssetType>[]
   setSelectedAssetAndClose: (
@@ -28,12 +54,22 @@ interface SelectAssetMenuContentProps<AssetType extends AnyAsset> {
 }
 
 // Sorts an AnyAssetWithOptionalAmount by symbol, alphabetically, according to
-// the current locale.
-function assetAlphabeticSorter<
+// the current locale.  Symbols passed into the symbolList will take priority
+// over alphabetical sorting.
+function prioritizedAssetAlphabeticSorter<
   AssetType extends AnyAsset,
   T extends AnyAssetWithOptionalAmount<AssetType>
->({ asset: { symbol } }: T, { asset: { symbol: symbol2 } }: T) {
-  return symbol.localeCompare(symbol2)
+>({ asset: { symbol: symbol1 } }: T, { asset: { symbol: symbol2 } }: T) {
+  const firstSymbolPriority = symbolPriority[symbol1] ?? 0
+  const secondSymbolPriority = symbolPriority[symbol2] ?? 0
+  if (firstSymbolPriority > secondSymbolPriority) {
+    return -1
+  }
+  if (firstSymbolPriority < secondSymbolPriority) {
+    return 1
+  }
+
+  return symbol1.localeCompare(symbol2)
 }
 
 // Sorts an AnyAssetWithOptionalAmount by symbol, alphabetically, according to
@@ -100,7 +136,7 @@ function SelectAssetMenuContent<T extends AnyAsset>(
 
   const sortedFilteredAssets = filteredAssets.sort(
     searchTerm.trim() === ""
-      ? assetAlphabeticSorter
+      ? prioritizedAssetAlphabeticSorter
       : assetAlphabeticSorterWithFilter(searchTerm.trim())
   )
 


### PR DESCRIPTION
This PR adds an easily customizable priority list so that when users use swaps they are not immediately presented with a bunch of AAVE tokens with no icons.  The list of assets I chose is pretty much random - I went through our lists and picked some assets that actually had icons.  Completely open to changing up the list if desired.

### To Test:
Open the swaps page - try selecting a buy asset - if you see UST and KEEP at the top of the list - great success!

https://user-images.githubusercontent.com/94649004/157496668-d7d5bfb8-c5be-44ca-9996-b5f80634d411.mov


