### PR TITLE
Modalicious: Make transaction signing modal

### DIFF
--- a/background/lib/logger.ts
+++ b/background/lib/logger.ts
@@ -81,7 +81,6 @@ function logLabelFromStackEntry(
     return stackEntry
       .split(WEBKIT_GECKO_DELIMITER)[0]
       .split(GECKO_MARKER)
-      .reverse()
       .filter((item) => item.replace(/(?:promise)?</, "").trim() !== "")
       .slice(-2)
       .join(".")

--- a/background/redux-slices/transaction-construction.ts
+++ b/background/redux-slices/transaction-construction.ts
@@ -313,6 +313,12 @@ export const selectTransactionData = createSelector(
   (transactionRequestData) => transactionRequestData
 )
 
+export const selectIsTransactionPendingSignature = createSelector(
+  (state: { transactionConstruction: TransactionConstruction }) =>
+    state.transactionConstruction.status,
+  (status) => status === "loaded" || status === "pending"
+)
+
 export const selectIsTransactionLoaded = createSelector(
   (state: { transactionConstruction: TransactionConstruction }) =>
     state.transactionConstruction.status,

--- a/background/redux-slices/transaction-construction.ts
+++ b/background/redux-slices/transaction-construction.ts
@@ -8,6 +8,7 @@ import {
   REGULAR,
 } from "../constants/network-fees"
 import { USE_MAINNET_FORK } from "../features/features"
+import logger from "../lib/logger"
 
 import {
   BlockEstimate,
@@ -47,10 +48,7 @@ export enum NetworkFeeTypeChosen {
 }
 export type TransactionConstruction = {
   status: TransactionConstructionStatus
-  // @TODO Check if this can still be both types
-  transactionRequest?:
-    | EIP1559TransactionRequest
-    | EnrichedEIP1559TransactionRequest
+  transactionRequest?: EnrichedEIP1559TransactionRequest
   signedTransaction?: SignedEVMTransaction
   broadcastOnSign?: boolean
   transactionLikelyFails?: boolean
@@ -103,13 +101,6 @@ export const signTransaction = createBackgroundAsyncThunk(
     }
 
     await emitter.emit("requestSignature", request)
-  }
-)
-
-export const broadcastSignedTransaction = createBackgroundAsyncThunk(
-  "transaction-construction/broadcast",
-  async (transaction: SignedEVMTransaction) => {
-    await emitter.emit("broadcastSignedTransaction", transaction)
   }
 )
 
@@ -251,6 +242,28 @@ export const {
 } = transactionSlice.actions
 
 export default transactionSlice.reducer
+
+export const broadcastSignedTransaction = createBackgroundAsyncThunk(
+  "transaction-construction/broadcast",
+  async (transaction: SignedEVMTransaction) => {
+    await emitter.emit("broadcastSignedTransaction", transaction)
+  }
+)
+
+export const transactionSigned = createBackgroundAsyncThunk(
+  "transaction-construction/transaction-signed",
+  async (transaction: SignedEVMTransaction, { dispatch, getState }) => {
+    await dispatch(signed(transaction))
+
+    const { transactionConstruction } = getState() as {
+      transactionConstruction: TransactionConstruction
+    }
+
+    if (transactionConstruction.broadcastOnSign ?? false) {
+      await dispatch(broadcastSignedTransaction(transaction))
+    }
+  }
+)
 
 export const rejectTransactionSignature = createBackgroundAsyncThunk(
   "transaction-construction/reject",

--- a/background/services/ledger/index.ts
+++ b/background/services/ledger/index.ts
@@ -227,22 +227,23 @@ export default class LedgerService extends BaseService<Events> {
     this.onConnection(event.device.productId)
   }
 
-  #handleUSBDisconnect = async (event: USBConnectionEvent): Promise<void> => {
-    this.emitter.emit(
-      "usbDeviceCount",
-      (await navigator.usb.getDevices()).length
-    )
-    if (!this.#currentLedgerId) {
-      return
+  #handleUSBDisconnect =
+    async (/* event: USBConnectionEvent */): Promise<void> => {
+      this.emitter.emit(
+        "usbDeviceCount",
+        (await navigator.usb.getDevices()).length
+      )
+      if (!this.#currentLedgerId) {
+        return
+      }
+
+      this.emitter.emit("disconnected", {
+        id: this.#currentLedgerId,
+        type: LedgerType.LEDGER_NANO_S,
+      })
+
+      this.#currentLedgerId = null
     }
-
-    this.emitter.emit("disconnected", {
-      id: this.#currentLedgerId,
-      type: LedgerType.LEDGER_NANO_S,
-    })
-
-    this.#currentLedgerId = null
-  }
 
   protected async internalStartService(): Promise<void> {
     await super.internalStartService() // Not needed, but better to stick to the patterns

--- a/background/tests/keyring-integration.test.ts
+++ b/background/tests/keyring-integration.test.ts
@@ -79,7 +79,7 @@ function expectBase64String(
 
 const mockAlarms = (mock: MockzillaDeep<Browser>) => {
   mock.alarms.create.mock(() => ({}))
-  mock.alarms.onAlarm.addListener.mock((_, __) => ({}))
+  mock.alarms.onAlarm.addListener.mock(() => ({}))
 }
 
 describe("KeyringService when uninitialized", () => {

--- a/provider-bridge-shared/eip-1193.ts
+++ b/provider-bridge-shared/eip-1193.ts
@@ -48,7 +48,7 @@ export class EIP1193Error extends Error {
     super(eip1193Error.message)
   }
 
-  toJSON() {
+  toJSON(): unknown {
     return this.eip1193Error
   }
 }

--- a/provider-bridge-shared/runtime-typechecks.ts
+++ b/provider-bridge-shared/runtime-typechecks.ts
@@ -7,7 +7,7 @@ import {
   TallyAccountPayload,
 } from "./types"
 
-export function getType(arg: unknown) {
+export function getType(arg: unknown): string {
   return Object.prototype.toString.call(arg).slice("[object ".length, -1)
 }
 

--- a/ui/components/Core/CorePage.tsx
+++ b/ui/components/Core/CorePage.tsx
@@ -3,12 +3,11 @@ import Snackbar from "../Snackbar/Snackbar"
 
 interface Props {
   children: React.ReactNode
-  hasTabBar: boolean
   hasTopBar: boolean
 }
 
 export default function CorePage(props: Props): ReactElement {
-  const { children, hasTabBar, hasTopBar } = props
+  const { children, hasTopBar } = props
 
   return (
     <main>
@@ -40,6 +39,5 @@ export default function CorePage(props: Props): ReactElement {
 }
 
 CorePage.defaultProps = {
-  hasTabBar: true,
   hasTopBar: true,
 }

--- a/ui/components/Onboarding/OnboardingDerivationPathSelect.tsx
+++ b/ui/components/Onboarding/OnboardingDerivationPathSelect.tsx
@@ -177,7 +177,6 @@ export default function OnboardingDerivationPathSelect({
       </SharedModal>
       <SharedSelect
         label="Derivation path"
-        placeholder="Add custom path"
         options={derivationPaths}
         onChange={onChange}
         defaultIndex={defaultIndex}

--- a/ui/components/Shared/SharedSelect.tsx
+++ b/ui/components/Shared/SharedSelect.tsx
@@ -15,7 +15,6 @@ type Props = {
   options: Option[] | string[]
   onChange: (value: string) => void
   defaultIndex?: number
-  placeholder?: string
   label?: string
   placement?: "top" | "bottom"
   triggerLabel?: string
@@ -29,7 +28,6 @@ export default function SharedSelect(props: Props): ReactElement {
     onChange,
     defaultIndex = 0,
     label,
-    placeholder,
     placement = "bottom",
     triggerLabel,
     onTrigger,

--- a/ui/components/SignTransaction/SignTransactionDetailPanel.tsx
+++ b/ui/components/SignTransaction/SignTransactionDetailPanel.tsx
@@ -5,7 +5,6 @@ import {
   selectTransactionData,
   updateTransactionOptions,
 } from "@tallyho/tally-background/redux-slices/transaction-construction"
-import logger from "@tallyho/tally-background/lib/logger"
 import { useBackgroundDispatch, useBackgroundSelector } from "../../hooks"
 import FeeSettingsButton from "../NetworkFees/FeeSettingsButton"
 import NetworkSettingsChooser from "../NetworkFees/NetworkSettingsChooser"

--- a/ui/components/SignTransaction/SignTransactionTransferInfoProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionTransferInfoProvider.tsx
@@ -1,7 +1,4 @@
-import {
-  truncateAddress,
-  truncateDecimalAmount,
-} from "@tallyho/tally-background/lib/utils"
+import { truncateDecimalAmount } from "@tallyho/tally-background/lib/utils"
 import { selectAssetPricePoint } from "@tallyho/tally-background/redux-slices/assets"
 import {
   getAssetsState,
@@ -37,10 +34,6 @@ export default function SignTransactionTransferInfoProvider({
   const localizedMainCurrencyAmount =
     enrichAssetAmountWithMainCurrencyValues(assetAmount, assetPricePoint, 2)
       .localizedMainCurrencyAmount ?? "-"
-
-  const recipientAddressSpan = (
-    <span title={recipientAddress}>{truncateAddress(recipientAddress)}</span>
-  )
 
   return (
     <SignTransactionBaseInfoProvider

--- a/ui/components/Swap/SwapQuote.tsx
+++ b/ui/components/Swap/SwapQuote.tsx
@@ -51,11 +51,7 @@ export default function SwapQuote({
   const handleConfirmClick = useCallback(async () => {
     const { gasPrice, ...quoteWithoutGasPrice } = finalQuote
 
-    // FIXME Set state to pending so SignTransaction doesn't redirect back; drop after
-    // FIXME proper transaction queueing is in effect.
-    await dispatch(clearTransactionState(TransactionConstructionStatus.Pending))
-
-    dispatch(
+    await dispatch(
       executeSwap({
         ...quoteWithoutGasPrice,
         gasPrice:
@@ -64,9 +60,7 @@ export default function SwapQuote({
       })
     )
 
-    history.push("/sign-transaction", {
-      redirectTo: { path: "/" },
-    })
+    history.push("/")
   }, [
     finalQuote,
     dispatch,

--- a/ui/components/Wallet/WalletActivityDetails.tsx
+++ b/ui/components/Wallet/WalletActivityDetails.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, ReactElement } from "react"
 import { ActivityItem } from "@tallyho/tally-background/redux-slices/activities"
-import { truncateAddress } from "@tallyho/tally-background/lib/utils"
 import { getRecipient } from "@tallyho/tally-background/redux-slices/utils/activity-utils"
 import SharedButton from "../Shared/SharedButton"
 import SharedAddress from "../Shared/SharedAddress"

--- a/ui/pages/Popup.tsx
+++ b/ui/pages/Popup.tsx
@@ -189,24 +189,17 @@ export function Main(): ReactElement {
                     </div>
                     {/* @ts-expect-error TODO: fix the typing when the feature works */}
                     <Switch location={transformedLocation}>
-                      {pageList.map(
-                        ({ path, Component, hasTabBar, hasTopBar }) => {
-                          return (
-                            <Route path={path} key={path}>
-                              <CorePage
-                                hasTabBar={hasTabBar}
-                                hasTopBar={hasTopBar}
-                              >
-                                <ErrorBoundary
-                                  FallbackComponent={ErrorFallback}
-                                >
-                                  <Component location={transformedLocation} />
-                                </ErrorBoundary>
-                              </CorePage>
-                            </Route>
-                          )
-                        }
-                      )}
+                      {pageList.map(({ path, Component, hasTopBar }) => {
+                        return (
+                          <Route path={path} key={path}>
+                            <CorePage hasTopBar={hasTopBar}>
+                              <ErrorBoundary FallbackComponent={ErrorFallback}>
+                                <Component location={transformedLocation} />
+                              </ErrorBoundary>
+                            </CorePage>
+                          </Route>
+                        )
+                      })}
                     </Switch>
                   </div>
                 </CSSTransition>

--- a/ui/pages/Send.tsx
+++ b/ui/pages/Send.tsx
@@ -173,15 +173,6 @@ export default function Send(): ReactElement {
                 !isAddress(destinationAddress) ||
                 hasError
               }
-              linkTo={{
-                pathname: "/sign-transaction",
-                state: {
-                  redirectTo: {
-                    path: "/singleAsset",
-                    state: { symbol: selectedAsset.symbol },
-                  },
-                },
-              }}
               onClick={sendTransactionRequest}
             >
               Send

--- a/ui/pages/SignTransaction.tsx
+++ b/ui/pages/SignTransaction.tsx
@@ -24,8 +24,6 @@ export default function SignTransaction({
   location,
 }: {
   location: {
-    key?: string
-    pathname: string
     state?: { redirectTo: { path: string; state: unknown } }
   }
 }): ReactElement {
@@ -72,16 +70,6 @@ export default function SignTransaction({
     if (isTransactionSigned && isTransactionSigning) {
       if (shouldBroadcastOnSign && typeof signedTransaction !== "undefined") {
         dispatch(broadcastSignedTransaction(signedTransaction))
-      }
-
-      // Request broadcast if not dApp...
-      if (typeof location.state !== "undefined") {
-        history.push(
-          location.state.redirectTo.path,
-          location.state.redirectTo.state
-        )
-      } else {
-        history.goBack()
       }
     }
   }, [

--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -243,18 +243,12 @@ export default function Swap(): ReactElement {
       return
     }
 
-    // FIXME Set state to pending so SignTransaction doesn't redirect back; drop after
-    // FIXME proper transaction queueing is in effect.
-    await dispatch(clearTransactionState(TransactionConstructionStatus.Pending))
-
-    dispatch(
+    await dispatch(
       approveTransfer({
         assetContractAddress: sellAsset.contractAddress,
         approvalTarget,
       })
     )
-
-    history.push("/sign-transaction")
   }
 
   const updateSwapData = useCallback(

--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -77,7 +77,7 @@ export default class TallyWindowProvider extends EventEmitter {
   }
 
   // deprecated EIP-1193 method
-  async enable() {
+  async enable(): Promise<unknown> {
     return this.request({ method: "eth_requestAccounts" })
   }
 
@@ -207,7 +207,7 @@ export default class TallyWindowProvider extends EventEmitter {
     })
   }
 
-  handleAddressChange(address: Array<string>) {
+  handleAddressChange(address: Array<string>): void {
     if (this.selectedAddress !== address[0]) {
       // eslint-disable-next-line prefer-destructuring
       this.selectedAddress = address[0]


### PR DESCRIPTION
Currently this is achieved not by overlaying signing, but by
replacing the location when a signature is in progress. Overlaying
signing proved too much for an initial pass due to how complex
the CSS transition logic is and how entangled it is with the page
structure.

Note also that the keyring handling here will likely be dropped in
favor of a signing-flow-specific approach via #1165 .

A few linter fixes and a small logger improvement are also in here.

## Testing

Try sending ETH, swapping, and using dApp transaction signing. All
should behave correctly.