### PR TITLE
Properly display infinite token approval

### DIFF
--- a/ui/components/Shared/SharedTooltip.tsx
+++ b/ui/components/Shared/SharedTooltip.tsx
@@ -1,26 +1,15 @@
 import React, { ReactElement, useState } from "react"
 
 type VeriticalPosition = "top" | "bottom"
-type HorizontalPosition = "left" | "center" | "right"
 
 interface Props {
   verticalPosition?: VeriticalPosition
-  horizontalPosition?: HorizontalPosition
-  width?: number
+  width: number
   children: React.ReactNode
 }
 
-function getHorizontalPosition(horizontal: HorizontalPosition, width?: number) {
-  switch (horizontal) {
-    case "center":
-      return width ? `right: -${width / 2 + 8}px;` : ""
-    case "left":
-      return "right: 0;"
-    case "right":
-      return "left: 0;"
-    default:
-      return ""
-  }
+function getHorizontalPosition(width: number) {
+  return `right: -${width / 2 + 4}px;`
 }
 
 function getVerticalPosition(vertical: VeriticalPosition) {
@@ -35,12 +24,7 @@ function getVerticalPosition(vertical: VeriticalPosition) {
 }
 
 export default function SharedTooltip(props: Props): ReactElement {
-  const {
-    children,
-    verticalPosition = "bottom",
-    horizontalPosition = "right",
-    width,
-  } = props
+  const { children, verticalPosition = "bottom", width } = props
   const [isShowingTooltip, setIsShowingTooltip] = useState(false)
 
   return (
@@ -72,7 +56,7 @@ export default function SharedTooltip(props: Props): ReactElement {
             display: block;
           }
           .tooltip {
-            width: ${width ? `${width}px` : "auto"};
+            width: ${width}px;
             position: absolute;
             box-shadow: 0 2px 4px rgba(0, 20, 19, 0.24),
               0 6px 8px rgba(0, 20, 19, 0.14), 0 16px 16px rgba(0, 20, 19, 0.04);
@@ -84,7 +68,7 @@ export default function SharedTooltip(props: Props): ReactElement {
             border-radius: 3px;
             padding: 12px;
             ${getVerticalPosition(verticalPosition)}
-            ${getHorizontalPosition(horizontalPosition, width)}
+            ${getHorizontalPosition(width)}
           }
         `}
       </style>

--- a/ui/components/Shared/SharedTooltip.tsx
+++ b/ui/components/Shared/SharedTooltip.tsx
@@ -1,11 +1,46 @@
 import React, { ReactElement, useState } from "react"
 
+type VeriticalPosition = "top" | "bottom"
+type HorizontalPosition = "left" | "center" | "right"
+
 interface Props {
+  verticalPosition?: VeriticalPosition
+  horizontalPosition?: HorizontalPosition
+  width?: number
   children: React.ReactNode
 }
 
+function getHorizontalPosition(horizontal: HorizontalPosition, width?: number) {
+  switch (horizontal) {
+    case "center":
+      return width ? `right: -${width / 2 + 8}px;` : ""
+    case "left":
+      return "right: 0;"
+    case "right":
+      return "left: 0;"
+    default:
+      return ""
+  }
+}
+
+function getVerticalPosition(vertical: VeriticalPosition) {
+  switch (vertical) {
+    case "bottom":
+      return "top: 16px; margin-top: 5px;"
+    case "top":
+      return "bottom: 16px; margin-bottom: 5px;"
+    default:
+      return ""
+  }
+}
+
 export default function SharedTooltip(props: Props): ReactElement {
-  const { children } = props
+  const {
+    children,
+    verticalPosition = "bottom",
+    horizontalPosition = "right",
+    width,
+  } = props
   const [isShowingTooltip, setIsShowingTooltip] = useState(false)
 
   return (
@@ -25,6 +60,7 @@ export default function SharedTooltip(props: Props): ReactElement {
           .tooltip_wrap {
             width: fit-content;
             display: inline-block;
+            position: relative;
             margin-left: 8px;
             z-index: 20;
           }
@@ -36,8 +72,7 @@ export default function SharedTooltip(props: Props): ReactElement {
             display: block;
           }
           .tooltip {
-            margin-top: 10px;
-            max-width: 213px;
+            width: ${width ? `${width}px` : "auto"};
             position: absolute;
             box-shadow: 0 2px 4px rgba(0, 20, 19, 0.24),
               0 6px 8px rgba(0, 20, 19, 0.14), 0 16px 16px rgba(0, 20, 19, 0.04);
@@ -48,6 +83,8 @@ export default function SharedTooltip(props: Props): ReactElement {
             line-height: 20px;
             border-radius: 3px;
             padding: 12px;
+            ${getVerticalPosition(verticalPosition)}
+            ${getHorizontalPosition(horizontalPosition, width)}
           }
         `}
       </style>

--- a/ui/components/SignTransaction/SignTransactionSpendAssetInfoProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionSpendAssetInfoProvider.tsx
@@ -177,10 +177,9 @@ export default function SignTransactionSpendAssetInfoProvider({
             ) : (
               <>
                 <span
-                  className={classNames(
-                    { spend_amount: true },
-                    { has_error: approvalLimitString === null }
-                  )}
+                  className={classNames("spend_amount", {
+                    has_error: approvalLimitString === null,
+                  })}
                 >
                   {approvalLimitDisplayValue}
                 </span>
@@ -257,7 +256,7 @@ export default function SignTransactionSpendAssetInfoProvider({
                 line-height: 24px;
               }
               .spend_amount.has_error {
-                color: #d64045;
+                color: var(--error);
               }
               .spacer {
                 margin-bottom: 18px;

--- a/ui/components/SignTransaction/SignTransactionSpendAssetInfoProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionSpendAssetInfoProvider.tsx
@@ -131,7 +131,7 @@ export default function SignTransactionSpendAssetInfoProvider({
           <form onSubmit={(event) => event.preventDefault()}>
             <div className="spend_limit_header">
               <span className="spend_limit_label">Spend limit</span>
-              <SharedTooltip>
+              <SharedTooltip horizontalPosition="center" width={250}>
                 <p className="spend_limit_tooltip">
                   Spend limit is the amount of funds from a particular asset,
                   that you allow a contract to spend.

--- a/ui/components/SignTransaction/SignTransactionSpendAssetInfoProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionSpendAssetInfoProvider.tsx
@@ -131,7 +131,7 @@ export default function SignTransactionSpendAssetInfoProvider({
           <form onSubmit={(event) => event.preventDefault()}>
             <div className="spend_limit_header">
               <span className="spend_limit_label">Spend limit</span>
-              <SharedTooltip horizontalPosition="center" width={250}>
+              <SharedTooltip width={250}>
                 <p className="spend_limit_tooltip">
                   Spend limit is the amount of funds from a particular asset,
                   that you allow a contract to spend.

--- a/ui/components/SignTransaction/SignTransactionSpendAssetInfoProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionSpendAssetInfoProvider.tsx
@@ -18,11 +18,13 @@ import { ethers } from "ethers"
 import { hexlify } from "ethers/lib/utils"
 import React, { ReactElement, useState } from "react"
 import { useDispatch } from "react-redux"
+import classNames from "classnames"
 import FeeSettingsText from "../NetworkFees/FeeSettingsText"
 import SharedAssetIcon from "../Shared/SharedAssetIcon"
 import SharedButton from "../Shared/SharedButton"
 import SharedInput from "../Shared/SharedInput"
 import SharedSkeletonLoader from "../Shared/SharedSkeletonLoader"
+import SharedTooltip from "../Shared/SharedTooltip"
 import TransactionDetailAddressValue from "../TransactionDetail/TransactionDetailAddressValue"
 import TransactionDetailContainer from "../TransactionDetail/TransactionDetailContainer"
 import TransactionDetailItem from "../TransactionDetail/TransactionDetailItem"
@@ -127,7 +129,19 @@ export default function SignTransactionSpendAssetInfoProvider({
             )}
           </span>
           <form onSubmit={(event) => event.preventDefault()}>
-            <span className="speed_limit_label">Spend limit</span>
+            <div className="spend_limit_header">
+              <span className="spend_limit_label">Spend limit</span>
+              <SharedTooltip>
+                <p className="spend_limit_tooltip">
+                  Spend limit is the amount of funds from a particular asset,
+                  that you allow a contract to spend.
+                </p>
+                <p className="spend_limit_tooltip">
+                  Infinite tx has the drawback that if the contract is
+                  mailicous, it can steal all your funds.
+                </p>
+              </SharedTooltip>
+            </div>
             {changing ? (
               <div>
                 <SharedInput
@@ -162,7 +176,12 @@ export default function SignTransactionSpendAssetInfoProvider({
               </div>
             ) : (
               <>
-                <span className="spend_amount">
+                <span
+                  className={classNames(
+                    { spend_amount: true },
+                    { has_error: approvalLimitString === null }
+                  )}
+                >
                   {approvalLimitDisplayValue}
                 </span>
                 <SharedButton
@@ -212,11 +231,21 @@ export default function SignTransactionSpendAssetInfoProvider({
                 margin-bottom: 16px;
                 text-align: center;
               }
-              .speed_limit_label {
+              .spend_limit_header {
+                display: flex;
+                justify-content: center;
+              }
+              .spend_limit_label {
                 color: var(--green-40);
                 font-size: 14px;
                 line-height: 16px;
                 margin-bottom: 4px;
+              }
+              .spend_limit_tooltip {
+                margin: 0 0 5px;
+              }
+              .spend_limit_tooltip:last-child {
+                margin-bottom: 0;
               }
               .change_limit_actions {
                 display: flex;
@@ -226,6 +255,9 @@ export default function SignTransactionSpendAssetInfoProvider({
                 color: #fff;
                 font-size: 16px;
                 line-height: 24px;
+              }
+              .spend_amount.has_error {
+                color: #d64045;
               }
               .spacer {
                 margin-bottom: 18px;


### PR DESCRIPTION
FIxes #726
### What is new
Mark with red color infinite spend limit. User can change spend limit and it will be white. 
Add tooltip to explain spend limit role.