### PR TITLE
Helpers and alignments: Handful of helper and alignment tweaks

### DIFF
--- a/background/lib/utils/index.ts
+++ b/background/lib/utils/index.ts
@@ -3,9 +3,20 @@ import { normalizeHexAddress } from "@tallyho/hd-keyring"
 import { HexString } from "../../types"
 import { EVMNetwork } from "../../networks"
 import { ETHEREUM, ROPSTEN, RINKEBY, GOERLI, KOVAN } from "../../constants"
+import { AddressOnNetwork } from "../../accounts"
 
 export function normalizeEVMAddress(address: string | Buffer): HexString {
   return normalizeHexAddress(address)
+}
+
+export function normalizeAddressOnNetwork({
+  address,
+  network,
+}: AddressOnNetwork): AddressOnNetwork {
+  return {
+    address: normalizeEVMAddress(address),
+    network,
+  }
 }
 
 export function truncateDecimalAmount(

--- a/background/lib/utils/type-guards.ts
+++ b/background/lib/utils/type-guards.ts
@@ -1,0 +1,20 @@
+// A set of type guards for external packages. Type guards for package-specific
+// types should generally live alongside those types.
+
+/**
+ * A type guard that can be used to filter to only fulfilled promises in a
+ * `Promise.allSettled` result list.
+ */
+export function isFulfilledPromise<T>(
+  settledResult: PromiseSettledResult<T>
+): settledResult is PromiseFulfilledResult<T> {
+  return settledResult.status === "fulfilled"
+}
+
+/**
+ * A type guard that can be used to filter to only results that are not
+ * `undefined` in a list that might be `undefined`.
+ */
+export function isDefined<T>(input: T | undefined): input is T {
+  return input !== undefined
+}

--- a/ui/pages/Send.tsx
+++ b/ui/pages/Send.tsx
@@ -325,9 +325,11 @@ export default function Send(): ReactElement {
             text-align: end;
             margin-top: -25px;
             margin-right: 15px;
+            margin-bottom: 5px;
           }
           input#send_address ~ .validating {
             margin-top: -50px;
+            margin-bottom: 22px;
             margin-right: 15px;
             align-self: flex-end;
           }


### PR DESCRIPTION
The three helpers here are used in later PRs and likely
useful across the code base, while the alignment tweaks
fix some margin jumps that happen during ENS resolution
on the asset Send page.

## Testing

Check that as you type a name/address on the Send page,
the network fee box doesn't move or jump, both while the
name/address is invalid and once it is valid or blank.