### PR TITLE
Remove "ETH coming soon" notice

### DIFF
--- a/ui/components/Shared/SharedAssetInput.tsx
+++ b/ui/components/Shared/SharedAssetInput.tsx
@@ -161,10 +161,6 @@ function SelectAssetMenuContent<T extends AnyAsset>(
         </div>
       </div>
       <div className="divider" />
-      <div className="coming_soon_notice">
-        <div className="notice_icon" />
-        ETH coming soon
-      </div>
       <ul className="assets_list">
         {sortedFilteredAssets.map((assetWithOptionalAmount) => {
           const { asset } = assetWithOptionalAmount
@@ -183,24 +179,6 @@ function SelectAssetMenuContent<T extends AnyAsset>(
       </ul>
       <style jsx>
         {`
-          .coming_soon_notice {
-            display: flex;
-            color: var(--attention);
-            font-size: 14px;
-            font-weight: 400;
-            margin-left: 25px;
-            padding-top: 13px;
-            padding-bottom: 12px;
-            align-items: center;
-          }
-          .notice_icon {
-            mask-image: url("./images/warning@2x.png");
-            background-color: var(--attention);
-            mask-size: 15px 14px;
-            width: 15px;
-            height: 14px;
-            margin-right: 6px;
-          }
           .search_label {
             height: 20px;
             color: var(--green-60);


### PR DESCRIPTION
Now that we support swapping from ETH into other ERC-20 Tokens.  The notice is no longer needed.

### To Test
- Open up the Swaps page, select ETH as your `From` Asset, the notice should not be there.