### PR TITLE
So Refreshing 🍋 - Update token balances every minute.

### DIFF
--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -266,7 +266,7 @@ export default class ChainService extends BaseService<Events> {
    * provider exists.
    */
   providerForNetwork(network: EVMNetwork): SerialFallbackProvider | undefined {
-    return this.providers[network.name]
+    return this.providers[network.name.toLowerCase()]
   }
 
   /**

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -81,8 +81,7 @@ export default class IndexingService extends BaseService<Events> {
     super({
       tokens: {
         schedule: {
-          delayInMinutes: 1,
-          periodInMinutes: 30,
+          periodInMinutes: 1,
         },
         handler: () => this.handleTokenAlarm(),
         runAtStart: true,


### PR DESCRIPTION
This PR fixes a regression introduced post 0.12.1  that prevented the wallet from getting _any_ token balances - as well as reduces the interval at which we check for token balances down to 1 minute (from 30).  It partially addresses the symptoms caused by #1158 but probably not the root cause.



### To Test
• complete a swap for (or send yourself) a token you do not already have in your wallet
• wait a maximum of 1 minute
• the token and balance should show up in your asset list