### PR TITLE
Address Whack-A-Mole - Fixing `appearing` addresses.

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -610,9 +610,9 @@ export default class Main extends BaseService<never> {
         address,
         network: ETHEREUM,
       }
+      this.store.dispatch(loadAccount(address))
       // eslint-disable-next-line no-await-in-loop
       await this.chainService.addAccountToTrack(addressNetwork)
-      this.store.dispatch(loadAccount(address))
       this.store.dispatch(setNewSelectedAccount(addressNetwork))
     }
   }

--- a/background/redux-slices/accounts.ts
+++ b/background/redux-slices/accounts.ts
@@ -124,8 +124,14 @@ function getOrCreateAccountData(
   account: HexString,
   network: Network,
   existingAccountsCount: number
-): AccountData {
-  if (data === "loading" || !data) {
+): AccountData | undefined {
+  if (typeof data === "undefined") {
+    // data will be unefined when we are trying to get account data
+    // for an account not on any of our keyrings. If this is the case
+    // we definitely do not want to add that account to the wallet.
+    return data
+  }
+  if (data === "loading") {
     return newAccountData(account, network, existingAccountsCount)
   }
   return data
@@ -233,9 +239,12 @@ const accountSlice = createSlice({
         Object.keys(immerState.accountsData).filter((key) => key !== address)
           .length
       )
-      immerState.accountsData[address] = {
-        ...baseAccountData,
-        ens: { ...baseAccountData.ens, name: addressNetworkName.name },
+
+      if (baseAccountData) {
+        immerState.accountsData[address] = {
+          ...baseAccountData,
+          ens: { ...baseAccountData.ens, name: addressNetworkName.name },
+        }
       }
     },
     updateENSAvatar: (
@@ -253,9 +262,14 @@ const accountSlice = createSlice({
         Object.keys(immerState.accountsData).filter((key) => key !== address)
           .length
       )
-      immerState.accountsData[address] = {
-        ...baseAccountData,
-        ens: { ...baseAccountData.ens, avatarURL: addressNetworkAvatar.avatar },
+      if (baseAccountData) {
+        immerState.accountsData[address] = {
+          ...baseAccountData,
+          ens: {
+            ...baseAccountData.ens,
+            avatarURL: addressNetworkAvatar.avatar,
+          },
+        }
       }
     },
   },

--- a/ui/components/SignTransaction/SignTransactionTransferInfoProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionTransferInfoProvider.tsx
@@ -1,7 +1,4 @@
-import {
-  truncateAddress,
-  truncateDecimalAmount,
-} from "@tallyho/tally-background/lib/utils"
+import { truncateDecimalAmount } from "@tallyho/tally-background/lib/utils"
 import { selectAssetPricePoint } from "@tallyho/tally-background/redux-slices/assets"
 import {
   getAssetsState,
@@ -37,10 +34,6 @@ export default function SignTransactionTransferInfoProvider({
   const localizedMainCurrencyAmount =
     enrichAssetAmountWithMainCurrencyValues(assetAmount, assetPricePoint, 2)
       .localizedMainCurrencyAmount ?? "-"
-
-  const recipientAddressSpan = (
-    <span title={recipientAddress}>{truncateAddress(recipientAddress)}</span>
-  )
 
   return (
     <SignTransactionBaseInfoProvider


### PR DESCRIPTION
This PR addresses an issue where ENS queries resulted in addresses with resolved names being added to the accounts list under the read-only header.

### To Test
- [ ] Open up the Send ETH menu.
- [ ] Fill out the inputs to send 0.00001 ETH to `0x3aa7e4fdecb4bc74a5dd994fa3c894ae06e2d50e`.  Click Send
- [ ] The next screen should have `baz.eth` in the signature details.
- [ ] `baz.eth` should not be in the accounts tab as a read-only address.
- [ ] ENS name resolution should continue working as expected in other parts of the app (e.g. EIP-2612 signing on uniswap).