### PR TITLE
🚨🚓🚨 - Alert on failed transaction broadcasts.

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -642,12 +642,6 @@ export default class Main extends BaseService<never> {
       this.store.dispatch(blockSeen(block))
     })
 
-    this.chainService.emitter.on("transactionSent", () => {
-      this.store.dispatch(
-        setSnackbarMessage("Transaction signed, broadcasting...")
-      )
-    })
-
     transactionConstructionSliceEmitter.on("updateOptions", async (options) => {
       const {
         values: { maxFeePerGas, maxPriorityFeePerGas },
@@ -692,7 +686,17 @@ export default class Main extends BaseService<never> {
     transactionConstructionSliceEmitter.on(
       "broadcastSignedTransaction",
       async (transaction: SignedEVMTransaction) => {
-        this.chainService.broadcastSignedTransaction(transaction)
+        try {
+          await this.chainService.broadcastSignedTransaction(transaction)
+          this.store.dispatch(
+            setSnackbarMessage("Transaction signed, broadcasting...")
+          )
+        } catch (e) {
+          // Error logging is handled inside of `broadcastSignedTransaction`.
+          this.store.dispatch(
+            setSnackbarMessage("Transaction failed to broadcast.")
+          )
+        }
       }
     )
 

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -83,7 +83,6 @@ const TRANSACTION_CHECK_LIFETIME_MS = 10 * HOUR
 interface Events extends ServiceLifecycleEvents {
   newAccountToTrack: AddressOnNetwork
   accountBalance: AccountBalance
-  transactionSent: HexString
   assetTransfers: {
     addressNetwork: AddressOnNetwork
     assetTransfers: AssetTransfer[]
@@ -622,26 +621,21 @@ export default class ChainService extends BaseService<Events> {
     )
     try {
       await Promise.all([
-        this.providers.ethereum
-          .sendTransaction(serialized)
-          .then((transactionResponse) => {
-            this.emitter.emit("transactionSent", transactionResponse.hash)
-          })
-          .catch((error) => {
-            logger.debug(
-              "Broadcast error caught, saving failed status and releasing nonce...",
-              transaction,
-              error
-            )
-            // Failure to broadcast needs to be registered.
-            this.saveTransaction(
-              { ...transaction, status: 0, error: error.toString() },
-              "alchemy"
-            )
-            this.releaseEVMTransactionNonce(transaction)
+        this.providers.ethereum.sendTransaction(serialized).catch((error) => {
+          logger.debug(
+            "Broadcast error caught, saving failed status and releasing nonce...",
+            transaction,
+            error
+          )
+          // Failure to broadcast needs to be registered.
+          this.saveTransaction(
+            { ...transaction, status: 0, error: error.toString() },
+            "alchemy"
+          )
+          this.releaseEVMTransactionNonce(transaction)
 
-            return Promise.reject(error)
-          }),
+          return Promise.reject(error)
+        }),
         this.subscribeToTransactionConfirmation(
           transaction.network,
           transaction

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -614,12 +614,12 @@ export default class ChainService extends BaseService<Events> {
   async broadcastSignedTransaction(
     transaction: SignedEVMTransaction
   ): Promise<void> {
-    // TODO make proper use of tx.network to choose provider
-    const serialized = utils.serializeTransaction(
-      ethersTransactionFromSignedTransaction(transaction),
-      { r: transaction.r, s: transaction.s, v: transaction.v }
-    )
     try {
+      // TODO make proper use of tx.network to choose provider
+      const serialized = utils.serializeTransaction(
+        ethersTransactionFromSignedTransaction(transaction),
+        { r: transaction.r, s: transaction.s, v: transaction.v }
+      )
       await Promise.all([
         this.providers.ethereum.sendTransaction(serialized).catch((error) => {
           logger.debug(


### PR DESCRIPTION
This PR gets rid of the `transactionSent` event in `chainService` in favor of a try / catch inside of the `broadcastSignedTransaction` event handler that reports a success or failure based on the result of `broadcastSignedTransaction` method in `chainService`.

### Test Criteria
- [ ] A successful transaction should result in a snackbar message of `Transaction signed, broadcasting...`
- [ ] An unsuccessful transaction should result in a snackbar message of `Transaction failed to broadcast.`

The easiest way to simulate an unsuccessful transaction is to edit the code and throw an error inside of `broadcastSignedTransaction`

This PR addresses [an excellent suggestion](https://github.com/tallycash/extension/pull/1201#discussion_r831486778) made in #1201 