### PR TITLE
Wiggle Wiggle: Little niggles

### DIFF
--- a/background/services/enrichment/types.ts
+++ b/background/services/enrichment/types.ts
@@ -44,6 +44,7 @@ export type AssetTransfer = BaseTransactionAnnotation & {
   type: "asset-transfer"
   assetAmount: AnyAssetAmount & AssetDecimalAmount
   recipientAddress: HexString
+  recipientName: HexString | undefined
   senderAddress: HexString
 }
 

--- a/manifest/manifest.brave.json
+++ b/manifest/manifest.brave.json
@@ -1,1 +1,5 @@
-{}
+{
+  "externally_connectable": {
+    "ids": []
+  }
+}

--- a/manifest/manifest.chrome.json
+++ b/manifest/manifest.chrome.json
@@ -1,3 +1,6 @@
 {
-  "minimum_chrome_version": "74"
+  "minimum_chrome_version": "74",
+  "externally_connectable": {
+    "ids": []
+  }
 }

--- a/manifest/manifest.firefox.json
+++ b/manifest/manifest.firefox.json
@@ -3,7 +3,7 @@
     "gecko": {
       "id": "webextension@tally.cash",
       "strict_min_version": "68.0"
-    },
-    "permissions": ["https://*/*"]
-  }
+    }
+  },
+  "permissions": ["https://*/*"]
 }

--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -34,9 +34,6 @@
     "default_popup": "popup.html"
   },
   "permissions": ["alarms", "storage", "unlimitedStorage", "activeTab"],
-  "externally_connectable": {
-    "ids": []
-  },
   "background": {
     "persistent": true,
     "scripts": ["background.js", "background-ui.js"]

--- a/manifest/manifest.opera.json
+++ b/manifest/manifest.opera.json
@@ -1,1 +1,5 @@
-{}
+{
+  "externally_connectable": {
+    "ids": []
+  }
+}

--- a/ui/components/SignTransaction/SignTransactionSpendAssetInfoProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionSpendAssetInfoProvider.tsx
@@ -108,6 +108,10 @@ export default function SignTransactionSpendAssetInfoProvider({
     )
   }
 
+  const spenderAddressSpan = (
+    <span title={spenderAddress}>{truncateAddress(spenderAddress)}</span>
+  )
+
   return (
     <SignTransactionBaseInfoProvider
       title="Approve asset spend"
@@ -124,7 +128,16 @@ export default function SignTransactionSpendAssetInfoProvider({
               />
             </div>
           </div>
-          <span className="site">Smart Contract Interaction</span>
+          <span className="site">
+            Approve{" "}
+            {annotation.spenderName === undefined ? (
+              spenderAddressSpan
+            ) : (
+              <>
+                {annotation.spenderName} ({spenderAddressSpan})
+              </>
+            )}
+          </span>
           <span className="spending_label">
             {asset.symbol ? (
               `Spend ${

--- a/ui/components/SignTransaction/SignTransactionSpendAssetInfoProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionSpendAssetInfoProvider.tsx
@@ -117,7 +117,11 @@ export default function SignTransactionSpendAssetInfoProvider({
           <div className="spend_destination_icons">
             <div className="site_icon" />
             <div className="asset_icon_wrap">
-              <SharedAssetIcon size="large" symbol={asset.symbol} />
+              <SharedAssetIcon
+                size="large"
+                symbol={asset.symbol}
+                logoURL={asset.metadata?.logoURL}
+              />
             </div>
           </div>
           <span className="site">Smart Contract Interaction</span>

--- a/ui/components/SignTransaction/SignTransactionTransferInfoProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionTransferInfoProvider.tsx
@@ -21,7 +21,7 @@ import SignTransactionBaseInfoProvider, {
 
 export default function SignTransactionTransferInfoProvider({
   transactionDetails,
-  annotation: { assetAmount, recipientAddress },
+  annotation: { assetAmount, recipientAddress, recipientName },
   inner,
 }: SignTransactionInfoProviderProps & {
   annotation: TransactionAnnotation & { type: "asset-transfer" }
@@ -37,6 +37,10 @@ export default function SignTransactionTransferInfoProvider({
     enrichAssetAmountWithMainCurrencyValues(assetAmount, assetPricePoint, 2)
       .localizedMainCurrencyAmount ?? "-"
 
+  const recipientAddressSpan = (
+    <span title={recipientAddress}>{truncateAddress(recipientAddress)}</span>
+  )
+
   return (
     <SignTransactionBaseInfoProvider
       title="Sign Transfer"
@@ -45,7 +49,15 @@ export default function SignTransactionTransferInfoProvider({
         <div className="sign_block">
           <div className="container">
             <div className="label">Send to</div>
-            <div className="send_to">{truncateAddress(recipientAddress)}</div>
+            <div className="send_to">
+              {recipientName !== undefined ? (
+                <>
+                  {recipientName} ({recipientAddressSpan})
+                </>
+              ) : (
+                recipientAddressSpan
+              )}
+            </div>
           </div>
           <div className="divider" />
           <div className="container">


### PR DESCRIPTION
Fixes a few manifest issues for Firefox, shows asset icons correctly
on the asset approve page, and shows recipient names in asset transfers
and spender names approve signatures, when available. Also shows spender
addresses on approve signatures, which was not happening before.

Lastly, starts putting in some `span`s with full address OS tooltips. This
needs to be refactored to a component with copy functionality (see #649),
but one thing at a time.

<img width="370" alt="Screen Shot 2022-03-22 at 17 19 29" src="https://user-images.githubusercontent.com/8245/159577864-885ff90f-fb51-4d1a-939c-920b7e9242d7.png">

<img width="390" alt="Screen Shot 2022-03-22 at 17 21 30" src="https://user-images.githubusercontent.com/8245/159578168-1b3076a8-83ef-419e-a228-d5d6fb33f11b.png">

Builds on the awesome work from @jack-the-pug in #1221.

Fixes #1176.