### PR TITLE
init extension i18n support

### DIFF
--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -8,7 +8,7 @@
     "description": "in Wallet > WalletAccountBalanceControl"
   },
   "menuHideSmallAssetBalance": {
-    "message": "Hide asset balance under $$2",
+    "message": "Hide asset balance under $$$1",
     "description": "in pages > Menu"
   },
   "menuSetAsDefault": {

--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -8,7 +8,7 @@
     "description": "in Wallet > WalletAccountBalanceControl"
   },
   "menuHideSmallAssetBalance": {
-    "message": "Hide asset balance under %242",
+    "message": "Hide asset balance under $$2",
     "description": "in pages > Menu"
   },
   "menuSetAsDefault": {

--- a/ui/_locales/zh_TW/messages.json
+++ b/ui/_locales/zh_TW/messages.json
@@ -8,7 +8,7 @@
     "description": "in Wallet > WalletAccountBalanceControl"
   },
   "menuHideSmallAssetBalance": {
-    "message": "隱藏小於 $$2 的資產",
+    "message": "隱藏小於 $$$1 的資產",
     "description": "in pages > Menu"
   },
   "menuSetAsDefault": {

--- a/ui/_locales/zh_TW/messages.json
+++ b/ui/_locales/zh_TW/messages.json
@@ -1,18 +1,18 @@
 {
   "totalAccountBalance": {
-    "message": "Total account balance",
+    "message": "帳戶總額",
     "description": "in Wallet > WalletAccountBalanceControl"
   },
   "readOnlyNotice": {
-    "message": "Read-only mode",
+    "message": "唯讀模式",
     "description": "in Wallet > WalletAccountBalanceControl"
   },
   "menuHideSmallAssetBalance": {
-    "message": "Hide asset balance under %242",
+    "message": "隱藏小於 %242 的資產",
     "description": "in pages > Menu"
   },
   "menuSetAsDefault": {
-    "message": "Use Tally Ho as default wallet",
+    "message": "將 Tally Ho 設定成預設錢包",
     "description": "in pages > Menu"
   }
 }

--- a/ui/_locales/zh_TW/messages.json
+++ b/ui/_locales/zh_TW/messages.json
@@ -8,7 +8,7 @@
     "description": "in Wallet > WalletAccountBalanceControl"
   },
   "menuHideSmallAssetBalance": {
-    "message": "隱藏小於 %242 的資產",
+    "message": "隱藏小於 $$2 的資產",
     "description": "in pages > Menu"
   },
   "menuSetAsDefault": {

--- a/ui/components/Wallet/WalletAccountBalanceControl.tsx
+++ b/ui/components/Wallet/WalletAccountBalanceControl.tsx
@@ -7,12 +7,13 @@ import { useBackgroundSelector, useLocalStorage } from "../../hooks"
 import SharedButton from "../Shared/SharedButton"
 import SharedSlideUpMenu from "../Shared/SharedSlideUpMenu"
 import Receive from "../../pages/Receive"
+import t from "../../utils/i18n"
 
 function ReadOnlyNotice(): ReactElement {
   return (
     <div className="notice_wrap">
       <div className="icon_eye" />
-      Read-only mode
+      {t("readOnlyNotice")}
       <style jsx>{`
         .notice_wrap {
           width: 177px;
@@ -143,7 +144,7 @@ export default function WalletAccountBalanceControl(
             balance_label_loading: shouldIndicateLoading,
           })}
         >
-          Total account balance
+          {t("totalAccountBalance")}
         </div>
         <span className="balance_area">
           <span

--- a/ui/pages/Menu.tsx
+++ b/ui/pages/Menu.tsx
@@ -54,7 +54,7 @@ export default function Menu(): ReactElement {
   const settings = {
     general: [
       {
-        title: t("menuHideSmallAssetBalance"),
+        title: t("menuHideSmallAssetBalance", "2"),
         component: () => (
           <SharedToggleButton
             onChange={(toggleValue) => toggleHideDustAssets(toggleValue)}

--- a/ui/pages/Menu.tsx
+++ b/ui/pages/Menu.tsx
@@ -8,6 +8,7 @@ import {
 } from "@tallyho/tally-background/redux-slices/ui"
 import SharedButton from "../components/Shared/SharedButton"
 import SharedToggleButton from "../components/Shared/SharedToggleButton"
+import t from "../utils/i18n"
 
 function SettingRow(props: {
   title: string
@@ -53,7 +54,7 @@ export default function Menu(): ReactElement {
   const settings = {
     general: [
       {
-        title: "Hide asset balance under $2",
+        title: t("menuHideSmallAssetBalance"),
         component: () => (
           <SharedToggleButton
             onChange={(toggleValue) => toggleHideDustAssets(toggleValue)}
@@ -62,7 +63,7 @@ export default function Menu(): ReactElement {
         ),
       },
       {
-        title: "Use Tally Ho as default wallet",
+        title: t("menuSetAsDefault"),
         component: () => (
           <SharedToggleButton
             onChange={(toggleValue) => toggleDefaultWallet(toggleValue)}

--- a/ui/utils/i18n.ts
+++ b/ui/utils/i18n.ts
@@ -1,0 +1,5 @@
+import browser from "webextension-polyfill"
+
+export default function t(msg: string, params: string | string[] = ""): string {
+  return browser.i18n.getMessage(msg, params) ?? ""
+}


### PR DESCRIPTION
related to #438

refer official i18n doc https://developer.chrome.com/docs/webstore/i18n/
to localize some strings

<img width="385" alt="截圖 2022-03-18 下午11 13 43" src="https://user-images.githubusercontent.com/748808/159030321-201f133a-bf2f-434d-b8fb-596806420db4.png">

<img width="385" alt="截圖 2022-03-18 下午11 13 52" src="https://user-images.githubusercontent.com/748808/159030332-330efbf3-6a4e-48df-9923-05ccc18e5a72.png"> 

to add new locale, just add _locale/es/messages.json and copy from en/messages.json

Learned while porting:
- the message format is verbose, and json is not a good format to maintain multiple locale files. Need think about a better way to
  - merge new strings for locale files 
  - collaborate the translations work
- localize ui/pages/Tab.tsx broken the UI, need more tweak
- some strings (ex: `$`) need to be present as the encoded version in messages.json 
refer https://www.w3schools.com/tags/ref_urlencode.asp
