### PR TITLE
👻 False alarm: Remove brief error state from dapp connect

### DIFF
--- a/ui/pages/DAppConnectRequest.tsx
+++ b/ui/pages/DAppConnectRequest.tsx
@@ -78,7 +78,7 @@ export default function DAppConnectRequest(): ReactElement {
 
   const grant = useCallback(async () => {
     if (typeof permission !== "undefined") {
-      await dispatch(
+      dispatch(
         grantPermission({
           ...permission,
           state: "allow",


### PR DESCRIPTION
waiting for the dispatch to go through resulted in a
temporary state where the actual permission has already
been cleared up, but the window was not yet closed
resulting in a protective clause to briefly show the error state
which was confusing

https://discord.com/channels/808358975287722045/888500174685614090/958726241924554823


![CleanShot 2022-03-30 at 16 37 04](https://user-images.githubusercontent.com/7690112/160860968-a07d193e-13f7-4794-9e9d-84a8ce7c8cbd.gif)
