### PR TITLE
DO NOT MERGE - change a dependency version to test lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@tallyho/tally-ui": "0.0.1",
     "@tallyho/window-provider": "0.0.1",
     "buffer": "^6.0.3",
-    "react": "^17.0.2",
+    "react": "^15.0.2",
     "webext-options-sync": "^2.0.1",
     "webextension-polyfill": "^0.7.0"
   },


### PR DESCRIPTION
`yarn.lock` should ensure that we never build a packages with dependencies which are different to those used during development. This PR is a PoC that the mechanism works.
Expected result: CI should fail, no package is created.