### PR TITLE
#1227, shared typed input shim

### DIFF
--- a/ui/components/NetworkFees/NetworkSettingsSelect.tsx
+++ b/ui/components/NetworkFees/NetworkSettingsSelect.tsx
@@ -12,7 +12,7 @@ import { weiToGwei } from "@tallyho/tally-background/lib/utils"
 import { ETH } from "@tallyho/tally-background/constants"
 import { PricePoint } from "@tallyho/tally-background/assets"
 import { enrichAssetAmountWithMainCurrencyValues } from "@tallyho/tally-background/redux-slices/utils/asset-utils"
-import SharedInput from "../Shared/SharedInput"
+import { SharedTypedInput } from "../Shared/SharedInput"
 import { useBackgroundSelector } from "../../hooks"
 import capitalize from "../../utils/capitalize"
 
@@ -231,7 +231,7 @@ export default function NetworkSettingsSelect({
       })}
       <div className="info">
         <div className="limit">
-          <SharedInput
+          <SharedTypedInput
             id="gasLimit"
             value={networkSettings.gasLimit?.toString() ?? ""}
             placeholder={networkSettings.suggestedGasLimit?.toString() ?? ""}

--- a/ui/components/Shared/SharedInput.tsx
+++ b/ui/components/Shared/SharedInput.tsx
@@ -21,10 +21,10 @@ interface Props<T> {
   errorMessage?: string
   autoFocus?: boolean
   autoSelect?: boolean
-  parseAndValidate?: (value: string) => { parsed: T } | { error: string }
+  parseAndValidate: (value: string) => { parsed: T } | { error: string }
 }
 
-export default function SharedInput<T = string>(props: Props<T>): ReactElement {
+export function SharedTypedInput<T = string>(props: Props<T>): ReactElement {
   const {
     id,
     label,
@@ -38,7 +38,7 @@ export default function SharedInput<T = string>(props: Props<T>): ReactElement {
     errorMessage,
     autoFocus = false,
     autoSelect = false,
-    parseAndValidate = (v) => ({ parsed: v as unknown as T }),
+    parseAndValidate,
   } = props
   const inputRef = useRef<HTMLInputElement | null>(null)
   const [parserError, setParserError] = useState<string | undefined>(undefined)
@@ -153,7 +153,20 @@ export default function SharedInput<T = string>(props: Props<T>): ReactElement {
   )
 }
 
-SharedInput.defaultProps = {
+const SHARED_INPUT_DEFAULT_PROPS = {
   type: "text",
   focusedLabelBackgroundColor: "var(--hunter-green)",
+}
+
+SharedTypedInput.defaultProps = {
+  ...SHARED_INPUT_DEFAULT_PROPS,
+}
+
+export default function SharedInput(props: Props<string>): ReactElement {
+  return SharedTypedInput(props)
+}
+
+SharedInput.defaultProps = {
+  ...SHARED_INPUT_DEFAULT_PROPS,
+  parseAndValidate: (v: string) => ({ parsed: v }),
 }


### PR DESCRIPTION
Following up on PR #1257, specifically the discussion [here](https://github.com/tallycash/extension/pull/1257#discussion_r837801917).

This updates `SharedInput.tsx` such that we now have a default export of `<SharedInput />` that is essentially a `<SharedTypedInput<string> />` and an additional export of `<SharedTypedInput<T> />`.

The purpose of this was to make `parseAndValidate` a required prop, avoiding a case where type expectations could be broken.