### PR TITLE
Fix broken USD network fees labels

### DIFF
--- a/ui/components/NetworkFees/NetworkSettingsSelect.tsx
+++ b/ui/components/NetworkFees/NetworkSettingsSelect.tsx
@@ -61,6 +61,7 @@ const gasOptionFromEstimate = (
           2
         )
       : undefined
+  const dollarValue = feeAssetAmount?.localizedMainCurrencyAmount
 
   return {
     confidence: `${confidence}`,
@@ -69,7 +70,7 @@ const gasOptionFromEstimate = (
       (baseFeePerGas * ESTIMATED_FEE_MULTIPLIERS[confidence]) / 10n
     ).split(".")[0],
     maxGwei: weiToGwei(maxFeePerGas).split(".")[0],
-    dollarValue: feeAssetAmount?.localizedMainCurrencyAmount ?? "-",
+    dollarValue: dollarValue ? `$${dollarValue}` : "-",
     estimatedFeePerGas:
       (baseFeePerGas * ESTIMATED_FEE_MULTIPLIERS[confidence]) / 10n,
     price,
@@ -161,13 +162,16 @@ export default function NetworkSettingsSelect({
     if (typeof estimatedFeesPerGas !== "undefined") {
       const { regular, express, instant } = estimatedFeesPerGas ?? {}
       let gasLimit = networkSettings.suggestedGasLimit
-      try {
-        gasLimit = BigInt(networkSettings.gasLimit)
-      } catch (error) {
-        logger.debug(
-          "Failed to parse network settings gas limit",
-          networkSettings.gasLimit
-        )
+
+      if (networkSettings.gasLimit !== "") {
+        try {
+          gasLimit = BigInt(networkSettings.gasLimit)
+        } catch (error) {
+          logger.debug(
+            "Failed to parse network settings gas limit",
+            networkSettings.gasLimit
+          )
+        }
       }
 
       if (
@@ -236,7 +240,7 @@ export default function NetworkSettingsSelect({
             </div>
             <div className="option_right">
               <div className="price">{`~${option.estimatedGwei} Gwei`}</div>
-              <div className="subtext">${option.dollarValue}</div>
+              <div className="subtext">{option.dollarValue}</div>
             </div>
           </button>
         )


### PR DESCRIPTION
Resolves #1161

### What has been fixed

Network fees have estimated values in gwei and they should show estimated values in USD too. There was a problem that USD values were always `$0.00`.

### How it was fixed

As user has possibility to set gas limit in the input and override suggested gas limit there was attempt to set 
```gasLimit = BigInt(overrideValue)``` but as `overrideValue = ""` and `BigInt("") === 0n` we had a problem where `gasLimit` was `0`. 

Now we will check if `overrideValue` is an empty string before conversion to BigInt.