### PR TITLE
Disable Editing of Slippage Tolerance in Swaps Network Settings.

### DIFF
--- a/ui/components/Swap/SwapTransactionSettingsChooser.tsx
+++ b/ui/components/Swap/SwapTransactionSettingsChooser.tsx
@@ -72,9 +72,7 @@ export default function SwapTransactionSettingsChooser({
             <div className="settings_wrap">
               <div className="row row_slippage">
                 <span className="settings_label">Slippage tolerance</span>
-                <SharedButton type="secondary" size="medium" icon="chevron">
-                  1%
-                </SharedButton>
+                <span>1%</span>
               </div>
               <div className="row row_fee">
                 <NetworkSettingsSelect


### PR DESCRIPTION
Closes #863

Since this is a setting we do not ~~have control over~~ currently allow the user to change we should just display is as a value and not a dropdown.

Before:
<img width="386" alt="image" src="https://user-images.githubusercontent.com/94649004/159051413-d7143319-7579-4bc1-b0ca-b675db17b647.png">


After: 
<img width="384" alt="image" src="https://user-images.githubusercontent.com/94649004/159051292-d2767bcf-e75e-4f21-a77f-b68a86320c62.png">
