### PR TITLE
Turbo Check: Implement accelerated balance checks for known transfers

### DIFF
--- a/background/lib/alchemy.ts
+++ b/background/lib/alchemy.ts
@@ -137,10 +137,13 @@ export async function getTokenBalances(
   { address, network }: AddressOnNetwork,
   tokens?: HexString[]
 ): Promise<SmartContractAmount[]> {
+  const uniqueTokens = [...new Set(tokens ?? [])]
+
   const json: unknown = await provider.send("alchemy_getTokenBalances", [
     address,
-    tokens || "DEFAULT_TOKENS",
+    uniqueTokens || "DEFAULT_TOKENS",
   ])
+
   if (!isValidAlchemyTokenBalanceResponse(json)) {
     logger.warn(
       "Alchemy token balance response didn't validate, did the API change?",

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -964,14 +964,15 @@ export default class ChainService extends BaseService<Events> {
   }
 
   /**
-   * Looks up whether any of the passed address/network pairs are being tracked.
+   * Given a list of AddressOnNetwork objects, return only the ones that
+   * are currently being tracked.
    */
-  async isTrackingAddressesOnNetworks(
-    ...addressesOnNetworks: AddressOnNetwork[]
-  ): Promise<boolean> {
+  async filterTrackedAddressesOnNetworks(
+    addressesOnNetworks: AddressOnNetwork[]
+  ): Promise<AddressOnNetwork[]> {
     const accounts = await this.getAccountsToTrack()
 
-    return addressesOnNetworks.some(({ address, network }) =>
+    return addressesOnNetworks.filter(({ address, network }) =>
       accounts.some(
         ({ address: trackedAddress, network: trackedNetwork }) =>
           sameEVMAddress(trackedAddress, address) &&

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -85,7 +85,7 @@ export default class IndexingService extends BaseService<Events> {
     super({
       tokens: {
         schedule: {
-          periodInMinutes: 10,
+          periodInMinutes: 1,
         },
         handler: () => this.handleTokenAlarm(),
         runAtStart: true,


### PR DESCRIPTION
Direct commit message lift:

Enriched transaction annotations can give us high-certainty token
transfers for most ERC20 token transfers. In these scenarios, rather
than doing a within-1-minute balance check, the indexing service now
does an accelerated within-300-ms check for just those addresses,
which should considerably improve responsiveness to transaction
confirmation in those cases.

Additionally, fixed an issue in the accounts slice where normalized
addresses weren't being used to key into the accounts map consistently.
Balances should start behaving more consistently across the board now!

## Testing

- Do some swaps and other transactions that move around ERC20s. You
  should see fast balance updates fairly consistently, rather than
  having to wait up to a minute.