### PR TITLE
Don't fail to unlock already unlocked keyrings.

### DIFF
--- a/background/services/keyring/index.ts
+++ b/background/services/keyring/index.ts
@@ -24,6 +24,7 @@ import { ETH, FORK, MINUTE } from "../../constants"
 import { ethersTransactionRequestFromEIP1559TransactionRequest } from "../chain/utils"
 import { HIDE_IMPORT_LEDGER, USE_MAINNET_FORK } from "../../features/features"
 import { AddressOnNetwork } from "../../accounts"
+import logger from "../../lib/logger"
 
 export const MAX_KEYRING_IDLE_TIME = 60 * MINUTE
 export const MAX_OUTSIDE_IDLE_TIME = 60 * MINUTE
@@ -134,6 +135,15 @@ export default class KeyringService extends BaseService<Events> {
   }
 
   /**
+   * Update activity timestamps and emit unlocked event.
+   */
+  #unlock(): void {
+    this.lastKeyringActivity = Date.now()
+    this.lastOutsideActivity = Date.now()
+    this.emitter.emit("locked", false)
+  }
+
+  /**
    * Unlock the keyring with a provided password, initializing from the most
    * recently persisted keyring vault if one exists.
    *
@@ -158,7 +168,9 @@ export default class KeyringService extends BaseService<Events> {
     ignoreExistingVaults = false
   ): Promise<boolean> {
     if (!this.locked()) {
-      throw new Error("KeyringService is already unlocked!")
+      logger.warn("KeyringService is already unlocked!")
+      this.#unlock()
+      return true
     }
 
     if (!ignoreExistingVaults) {
@@ -207,9 +219,7 @@ export default class KeyringService extends BaseService<Events> {
       await this.persistKeyrings()
     }
 
-    this.lastKeyringActivity = Date.now()
-    this.lastOutsideActivity = Date.now()
-    this.emitter.emit("locked", false)
+    this.#unlock()
     return true
   }
 

--- a/background/tests/keyring-integration.test.ts
+++ b/background/tests/keyring-integration.test.ts
@@ -11,6 +11,7 @@ import KeyringService, {
 import { KeyringTypes } from "../types"
 import { EIP1559TransactionRequest } from "../networks"
 import { ETHEREUM } from "../constants"
+import logger from "../lib/logger"
 
 const originalCrypto = global.crypto
 beforeEach(() => {
@@ -264,6 +265,15 @@ describe("KeyringService when initialized", () => {
         transactionWithFrom
       )
     ).resolves.toBeDefined()
+  })
+
+  it("successfully unlocks already unlocked wallet", async () => {
+    jest.spyOn(logger, "warn").mockImplementation((arg) => {
+      // We should log if we try to unlock an unlocked keyring
+      expect(arg).toEqual("KeyringService is already unlocked!")
+    })
+    expect(service.locked()).toEqual(false)
+    expect(await service.unlock(testPassword)).toEqual(true)
   })
 })
 


### PR DESCRIPTION
Partially addresses #1213 until we can figure out the problem on the UI side.

### To Test
I am not sure how to recreate this naturally in the application so these are the steps I took to reliably create inconsistent state:


#### Setup
- add `;(window as any).keyringService = this.keyringService` on the last line of `internalStartService` in `main.ts`.
- add an optional `broadcast` parameter to the `#unlock` method that defaults to true.
- wrap line `143` in `services/keyrings/index.ts` in an `if (broadcast) { ... }` clause.
- pass `false` to `this.#unlock` on like `222` in `services/keyrings/index.ts`

#### Execution
After making the above changes to the codebase
- ensure your wallet is locked by inspecting `keyringService.locked()` in the `background page` console.
- If it is not locked - `keyringService.lock()`.
- Navigate to a page that requires you to unlock your wallet (for example - adding a new address to an account).
- Once the `Enter Password` screen is open - do not enter your password.
- Open the background page console and type `keyringService.unlock(your_password)`
- Verify the keyring is unlocked (`keyringService.locked() === false`)
- The extension should still be asking you for a password (this is the state inconsistency we created above)
- Type in your password to the extension
- You should see a `warning` in the `background page` console about keyrings already being unlocked - and the extension should successfully accept your password and unlock.