### PR TITLE
Copy Waste: Add SharedAddress component with address copying

### DIFF
--- a/background/lib/utils/index.ts
+++ b/background/lib/utils/index.ts
@@ -123,7 +123,7 @@ export function isProbablyEVMAddress(str: string): str is HexString {
 }
 
 export function truncateAddress(address: string): string {
-  return `${address.slice(0, 6)}...${address.slice(-5)}`
+  return `${address.slice(0, 6)}…${address.slice(-5)}`
 }
 
 export const getNumericStringValueFromBigNumber = (

--- a/background/services/name/index.ts
+++ b/background/services/name/index.ts
@@ -11,6 +11,8 @@ import logger from "../../lib/logger"
 import { AddressOnNetwork } from "../../accounts"
 import { SECOND } from "../../constants"
 
+export type NameResolverSystem = "ENS" | "UNS" | "local"
+
 type ResolvedAddressRecord = {
   from: {
     name: DomainName
@@ -18,7 +20,7 @@ type ResolvedAddressRecord = {
   resolved: {
     addressNetwork: AddressOnNetwork
   }
-  system: "ENS" | "UNS"
+  system: NameResolverSystem
 }
 
 type ResolvedNameRecord = {
@@ -29,7 +31,7 @@ type ResolvedNameRecord = {
     name: DomainName
     expiresAt: UNIXTime
   }
-  system: "ENS" | "UNS"
+  system: NameResolverSystem
 }
 
 type ResolvedAvatarRecord = {
@@ -39,7 +41,7 @@ type ResolvedAvatarRecord = {
   resolved: {
     avatar: URL
   }
-  system: "ENS" | "UNS"
+  system: NameResolverSystem
 }
 
 type Events = ServiceLifecycleEvents & {

--- a/ui/components/Shared/SharedAddress.tsx
+++ b/ui/components/Shared/SharedAddress.tsx
@@ -1,0 +1,68 @@
+import { truncateAddress } from "@tallyho/tally-background/lib/utils"
+import { setSnackbarMessage } from "@tallyho/tally-background/redux-slices/ui"
+import { NameResolverSystem } from "@tallyho/tally-background/services/name"
+import React, { ReactElement, useCallback } from "react"
+import { useBackgroundDispatch } from "../../hooks"
+import SharedTooltip from "./SharedTooltip"
+
+type SharedAddressProps = {
+  address: string
+  name?: string | undefined
+  nameResolverSystem?: NameResolverSystem
+}
+
+/**
+ * The SharedAddress component is used to render addresses that can optionally
+ * be represented as resolved names, and that are copiable by clicking.
+ *
+ * The component always expects an `address` prop. If an optional `name` prop
+ * is passed, it is shown; otherwise, a truncated version of the address is
+ * shown. The component tooltip always has a tooltip with the full address.
+ * Additionally, clicking the component will copy the address to the clipboard
+ * and present the user with a snackbar message indicating this has occurred.
+ *
+ * If the optional `nameResolverSystem` property is provided, an info tooltip
+ * is included in the component to inform the user of which name resolver
+ * system was used to resolve the passed `name`. If no `name` is passed, the
+ * `nameResolverSystem` prop is ignored.
+ */
+export default function SharedAddress({
+  name,
+  address,
+  nameResolverSystem: nameSourceSystem,
+}: SharedAddressProps): ReactElement {
+  const dispatch = useBackgroundDispatch()
+
+  const primaryText = name ?? truncateAddress(address)
+
+  const copyAddress = useCallback(() => {
+    navigator.clipboard.writeText(address)
+    dispatch(setSnackbarMessage("Address copied to clipboard"))
+  }, [address, dispatch])
+
+  return (
+    <button type="button" onClick={copyAddress} title={address}>
+      {primaryText}
+      {name === undefined || nameSourceSystem === undefined ? (
+        <></>
+      ) : (
+        <>
+          <SharedTooltip width={130}>
+            <p className="name_source_tooltip">
+              Resolved using {nameSourceSystem}
+            </p>
+          </SharedTooltip>{" "}
+        </>
+      )}
+      <style jsx>{`
+        button :last-child {
+          top: 3px;
+        }
+        .name_source_tooltip {
+          margin: 0;
+          text-align: center;
+        }
+      `}</style>
+    </button>
+  )
+}

--- a/ui/components/Shared/SharedAddress.tsx
+++ b/ui/components/Shared/SharedAddress.tsx
@@ -59,8 +59,14 @@ export default function SharedAddress({
         </>
       )}
       <style jsx>{`
+        button {
+          transition: 300ms color;
+        }
         button :last-child {
           top: 3px;
+        }
+        button:hover {
+          color: var(--gold-80);
         }
         .name_source_tooltip {
           margin: 0;

--- a/ui/components/Shared/SharedAddress.tsx
+++ b/ui/components/Shared/SharedAddress.tsx
@@ -41,7 +41,11 @@ export default function SharedAddress({
   }, [address, dispatch])
 
   return (
-    <button type="button" onClick={copyAddress} title={address}>
+    <button
+      type="button"
+      onClick={copyAddress}
+      title={`Copy address:\n${address}`}
+    >
       {primaryText}
       {name === undefined || nameSourceSystem === undefined ? (
         <></>

--- a/ui/components/Shared/SharedAddress.tsx
+++ b/ui/components/Shared/SharedAddress.tsx
@@ -44,7 +44,7 @@ export default function SharedAddress({
     <button
       type="button"
       onClick={copyAddress}
-      title={`Copy address:\n${address}`}
+      title={`Copy to clipboard:\n${address}`}
     >
       {primaryText}
       {name === undefined || nameSourceSystem === undefined ? (

--- a/ui/components/Shared/SharedAddress.tsx
+++ b/ui/components/Shared/SharedAddress.tsx
@@ -29,7 +29,7 @@ type SharedAddressProps = {
 export default function SharedAddress({
   name,
   address,
-  nameResolverSystem: nameSourceSystem,
+  nameResolverSystem,
 }: SharedAddressProps): ReactElement {
   const dispatch = useBackgroundDispatch()
 
@@ -47,13 +47,13 @@ export default function SharedAddress({
       title={`Copy to clipboard:\n${address}`}
     >
       {primaryText}
-      {name === undefined || nameSourceSystem === undefined ? (
+      {name === undefined || nameResolverSystem === undefined ? (
         <></>
       ) : (
         <>
           <SharedTooltip width={130}>
             <p className="name_source_tooltip">
-              Resolved using {nameSourceSystem}
+              Resolved using {nameResolverSystem}
             </p>
           </SharedTooltip>{" "}
         </>

--- a/ui/components/Shared/SharedTooltip.tsx
+++ b/ui/components/Shared/SharedTooltip.tsx
@@ -1,9 +1,9 @@
 import React, { ReactElement, useState } from "react"
 
-type VeriticalPosition = "top" | "bottom"
+type VerticalPosition = "top" | "bottom"
 
 interface Props {
-  verticalPosition?: VeriticalPosition
+  verticalPosition?: VerticalPosition
   width: number
   children: React.ReactNode
   IconComponent?: () => ReactElement
@@ -13,7 +13,7 @@ function getHorizontalPosition(width: number) {
   return `right: -${width / 2 + 4}px;`
 }
 
-function getVerticalPosition(vertical: VeriticalPosition) {
+function getVerticalPosition(vertical: VerticalPosition) {
   switch (vertical) {
     case "bottom":
       return "top: 16px; margin-top: 5px;"
@@ -44,7 +44,7 @@ export default function SharedTooltip(props: Props): ReactElement {
         {`
           .tooltip_wrap {
             width: fit-content;
-            display: inline-block;
+            display: block;
             position: relative;
             margin-left: 8px;
             z-index: 20;

--- a/ui/components/SignTransaction/SignTransactionSignInfoProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionSignInfoProvider.tsx
@@ -1,6 +1,5 @@
 import { unitPricePointForPricePoint } from "@tallyho/tally-background/assets"
 import { USD } from "@tallyho/tally-background/constants"
-import { truncateAddress } from "@tallyho/tally-background/lib/utils"
 import { selectAssetPricePoint } from "@tallyho/tally-background/redux-slices/assets"
 import { selectCurrentAddressNetwork } from "@tallyho/tally-background/redux-slices/selectors"
 import {

--- a/ui/components/SignTransaction/SignTransactionSignInfoProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionSignInfoProvider.tsx
@@ -10,6 +10,7 @@ import {
 } from "@tallyho/tally-background/redux-slices/utils/asset-utils"
 import React, { ReactElement } from "react"
 import { useBackgroundSelector } from "../../hooks"
+import SharedAddress from "../Shared/SharedAddress"
 import TransactionDetailAddressValue from "../TransactionDetail/TransactionDetailAddressValue"
 import TransactionDetailContainer from "../TransactionDetail/TransactionDetailContainer"
 import TransactionDetailItem from "../TransactionDetail/TransactionDetailItem"
@@ -62,13 +63,14 @@ export default function SignTransactionSignInfoProvider({
             ) : (
               <>
                 <div className="label">Send to</div>
-                {annotation?.type === "contract-interaction" &&
-                annotation.contractName ? (
-                  <div className="send_to_name">{annotation.contractName}</div>
-                ) : null}
-                <div className="send_to">
-                  {truncateAddress(transactionDetails.to)}
-                </div>
+                <SharedAddress
+                  address={transactionDetails.to}
+                  name={
+                    annotation !== undefined && "contractName" in annotation
+                      ? annotation.contractName
+                      : undefined
+                  }
+                />
               </>
             )}
           </div>
@@ -116,9 +118,6 @@ export default function SignTransactionSignInfoProvider({
                 margin: 20px 0;
                 flex-direction: column;
                 align-items: center;
-              }
-              .send_to {
-                font-size: 16px;
               }
               .main_currency_value {
                 color: var(--green-40);

--- a/ui/components/SignTransaction/SignTransactionSpendAssetInfoProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionSpendAssetInfoProvider.tsx
@@ -30,6 +30,7 @@ import TransactionDetailItem from "../TransactionDetail/TransactionDetailItem"
 import SignTransactionBaseInfoProvider, {
   SignTransactionInfoProviderProps,
 } from "./SignTransactionInfoBaseProvider"
+import SharedAddress from "../Shared/SharedAddress"
 
 export default function SignTransactionSpendAssetInfoProvider({
   transactionDetails,
@@ -108,10 +109,6 @@ export default function SignTransactionSpendAssetInfoProvider({
     )
   }
 
-  const spenderAddressSpan = (
-    <span title={spenderAddress}>{truncateAddress(spenderAddress)}</span>
-  )
-
   return (
     <SignTransactionBaseInfoProvider
       title="Approve asset spend"
@@ -130,18 +127,17 @@ export default function SignTransactionSpendAssetInfoProvider({
           </div>
           <span className="site">
             Approve{" "}
-            {annotation.spenderName === undefined ? (
-              spenderAddressSpan
-            ) : (
-              <>
-                {annotation.spenderName} ({spenderAddressSpan})
-              </>
-            )}
+            <SharedAddress
+              address={spenderAddress}
+              name={annotation.spenderName}
+            />
           </span>
           <span className="spending_label">
             {asset.symbol ? (
               `Spend ${
-                asset.symbol ?? truncateAddress(transactionDetails.to ?? "")
+                asset.symbol ?? (
+                  <SharedAddress address={transactionDetails.to ?? ""} />
+                )
               } tokens`
             ) : (
               <SharedSkeletonLoader />

--- a/ui/components/SignTransaction/SignTransactionSpendAssetInfoProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionSpendAssetInfoProvider.tsx
@@ -7,10 +7,7 @@ import {
   fixedPointNumberToString,
   parseToFixedPointNumber,
 } from "@tallyho/tally-background/lib/fixed-point"
-import {
-  isMaxUint256,
-  truncateAddress,
-} from "@tallyho/tally-background/lib/utils"
+import { isMaxUint256 } from "@tallyho/tally-background/lib/utils"
 import { updateTransactionOptions } from "@tallyho/tally-background/redux-slices/transaction-construction"
 import { AssetApproval } from "@tallyho/tally-background/services/enrichment"
 import { ethers } from "ethers"

--- a/ui/components/SignTransaction/SignTransactionTransferInfoProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionTransferInfoProvider.tsx
@@ -12,6 +12,7 @@ import { TransactionAnnotation } from "@tallyho/tally-background/services/enrich
 import React, { ReactElement } from "react"
 import { useBackgroundSelector } from "../../hooks"
 import FeeSettingsText from "../NetworkFees/FeeSettingsText"
+import SharedAddress from "../Shared/SharedAddress"
 import TransactionDetailAddressValue from "../TransactionDetail/TransactionDetailAddressValue"
 import TransactionDetailContainer from "../TransactionDetail/TransactionDetailContainer"
 import TransactionDetailItem from "../TransactionDetail/TransactionDetailItem"
@@ -50,13 +51,7 @@ export default function SignTransactionTransferInfoProvider({
           <div className="container">
             <div className="label">Send to</div>
             <div className="send_to">
-              {recipientName !== undefined ? (
-                <>
-                  {recipientName} ({recipientAddressSpan})
-                </>
-              ) : (
-                recipientAddressSpan
-              )}
+              <SharedAddress address={recipientAddress} name={recipientName} />
             </div>
           </div>
           <div className="divider" />

--- a/ui/components/Wallet/WalletActivityDetails.tsx
+++ b/ui/components/Wallet/WalletActivityDetails.tsx
@@ -3,6 +3,7 @@ import { ActivityItem } from "@tallyho/tally-background/redux-slices/activities"
 import { truncateAddress } from "@tallyho/tally-background/lib/utils"
 import { getRecipient } from "@tallyho/tally-background/redux-slices/utils/activity-utils"
 import SharedButton from "../Shared/SharedButton"
+import SharedAddress from "../Shared/SharedAddress"
 
 interface DetailRowItemProps {
   label: string
@@ -61,7 +62,7 @@ function DestinationCard(props: DestinationCardProps): ReactElement {
   return (
     <div className="card_wrap">
       <div className="sub_info from">{label}:</div>
-      {truncateAddress(address)}
+      <SharedAddress address={address} />
       <div className="sub_info name" />
       <style jsx>
         {`


### PR DESCRIPTION
Add `SharedAddress` component and use it in transaction signing
and activity details.

Current limitations:
- Tooltip is an OS tooltip using `title`, preferences may vary.
- We don't propagate name system information and don't yet have
  a design for how to tell the user which name system was used
  to determine the name they see.
- Names are not resolved in as many places as might be ideal.
- There is no icon indicator that a copy is possible.

That said, anywhere a name is resolved it is displayed, tooltip
has the address, and clicking copies, so the basis for the
functionality we want is there and we are in a strictly better
place with these changes.

Screenshots:

<img width="478" alt="Screen Shot 2022-03-22 at 21 57 10" src="https://user-images.githubusercontent.com/8245/159606620-2ee90dee-a03a-4ac0-a677-8358b6484122.png">

<img width="408" alt="Screen Shot 2022-03-22 at 21 57 30" src="https://user-images.githubusercontent.com/8245/159606644-5fae192d-5a3a-47a6-98cf-f3944568afce.png">

See #649.