### PR TITLE
Change "Execute Swap" to "Confirm Swap"

### DIFF
--- a/ui/components/Swap/SwapQuote.tsx
+++ b/ui/components/Swap/SwapQuote.tsx
@@ -114,9 +114,9 @@ export default function SwapQuote({
           </div>
         ))}
       </div>
-      <div className="approve_button center_horizontal">
+      <div className="confirm_button center_horizontal">
         <SharedButton type="primary" size="large" onClick={handleApproveClick}>
-          Approve Swap
+          Confirm Swap
         </SharedButton>
       </div>
       <style jsx>
@@ -182,7 +182,7 @@ export default function SwapQuote({
             padding: 0px 16px;
             box-sizing: border-box;
           }
-          .approve_button {
+          .confirm_button {
             width: fit-content;
             margin-top: 36px;
           }

--- a/ui/components/Swap/SwapQuote.tsx
+++ b/ui/components/Swap/SwapQuote.tsx
@@ -48,7 +48,7 @@ export default function SwapQuote({
 
   const history = useHistory()
 
-  const handleApproveClick = useCallback(async () => {
+  const handleConfirmClick = useCallback(async () => {
     const { gasPrice, ...quoteWithoutGasPrice } = finalQuote
 
     // FIXME Set state to pending so SignTransaction doesn't redirect back; drop after
@@ -115,7 +115,7 @@ export default function SwapQuote({
         ))}
       </div>
       <div className="confirm_button center_horizontal">
-        <SharedButton type="primary" size="large" onClick={handleApproveClick}>
+        <SharedButton type="primary" size="large" onClick={handleConfirmClick}>
           Confirm Swap
         </SharedButton>
       </div>

--- a/ui/components/Swap/SwapQuote.tsx
+++ b/ui/components/Swap/SwapQuote.tsx
@@ -116,7 +116,7 @@ export default function SwapQuote({
       </div>
       <div className="approve_button center_horizontal">
         <SharedButton type="primary" size="large" onClick={handleApproveClick}>
-          Execute Swap
+          Approve Swap
         </SharedButton>
       </div>
       <style jsx>


### PR DESCRIPTION
Having "Execute Swap" be the verbiage for approving was causing confusion when users were presented with an additional signing page after clicking "Execute Swap".