### PR TITLE
😌  Floodgate: Debounced throttled redux subscribe

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -288,8 +288,20 @@ const initializeStore = (preloadedState = {}, main: Main) =>
       return middleware
     },
     devTools: false,
-    enhancers:
-      process.env.NODE_ENV === "development"
+    enhancers: [
+      // TODO: refactor this into debouncedThrottledSubscribe variable with proper typing
+      (createStore) => (reducer, initialState) => {
+        const store: any = createStore(reducer, initialState)
+        const originalSubscribe = store.subscribe
+
+        store.subscribe = (listener: any) => {
+          console.log("hey we are spying with great success")
+          debugger
+          return originalSubscribe(listener)
+        }
+        return store
+      },
+      ...(process.env.NODE_ENV === "development"
         ? [
             devToolsEnhancer({
               hostname: "localhost",
@@ -299,7 +311,8 @@ const initializeStore = (preloadedState = {}, main: Main) =>
               stateSanitizer: devToolsSanitizer,
             }),
           ]
-        : [],
+        : []),
+    ],
   })
 
 type ReduxStoreType = ReturnType<typeof initializeStore>


### PR DESCRIPTION
# What? 

Implement a debounced throttled filter on all the redux state change listeners
The default debounce time is 100ms and the throttle time is 500ms. 

This means that events coming in a 100ms time window are debounced
but we will have a change propagation cycle every 500ms.

# Why? 

Our infrastructure is really sensitive to bursting loads. This is especially true 
for port communication and indexedDB writes. This solution provides a filter 
on our most likely element the redux store while keeping the system reactive 
in the meantime. 

# How? 

Creating and applying a redux store enhancer that wraps every listener
into debounceThrottle function. 

# Test 

- download this diff [debounce-logs.txt](https://github.com/tallycash/extension/files/8418339/debounce-logs.txt)
- `git apply debounce-logs.txt`
- open the background page console
- open the UI popup and check the logs

