### PR TITLE
💔 It's not you: remove git dependency from the build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@tallyho/tally-ui": "0.0.1",
     "@tallyho/window-provider": "0.0.1",
     "buffer": "^6.0.3",
-    "git-revision-webpack-plugin": "^5.0.0",
     "react": "^17.0.2",
     "webext-options-sync": "^2.0.1",
     "webextension-polyfill": "^0.7.0"

--- a/ui/pages/Menu.tsx
+++ b/ui/pages/Menu.tsx
@@ -102,11 +102,7 @@ export default function Menu(): ReactElement {
             Give feedback!
           </SharedButton>
           <div className="version">
-            Version: {process.env.VERSION ?? `<unknown>`} (
-            {new Date(
-              process.env.GIT_COMMIT_DATE ?? "invalid date"
-            ).toLocaleDateString(undefined, { dateStyle: "medium" })}
-            )
+            Version: {process.env.VERSION ?? `<unknown>`}
           </div>
         </div>
       </section>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6061,11 +6061,6 @@ getport@^0.1.0:
   resolved "https://registry.yarnpkg.com/getport/-/getport-0.1.0.tgz#abddf3d5d1e77dd967ccfa2b036a0a1fb26fd7f7"
   integrity sha1-q93z1dHnfdlnzPorA2oKH7Jv1/c=
 
-git-revision-webpack-plugin@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/git-revision-webpack-plugin/-/git-revision-webpack-plugin-5.0.0.tgz#0683a6a110ece618499880431cd89e1eb597b536"
-  integrity sha512-RptQN/4UKcEPkCBmRy8kLPo5i8MnF8+XfAgFYN9gbwmKLTLx4YHsQw726H+C5+sIGDixDkmGL3IxPA2gKo+u4w==
-
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"


### PR DESCRIPTION
https://www.youtube.com/watch?v=QVYgoejO3ac

Depending on the git to check version number during
build time proved to be a headache, so we have returned
to using the version from `package.json` file.

The idea is good though, probably should be placed into
the CI pipe as a step so the build itself does not depend
on the git tag.

(It caused issues with the firefox release and also internally)