### PR TITLE
Resolver Revolver: Introduce NameResolver and refactor NameService to use it

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -756,15 +756,20 @@ export default class Main extends BaseService<never> {
   async connectNameService(): Promise<void> {
     this.nameService.emitter.on(
       "resolvedName",
-      async ({ from: { addressNetwork }, resolved: { name } }) => {
-        this.store.dispatch(updateENSName({ ...addressNetwork, name }))
+      async ({
+        from: { addressOnNetwork },
+        resolved: {
+          nameOnNetwork: { name },
+        },
+      }) => {
+        this.store.dispatch(updateENSName({ ...addressOnNetwork, name }))
       }
     )
     this.nameService.emitter.on(
       "resolvedAvatar",
-      async ({ from: { addressNetwork }, resolved: { avatar } }) => {
+      async ({ from: { addressOnNetwork }, resolved: { avatar } }) => {
         this.store.dispatch(
-          updateENSAvatar({ ...addressNetwork, avatar: avatar.toString() })
+          updateENSAvatar({ ...addressOnNetwork, avatar: avatar.toString() })
         )
       }
     )
@@ -1158,12 +1163,11 @@ export default class Main extends BaseService<never> {
     this.telemetryService.connectReduxStore(this.store)
   }
 
-  async resolveNameOnNetwork({
-    name,
-    network,
-  }: NameOnNetwork): Promise<string | undefined> {
+  async resolveNameOnNetwork(
+    nameOnNetwork: NameOnNetwork
+  ): Promise<AddressOnNetwork | undefined> {
     try {
-      return await this.nameService.lookUpEthereumAddress(name /* , network */)
+      return await this.nameService.lookUpEthereumAddress(nameOnNetwork)
     } catch (error) {
       logger.info("Error looking up Ethereum address: ", error)
       return undefined

--- a/background/services/enrichment/index.ts
+++ b/background/services/enrichment/index.ts
@@ -122,7 +122,10 @@ export default class EnrichmentService extends BaseService<Events> {
       transaction.input === "0x" ||
       typeof transaction.input === "undefined"
     ) {
-      const toName = await this.nameService.lookUpName(transaction.to, ETHEREUM)
+      const { name: toName } = (await this.nameService.lookUpName({
+        address: transaction.to,
+        network,
+      })) ?? { name: undefined }
 
       // This is _almost certainly_ not a contract interaction, move on. Note that
       // a simple ETH send to a contract address can still effectively be a
@@ -174,10 +177,10 @@ export default class EnrichmentService extends BaseService<Events> {
         erc20Tx &&
         (erc20Tx.name === "transfer" || erc20Tx.name === "transferFrom")
       ) {
-        const toName = await this.nameService.lookUpName(
-          erc20Tx.args.to,
-          ETHEREUM
-        )
+        const { name: toName } = (await this.nameService.lookUpName({
+          address: erc20Tx.args.to,
+          network,
+        })) ?? { name: undefined }
 
         // We have an ERC-20 transfer
         txAnnotation = {
@@ -200,10 +203,10 @@ export default class EnrichmentService extends BaseService<Events> {
         erc20Tx &&
         erc20Tx.name === "approve"
       ) {
-        const spenderName = await this.nameService.lookUpName(
-          erc20Tx.args.spender,
-          ETHEREUM
-        )
+        const { name: spenderName } = (await this.nameService.lookUpName({
+          address: erc20Tx.args.spender,
+          network,
+        })) ?? { name: undefined }
 
         txAnnotation = {
           timestamp: resolvedTime,
@@ -220,10 +223,10 @@ export default class EnrichmentService extends BaseService<Events> {
           ),
         }
       } else {
-        const toName = await this.nameService.lookUpName(
-          transaction.to,
-          ETHEREUM
-        )
+        const { name: toName } = (await this.nameService.lookUpName({
+          address: transaction.to,
+          network,
+        })) ?? { name: undefined }
 
         // Fall back on a standard contract interaction.
         txAnnotation = {
@@ -258,7 +261,9 @@ export default class EnrichmentService extends BaseService<Events> {
               async (address) =>
                 [
                   normalizeEVMAddress(address),
-                  await this.nameService.lookUpName(address, ETHEREUM),
+                  (
+                    await this.nameService.lookUpName({ address, network })
+                  )?.name,
                 ] as const
             )
           )

--- a/background/services/enrichment/utils.ts
+++ b/background/services/enrichment/utils.ts
@@ -39,6 +39,7 @@ export async function enrichEIP2612SignTypedDataRequest(
 ): Promise<EIP2612SignTypedDataAnnotation> {
   const { message, domain } = typedData
   const { value, owner, spender, nonce } = message
+
   // If we have a corresponding asset - use known decimals to display a human-friendly
   // amount e.g. 10 USDC.  Otherwise just display the value e.g. 10000000
   const formattedValue = asset
@@ -48,10 +49,18 @@ export async function enrichEIP2612SignTypedDataRequest(
   // We only need to add the token if we're not able to properly format the value above
   const token = formattedValue === `${value}` ? domain.name : null
 
-  const [ownerName, spenderName] = await Promise.all([
-    await nameService.lookUpName(owner, ETHEREUM, false),
-    await nameService.lookUpName(spender, ETHEREUM, false),
-  ])
+  const [ownerName, spenderName] = (
+    await Promise.all([
+      await nameService.lookUpName(
+        { address: owner, network: ETHEREUM },
+        false
+      ),
+      await nameService.lookUpName(
+        { address: spender, network: ETHEREUM },
+        false
+      ),
+    ])
+  ).map((nameOnNetwork) => nameOnNetwork?.name)
 
   return {
     type: "EIP-2612",

--- a/background/services/name/index.ts
+++ b/background/services/name/index.ts
@@ -1,6 +1,5 @@
 import { DomainName, HexString, UNIXTime } from "../../types"
-import { EVMNetwork } from "../../networks"
-import { normalizeEVMAddress, sameEVMAddress } from "../../lib/utils"
+import { normalizeAddressOnNetwork } from "../../lib/utils"
 import { ETHEREUM } from "../../constants/networks"
 import { getTokenMetadata } from "../../lib/erc721"
 
@@ -8,27 +7,31 @@ import { ServiceCreatorFunction, ServiceLifecycleEvents } from "../types"
 import BaseService from "../base"
 import ChainService from "../chain"
 import logger from "../../lib/logger"
-import { AddressOnNetwork } from "../../accounts"
+import { AddressOnNetwork, NameOnNetwork } from "../../accounts"
 import { SECOND } from "../../constants"
 
-export type NameResolverSystem = "ENS" | "UNS" | "local"
+import { NameResolver } from "./name-resolver"
+import { NameResolverSystem, ensResolverFor } from "./resolvers"
+import { isFulfilledPromise } from "../../lib/utils/type-guards"
+
+export { NameResolverSystem }
 
 type ResolvedAddressRecord = {
   from: {
     name: DomainName
   }
   resolved: {
-    addressNetwork: AddressOnNetwork
+    addressOnNetwork: AddressOnNetwork
   }
   system: NameResolverSystem
 }
 
 type ResolvedNameRecord = {
   from: {
-    addressNetwork: AddressOnNetwork
+    addressOnNetwork: AddressOnNetwork
   }
   resolved: {
-    name: DomainName
+    nameOnNetwork: NameOnNetwork
     expiresAt: UNIXTime
   }
   system: NameResolverSystem
@@ -36,7 +39,7 @@ type ResolvedNameRecord = {
 
 type ResolvedAvatarRecord = {
   from: {
-    addressNetwork: AddressOnNetwork
+    addressOnNetwork: AddressOnNetwork
   }
   resolved: {
     avatar: URL
@@ -49,6 +52,9 @@ type Events = ServiceLifecycleEvents & {
   resolvedName: ResolvedNameRecord
   resolvedAvatar: ResolvedAvatarRecord
 }
+
+// A minimum record expiry that avoids infinite resolution loops.
+const MINIMUM_RECORD_EXPIRY = 10 * SECOND
 
 const ipfsGateway = new URL("https://ipfs.io/ipfs/")
 const arweaveGateway = new URL("https://arweave.net/")
@@ -98,9 +104,24 @@ function storageGatewayURL(url: URL): URL {
  * Initially, the service supports ENS on mainnet Ethereum.
  */
 export default class NameService extends BaseService<Events> {
-  private cachedEIP155AvatarURLs: Record<string, URL> = {}
+  private resolvers: NameResolver<NameResolverSystem>[] = []
 
-  private cachedResolvedNames: Record<string, ResolvedNameRecord> = {}
+  /**
+   * Cached resolution for avatar URIs that are not yet URLs, e.g. for EIP155.
+   */
+  private cachedResolvedEIP155Avatars: Record<string, ResolvedAvatarRecord> = {}
+
+  /**
+   * Cached resolution for name records, by network family followed by whatever
+   * discrimant might be used within a network family between networks.
+   */
+  private cachedResolvedNames: {
+    EVM: {
+      [chainID: string]: {
+        [address: HexString]: ResolvedNameRecord
+      }
+    }
+  } = { EVM: { [ETHEREUM.chainID]: {} } }
 
   /**
    * Create a new NameService. The service isn't initialized until
@@ -120,177 +141,224 @@ export default class NameService extends BaseService<Events> {
   private constructor(private chainService: ChainService) {
     super({})
 
-    chainService.emitter.on(
-      "newAccountToTrack",
-      async ({ address, network }) => {
-        try {
-          await this.lookUpName(address, network)
-        } catch (error) {
-          logger.error("Error fetching ENS name for address", address, error)
-        }
-      }
-    )
-    this.emitter.on(
-      "resolvedName",
-      async ({
-        from: {
-          addressNetwork: { address, network },
-        },
-      }) => {
-        try {
-          const avatar = await this.lookUpAvatar(address, network)
+    this.resolvers = [ensResolverFor(chainService)]
 
-          if (avatar) {
-            this.emitter.emit("resolvedAvatar", {
-              from: { addressNetwork: { address, network } },
-              resolved: { avatar },
-              system: "ENS",
-            })
-          }
-        } catch (error) {
-          logger.error("Error fetching avatar for address", address, error)
-        }
+    chainService.emitter.on("newAccountToTrack", async (addressOnNetwork) => {
+      try {
+        await this.lookUpName(addressOnNetwork)
+      } catch (error) {
+        logger.error("Error fetching name for address", addressOnNetwork, error)
       }
-    )
+    })
+    this.emitter.on("resolvedName", async ({ from: { addressOnNetwork } }) => {
+      try {
+        const avatar = await this.lookUpAvatar(addressOnNetwork)
+
+        if (avatar) {
+          this.emitter.emit("resolvedAvatar", avatar)
+        }
+      } catch (error) {
+        logger.error(
+          "Error fetching avatar for address",
+          addressOnNetwork,
+          error
+        )
+      }
+    })
   }
 
   async lookUpEthereumAddress(
-    name: DomainName
-  ): Promise<HexString | undefined> {
-    // if doesn't end in .eth, throw. TODO turn on other domain endings soon +
-    // include support for UNS
-    if (!name.match(/.*\.eth$/)) {
-      throw new Error("Only .eth names can be resolved today.")
-    }
-    // TODO ENS lookups should work on Ethereum mainnet and a few testnets as well.
-    // This is going to be strange, though, as we'll be looking up ENS names for
-    // non-Ethereum networks (eg eventually Bitcoin).
-    const provider = this.chainService.providers.ethereum
-    // TODO cache name resolution and TTL
-    const address = await provider.resolveName(name)
-    if (!address || !address.match(/^0x[a-zA-Z0-9]*$/)) {
+    nameOnNetwork: NameOnNetwork
+  ): Promise<AddressOnNetwork | undefined> {
+    const workingResolvers = this.resolvers.filter((resolver) =>
+      resolver.canAttemptAddressResolution(nameOnNetwork)
+    )
+
+    const resolved = (
+      await Promise.allSettled(
+        workingResolvers.map(async (resolver) => ({
+          type: resolver.type,
+          resolved: await resolver.lookUpAddressForName(nameOnNetwork),
+        }))
+      )
+    ).find(isFulfilledPromise)?.value
+
+    if (resolved === undefined || resolved.resolved === undefined) {
       return undefined
     }
-    const normalized = normalizeEVMAddress(address)
+
+    const { type: resolverType, resolved: addressOnNetwork } = resolved
+
+    // TODO cache name resolution and TTL
+    const normalizedAddressOnNetwork =
+      normalizeAddressOnNetwork(addressOnNetwork)
     this.emitter.emit("resolvedAddress", {
-      from: { name },
-      resolved: { addressNetwork: { address: normalized, network: ETHEREUM } },
-      system: "ENS",
+      from: nameOnNetwork,
+      resolved: { addressOnNetwork: normalizedAddressOnNetwork },
+      system: resolverType,
     })
-    return normalized
+
+    return normalizedAddressOnNetwork
   }
 
   async lookUpName(
-    address: HexString,
-    network: EVMNetwork,
+    addressOnNetwork: AddressOnNetwork,
     checkCache = true
-  ): Promise<DomainName | undefined> {
-    // TODO ENS lookups should work on a few testnets as well
-    if (network.chainID !== "1") {
-      throw new Error("Only Ethereum mainnet is supported.")
-    }
+  ): Promise<NameOnNetwork | undefined> {
+    const { address: normalizedAddress, network } =
+      normalizeAddressOnNetwork(addressOnNetwork)
 
-    if (checkCache && address in this.cachedResolvedNames) {
+    if (
+      checkCache &&
+      this.cachedResolvedNames[network.family][network.chainID][
+        normalizedAddress
+      ]
+    ) {
       const {
-        resolved: { name, expiresAt },
-      } = this.cachedResolvedNames[address]
+        resolved: { nameOnNetwork, expiresAt },
+      } =
+        this.cachedResolvedNames[network.family][network.chainID][
+          normalizedAddress
+        ]
 
       if (expiresAt >= Date.now()) {
-        return name
+        return nameOnNetwork
       }
     }
 
-    const provider = this.chainService.providers.ethereum
-    // TODO cache name resolution and TTL
-    const name = await provider.lookupAddress(address)
-    // TODO proper domain name validation ala RFC2181
-    if (
-      !name ||
-      !(
-        name.length <= 253 &&
-        name.match(
-          /^[a-zA-Z0-9][a-zA-Z0-9-]{1,62}\.([a-zA-Z0-9][a-zA-Z0-9-]{1,62}\.)*[a-zA-Z0-9][a-zA-Z0-9-]{1,62}/
-        )
+    const workingResolvers = this.resolvers.filter((resolver) =>
+      resolver.canAttemptNameResolution(addressOnNetwork)
+    )
+
+    const resolved = (
+      await Promise.allSettled(
+        workingResolvers.map(async (resolver) => ({
+          type: resolver.type,
+          resolved: await resolver.lookUpNameForAddress(addressOnNetwork),
+        }))
       )
-    ) {
+    ).find(isFulfilledPromise)?.value
+
+    if (resolved === undefined || resolved.resolved === undefined) {
       return undefined
     }
 
+    const { type: resolverType, resolved: nameOnNetwork } = resolved
+
     const nameRecord = {
-      from: { addressNetwork: { address, network } },
+      from: { addressOnNetwork },
       resolved: {
-        name,
+        nameOnNetwork,
         // TODO Read this from the name service; for now, this avoids infinite
         // TODO resolution loops.
-        expiresAt: Date.now() + 10 * SECOND,
+        expiresAt: Date.now() + MINIMUM_RECORD_EXPIRY,
       },
-      system: "ENS",
+      system: resolverType,
     } as const
 
-    const existingName = this.cachedResolvedNames[address]?.resolved?.name
-    this.cachedResolvedNames[address] = nameRecord
+    const { name: existingName } =
+      this.cachedResolvedNames[network.family][network.chainID][
+        normalizedAddress
+      ].resolved?.nameOnNetwork
+    this.cachedResolvedNames[network.family][network.chainID][
+      normalizedAddress
+    ] = nameRecord
 
     // Only emit an event if the resolved name changed.
-    if (existingName !== name) {
+    if (existingName !== nameOnNetwork.name) {
       this.emitter.emit("resolvedName", nameRecord)
     }
-    return name
+
+    return nameOnNetwork
   }
 
   async lookUpAvatar(
-    address: HexString,
-    network: EVMNetwork
-  ): Promise<URL | undefined> {
-    // TODO ENS lookups should work on a few testnets as well
-    if (network.chainID !== "1") {
-      throw new Error("Only Ethereum mainnet is supported.")
-    }
-    const name = await this.lookUpName(address, network)
-    if (!name) {
+    addressOnNetwork: AddressOnNetwork
+  ): Promise<ResolvedAvatarRecord | undefined> {
+    const workingResolvers = this.resolvers.filter((resolver) =>
+      resolver.canAttemptAvatarResolution(addressOnNetwork)
+    )
+
+    const resolved = (
+      await Promise.allSettled(
+        workingResolvers.map(async (resolver) => ({
+          type: resolver.type,
+          resolved: await resolver.lookUpAvatar(addressOnNetwork),
+        }))
+      )
+    ).find(isFulfilledPromise)?.value
+
+    if (resolved === undefined || resolved.resolved === undefined) {
       return undefined
     }
-    // TODO handle if it doesn't exist
-    const provider = this.chainService.providers.ethereum
-    const resolver = await provider.getResolver(name)
-    if (!sameEVMAddress(await resolver?.getAddress(), address)) {
-      return undefined
+
+    const {
+      type: resolverType,
+      resolved: { uri: avatarUri },
+    } = resolved
+
+    const baseResolvedAvatar = {
+      from: { addressOnNetwork },
+      system: resolverType,
     }
 
-    const avatar = await resolver?.getText("avatar")
+    if (avatarUri instanceof URL) {
+      return {
+        ...baseResolvedAvatar,
+        resolved: { avatar: storageGatewayURL(avatarUri) },
+      }
+    }
 
-    if (avatar) {
-      if (avatar.match(/^eip155:1\/erc721:/)) {
-        // check if we've cached the resolved URI, otherwise hit the chain
-        if (avatar.toLowerCase() in this.cachedEIP155AvatarURLs) {
-          // TODO properly cache this with any other non-ENS NFT stuff we do
-          return this.cachedEIP155AvatarURLs[avatar.toLowerCase()]
-        }
-        // these URIs look like eip155:1/erc721:0xb7F7F6C52F2e2fdb1963Eab30438024864c313F6/2430
-        // check the spec for more details https://gist.github.com/Arachnid/9db60bd75277969ee1689c8742b75182
-        const [, , , erc721Address, nftID] = avatar.split(/[:/]/)
-        if (
-          typeof erc721Address !== "undefined" &&
-          typeof nftID !== "undefined"
-        ) {
-          const metadata = await getTokenMetadata(
-            provider,
-            erc721Address,
-            BigInt(nftID)
-          )
+    if (avatarUri.match(/^eip155:1\/erc721:/)) {
+      // check if we've cached the resolved URL, otherwise hit the chain
+      if (avatarUri.toLowerCase() in this.cachedResolvedEIP155Avatars) {
+        // TODO properly cache this with any other non-ENS NFT stuff we do
+        return this.cachedResolvedEIP155Avatars[avatarUri.toLowerCase()]
+      }
 
-          if (metadata && metadata.image) {
-            const { image } = metadata
-            const resolvedGateway = storageGatewayURL(new URL(image))
-            this.cachedEIP155AvatarURLs[avatar] = resolvedGateway
-            return resolvedGateway
+      const provider = this.chainService.providerForNetwork(
+        addressOnNetwork.network
+      )
+
+      // these URIs look like eip155:1/erc721:0xb7F7F6C52F2e2fdb1963Eab30438024864c313F6/2430
+      // check the spec for more details https://gist.github.com/Arachnid/9db60bd75277969ee1689c8742b75182
+      const [, , , erc721Address, nftID] = avatarUri.split(/[:/]/)
+      if (
+        provider !== undefined &&
+        erc721Address !== undefined &&
+        nftID !== undefined
+      ) {
+        const metadata = await getTokenMetadata(
+          provider,
+          erc721Address,
+          BigInt(nftID)
+        )
+
+        if (metadata !== undefined && metadata.image !== undefined) {
+          const { image } = metadata
+          const resolvedGateway = {
+            ...baseResolvedAvatar,
+            resolved: { avatar: storageGatewayURL(new URL(image)) },
           }
+
+          this.cachedResolvedEIP155Avatars[avatarUri] = resolvedGateway
+          return resolvedGateway
         }
       }
-      return storageGatewayURL(new URL(avatar))
     }
 
-    return undefined
+    // If not an EIP URI, assume we're looking at a standard URL; if that
+    // fails, log an error and just return undefined.
+    try {
+      const plainURL = storageGatewayURL(new URL(avatarUri))
+      return {
+        ...baseResolvedAvatar,
+        resolved: { avatar: plainURL },
+      }
+    } catch (error) {
+      logger.error("Unexpected avatar URI scheme", avatarUri)
+      return undefined
+    }
   }
 }
-// TODO resolve other network addresses (eg Bitcoin)
 // TODO resolve content, eg IPFS hashes

--- a/background/services/name/index.ts
+++ b/background/services/name/index.ts
@@ -310,10 +310,11 @@ export default class NameService extends BaseService<Events> {
     }
 
     if (avatarUri.match(/^eip155:1\/erc721:/)) {
+      const normalizedAvatarUri = avatarUri.toLowerCase()
       // check if we've cached the resolved URL, otherwise hit the chain
-      if (avatarUri.toLowerCase() in this.cachedResolvedEIP155Avatars) {
+      if (normalizedAvatarUri in this.cachedResolvedEIP155Avatars) {
         // TODO properly cache this with any other non-ENS NFT stuff we do
-        return this.cachedResolvedEIP155Avatars[avatarUri.toLowerCase()]
+        return this.cachedResolvedEIP155Avatars[normalizedAvatarUri]
       }
 
       const provider = this.chainService.providerForNetwork(
@@ -341,7 +342,8 @@ export default class NameService extends BaseService<Events> {
             resolved: { avatar: storageGatewayURL(new URL(image)) },
           }
 
-          this.cachedResolvedEIP155Avatars[avatarUri] = resolvedGateway
+          this.cachedResolvedEIP155Avatars[normalizedAvatarUri] =
+            resolvedGateway
           return resolvedGateway
         }
       }

--- a/background/services/name/name-resolver.ts
+++ b/background/services/name/name-resolver.ts
@@ -1,0 +1,93 @@
+import { AddressOnNetwork, NameOnNetwork } from "../../accounts"
+import { Network } from "../../networks"
+
+/**
+ * This interface must be implemented by a resolver that can be used to resolve
+ * names. It also implements support, when the underlying resolver supports it,
+ * for resolving avatars and reverse-resolving names from addresses.
+ *
+ * When a network is passed to a name resolver function, the resolver MUST
+ * return results for the same network that was passed.
+ *
+ * Name resolvers are checked in two phases, one which is used to statically
+ * decide whether a resolver is _likely to be able to_ resolve a name, avatar,
+ * or address, and one in which the resolution is attempted. The static phase is
+ * used to avoid calls that are known to produce failures, such as attempting to
+ * resolve a Bitcoin name on a resolver that only supports Ethereum.
+ */
+export interface NameResolver<ResolverType extends string> {
+  type: ResolverType
+
+  /**
+   * Given a name and network, synchronously returns a boolean indicating
+   * whether this name resolver can attempt to resolve it. This is useful for
+   * avoiding lookups for names that are statically known to be malformed per
+   * this resolver, for example trying to look up Bitcoin name on a resolver
+   * that only supports Ethereum.
+   *
+   * Returning false should mean {@see lookUpNameForAddress} will never be
+   * called.
+   */
+  canAttemptNameResolution(addressOnNetwork: AddressOnNetwork): boolean
+  /**
+   * Given an address and network, synchronously returns a boolean indicating
+   * whether this name resolver can attempt to resolve an avatar for that name.
+   *
+   * Returning false should mean {@see lookUpAvatar} will never be called.
+   */
+  canAttemptAvatarResolution(
+    addressOrNameOnNetwork: AddressOnNetwork | NameOnNetwork
+  ): boolean
+  /**
+   * Given a name and network, synchronously returns a boolean indicating
+   * whether this resolver can resolve an address from that network back to a
+   * name.
+   *
+   * Returning false should mean {@see lookUpAddressForName} will never be
+   * called.
+   */
+  canAttemptAddressResolution(nameOnNetwork: NameOnNetwork): boolean
+
+  /**
+   * Given a name and network, attempt to resolve it to an address.
+   *
+   * Returns `undefined` if the address could not be resolved. Should return a
+   * rejected promise if {@see canAttemptNameResolution} would have returned
+   * `false`, or if internal resolution errors occurred (e.g., an issue
+   * communicating with a server).
+   */
+  lookUpAddressForName(
+    nameOnNetwork: NameOnNetwork
+  ): Promise<AddressOnNetwork | undefined>
+  /**
+   * Given an address and network, attempt to resolve an avatar URI for that
+   * address. Note that avatar URIs can be EIP155 or ERC721 URNs, not just
+   * URLs.
+   *
+   * Returns `undefined` if the avatar could not be resolved. Should return a
+   * rejected promise if {@see canAttemptAvatarResolution} would have returned
+   * `false`, or if internal resolution errors occurred (e.g., an issue
+   * communicating with a server).
+   */
+  lookUpAvatar(
+    addressOrNameOnNetwork: AddressOnNetwork | NameOnNetwork
+  ): Promise<
+    | {
+        uri: URL | string
+        network: Network
+      }
+    | undefined
+  >
+  /**
+   * Given an address and network, attempt to resolve the name of that address
+   * on that network.
+   *
+   * Returns `undefined` if the avatar could not be resolved. Should return a
+   * rejected promise if {@see canAttemptAddressResolution} would have returned
+   * `false`, or if internal resolution errors occurred (e.g., an issue
+   * communicating with a server).
+   */
+  lookUpNameForAddress(
+    addressOnNetwork: AddressOnNetwork
+  ): Promise<NameOnNetwork | undefined>
+}

--- a/background/services/name/name-resolver.ts
+++ b/background/services/name/name-resolver.ts
@@ -19,7 +19,7 @@ export interface NameResolver<ResolverType extends string> {
   type: ResolverType
 
   /**
-   * Given a name and network, synchronously returns a boolean indicating
+   * Given an address and network, synchronously returns a boolean indicating
    * whether this name resolver can attempt to resolve it. This is useful for
    * avoiding lookups for names that are statically known to be malformed per
    * this resolver, for example trying to look up Bitcoin name on a resolver

--- a/background/services/name/resolvers/ens.ts
+++ b/background/services/name/resolvers/ens.ts
@@ -1,0 +1,91 @@
+import ChainService from "../../chain"
+import { AddressOnNetwork, NameOnNetwork } from "../../../accounts"
+import { ETHEREUM } from "../../../constants"
+import { sameNetwork } from "../../../networks"
+import { NameResolver } from "../name-resolver"
+
+export default function ensResolverFor(
+  chainService: ChainService
+): NameResolver<"ENS"> {
+  return {
+    type: "ENS",
+    canAttemptNameResolution(): boolean {
+      return true
+    },
+    canAttemptAvatarResolution(addressOrNameOnNetwork: NameOnNetwork): boolean {
+      if ("name" in addressOrNameOnNetwork) {
+        return this.canAttemptAddressResolution(addressOrNameOnNetwork)
+      }
+      return true
+    },
+    canAttemptAddressResolution({ name, network }: NameOnNetwork): boolean {
+      return sameNetwork(network, ETHEREUM) && name.endsWith(".eth")
+    },
+
+    async lookUpAddressForName({
+      name,
+      network,
+    }: NameOnNetwork): Promise<AddressOnNetwork | undefined> {
+      const address = await chainService
+        .providerForNetwork(network)
+        ?.resolveName(name)
+
+      if (address === undefined || address === null) {
+        return undefined
+      }
+
+      return {
+        address,
+        network,
+      }
+    },
+    async lookUpAvatar(
+      addressOrNameOnNetwork: AddressOnNetwork | NameOnNetwork
+    ) {
+      const { network } = addressOrNameOnNetwork
+
+      const { name } =
+        "name" in addressOrNameOnNetwork
+          ? addressOrNameOnNetwork
+          : (await this.lookUpNameForAddress(addressOrNameOnNetwork)) ?? {
+              name: undefined,
+            }
+
+      const provider = chainService.providerForNetwork(network)
+
+      if (name === undefined || provider === undefined) {
+        return undefined
+      }
+
+      const { url: avatarUrn } = (await (
+        await provider.getResolver(name)
+      )?.getAvatar()) ?? { url: undefined }
+
+      if (avatarUrn === undefined) {
+        return undefined
+      }
+
+      return {
+        uri: avatarUrn,
+        network,
+      }
+    },
+    async lookUpNameForAddress({
+      address,
+      network,
+    }: AddressOnNetwork): Promise<NameOnNetwork | undefined> {
+      const name = await chainService
+        .providerForNetwork(network)
+        ?.lookupAddress(address)
+
+      if (name === undefined || name === null) {
+        return undefined
+      }
+
+      return {
+        name,
+        network,
+      }
+    },
+  }
+}

--- a/background/services/name/resolvers/index.ts
+++ b/background/services/name/resolvers/index.ts
@@ -1,0 +1,11 @@
+import ensResolverFor from "./ens"
+
+const resolvers = {
+  ensResolverFor,
+}
+
+type ResolverConstructors = ReturnType<typeof resolvers[keyof typeof resolvers]>
+
+export type NameResolverSystem = ResolverConstructors["type"]
+
+export { ensResolverFor }

--- a/ui/hooks/validation-hooks.ts
+++ b/ui/hooks/validation-hooks.ts
@@ -1,3 +1,4 @@
+import { AddressOnNetwork } from "@tallyho/tally-background/accounts"
 import { ETHEREUM } from "@tallyho/tally-background/constants"
 import { isProbablyEVMAddress } from "@tallyho/tally-background/lib/utils"
 import { resolveNameOnNetwork } from "@tallyho/tally-background/redux-slices/accounts"
@@ -160,7 +161,7 @@ export const useAddressOrNameValidation: AsyncValidationHook<
 
       const resolved = (await dispatch(
         resolveNameOnNetwork({ name: trimmed, network: ETHEREUM })
-      )) as unknown as string
+      )) as unknown as AddressOnNetwork | undefined
 
       // Asynchronicity means we could already have started validating another
       // value before this validation completed; ignore those cases.
@@ -169,7 +170,7 @@ export const useAddressOrNameValidation: AsyncValidationHook<
           onValidChange(undefined)
           setErrorMessage("Address could not be found")
         } else {
-          onValidChange(resolved)
+          onValidChange(resolved.address)
         }
 
         setIsValidating(false)


### PR DESCRIPTION
--> Draft until #1303 lands.

Two big differences here:

- The NameService is now able to use more than one resolver, though the
  only implemented resolver is still ENS.
- Lookups generally use *OnNetwork types, and results are similarly
  *OnNetwork types. Avatars are still returned as plain URLs, at least
  for now.

## Testing

Make sure that name resolution continues to work:

- Check that entering an ENS name resolves in the Send form.
- Check that entering an ENS name resolves in the Read-only form.
- Check that sending to an address with an ENS name correctly shows
  the ENS name in the Sign Transaction page.
- Check that sending to an address with an ENS name correctly shows
  the ENS name in the activity list.