### PR TITLE
📋 Add copy to clipboard button to onboarding save phrase

### DIFF
--- a/ui/pages/Onboarding/OnboardingSaveSeed.tsx
+++ b/ui/pages/Onboarding/OnboardingSaveSeed.tsx
@@ -1,10 +1,14 @@
 import React, { ReactElement } from "react"
+import { useDispatch } from "react-redux"
+import { setSnackbarMessage } from "@tallyho/tally-background/redux-slices/ui"
 import SharedButton from "../../components/Shared/SharedButton"
 import OnboardingStepsIndicator from "../../components/Onboarding/OnboardingStepsIndicator"
 import titleStyle from "../../components/Onboarding/titleStyle"
 import { useBackgroundSelector } from "../../hooks"
 
 export default function OnboardingSaveSeed(): ReactElement {
+  const dispatch = useDispatch()
+
   const freshMnemonic = useBackgroundSelector((state) => {
     return state.keyrings.keyringToVerify?.mnemonic
   })
@@ -64,6 +68,18 @@ export default function OnboardingSaveSeed(): ReactElement {
         >
           I wrote it down
         </SharedButton>
+        <SharedButton
+          type="tertiary"
+          size="medium"
+          icon="copy"
+          iconSize="large"
+          onClick={() => {
+            navigator.clipboard.writeText(freshMnemonic?.join(" ") ?? "")
+            dispatch(setSnackbarMessage("Copied!"))
+          }}
+        >
+          Copy phrase to clipboard
+        </SharedButton>
       </div>
       <style jsx>
         {`
@@ -78,7 +94,8 @@ export default function OnboardingSaveSeed(): ReactElement {
           }
           .serif_header {
             font-size: 31px;
-            margin-top: 16px;
+            margin-top: 12px;
+            margin-bottom: 5px;
           }
           .numbers {
             width: 18px;
@@ -108,18 +125,16 @@ export default function OnboardingSaveSeed(): ReactElement {
             text-align: left;
           }
           .button_group {
+            align-items: center;
+            height: 86px;
             display: flex;
             flex-direction: column;
-            justify-content: center;
-            align-items: center;
-          }
-          .copy_button {
-            margin: 16px 0px 4px 0px;
+            justify-content: space-between;
           }
           .top {
             display: flex;
             width: 100%;
-            height: 47px;
+            height: 40px;
           }
           .wordmark {
             background: url("./images/wordmark@2x.png");


### PR DESCRIPTION
This PR adds a copy to clipboard button on the save recovery phrase page. This has been a convenience feature repeatedly requested in Discord.
<img width="330" alt="clipboard" src="https://user-images.githubusercontent.com/1918798/159733682-9a8ad665-b96e-4be7-8c21-015e55a6469d.png">

Closes #1192
