### PR TITLE
Bonus ENS: Do not add accounts just because ENS was resolved

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -610,9 +610,9 @@ export default class Main extends BaseService<never> {
         address,
         network: ETHEREUM,
       }
+      this.store.dispatch(loadAccount(address))
       // eslint-disable-next-line no-await-in-loop
       await this.chainService.addAccountToTrack(addressNetwork)
-      this.store.dispatch(loadAccount(address))
       this.store.dispatch(setNewSelectedAccount(addressNetwork))
     }
   }

--- a/background/redux-slices/accounts.ts
+++ b/background/redux-slices/accounts.ts
@@ -120,7 +120,7 @@ function newAccountData(
 }
 
 function getOrCreateAccountData(
-  data: AccountData | "loading" | undefined,
+  data: AccountData | "loading",
   account: HexString,
   network: Network,
   existingAccountsCount: number
@@ -226,6 +226,12 @@ const accountSlice = createSlice({
     ) => {
       // TODO Refactor when accounts are also keyed per network.
       const address = addressNetworkName.address.toLowerCase()
+
+      // No entry means this ENS name isn't being tracked here.
+      if (immerState.accountsData[address] === undefined) {
+        return
+      }
+
       const baseAccountData = getOrCreateAccountData(
         immerState.accountsData[address],
         address,
@@ -246,6 +252,12 @@ const accountSlice = createSlice({
     ) => {
       // TODO Refactor when accounts are also keyed per network.
       const address = addressNetworkAvatar.address.toLowerCase()
+
+      // No entry means this ENS name isn't being tracked here.
+      if (immerState.accountsData[address] === undefined) {
+        return
+      }
+
       const baseAccountData = getOrCreateAccountData(
         immerState.accountsData[address],
         address,


### PR DESCRIPTION
The account slice's ENS result handlers were aggressive about adding
accounts even if there was no account loading for a newly resolved ENS
name or avatar. Now, ENS data is only added if the account is already
in existence or marked as in the process of loading.

## Testing

Add an account that has recently sent to an ENS-resolvable name.
`0x208e94d5661a73360d9387d3ca169e5c130090cd` has a recent send
to `henryboldi.eth`. On `main`, waiting for that transaction to load
should result in `henryboldi.eth` appearing in the read-only section
of the account dropdown. On this branch, that should not happen.