### PR TITLE
#1260, fix issue where to and from swap assets can be the same

### DIFF
--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -85,19 +85,6 @@ export default function Swap(): ReactElement {
         assetAmount.asset.symbol === "ETH"
     ) ?? []
 
-  const buyAssets = useBackgroundSelector((state) => {
-    // Some type massaging needed to remind TypeScript how these types fit
-    // together.
-    const knownAssets: AnyAsset[] = state.assets
-    return knownAssets.filter(
-      (asset): asset is SmartContractFungibleAsset | FungibleAsset =>
-        isSmartContractFungibleAsset(asset) ||
-        // Explicity add ETH even though it is not an ERC-20 token
-        // @TODO change as part of multi-network refactor.
-        (isFungibleAsset(asset) && asset.symbol === "ETH")
-    )
-  })
-
   const {
     symbol: locationAssetSymbol,
     contractAddress: locationAssetContractAddress,
@@ -143,23 +130,41 @@ export default function Swap(): ReactElement {
     undefined
   )
 
-  const sellAssetAmounts = ownedSellAssetAmounts.some(
-    ({ asset }) =>
-      typeof sellAsset !== "undefined" && isSameAsset(asset, sellAsset)
+  const buyAssets = useBackgroundSelector((state) => {
+    // Some type massaging needed to remind TypeScript how these types fit
+    // together.
+    const knownAssets: AnyAsset[] = state.assets
+    return knownAssets.filter(
+      (asset): asset is SmartContractFungibleAsset | FungibleAsset =>
+        (isSmartContractFungibleAsset(asset) ||
+          // Explicity add ETH even though it is not an ERC-20 token
+          // @TODO change as part of multi-network refactor.
+          (isFungibleAsset(asset) && asset.symbol === "ETH")) &&
+        asset.symbol !== sellAsset?.symbol
+    )
+  })
+
+  const sellAssetAmounts = (
+    ownedSellAssetAmounts.some(
+      ({ asset }) =>
+        typeof sellAsset !== "undefined" && isSameAsset(asset, sellAsset)
+    )
+      ? ownedSellAssetAmounts
+      : ownedSellAssetAmounts.concat(
+          typeof sellAsset === "undefined"
+            ? []
+            : [
+                {
+                  asset: sellAsset,
+                  amount: 0n,
+                  decimalAmount: 0,
+                  localizedDecimalAmount: "0",
+                },
+              ]
+        )
+  ).filter(
+    (sellAssetAmount) => sellAssetAmount.asset.symbol !== buyAsset?.symbol
   )
-    ? ownedSellAssetAmounts
-    : ownedSellAssetAmounts.concat(
-        typeof sellAsset === "undefined"
-          ? []
-          : [
-              {
-                asset: sellAsset,
-                amount: 0n,
-                decimalAmount: 0,
-                localizedDecimalAmount: "0",
-              },
-            ]
-      )
 
   useEffect(() => {
     if (typeof sellAsset !== "undefined") {


### PR DESCRIPTION
Removes the ability for a user to select the same asset as the To and From.

The diff is a little bit big because I needed to move `buyAssets` down so it could reference `sellAsset`. I've noted below via comments what the real changes are.

As an aside, during testing I've found another issue and created #1276 