### PR TITLE
🚦 Add countdown/delay on button for transaction signing

### DIFF
--- a/ui/components/Shared/SharedButton.tsx
+++ b/ui/components/Shared/SharedButton.tsx
@@ -189,6 +189,10 @@ export default function SharedButton(props: Props): ReactElement {
           .secondary:active {
             border-color: var(--trophy-gold);
           }
+          .primaryGreen {
+            color: var(--hunter-green);
+            background-color: var(--trophy-gold);
+          }
           .disabled {
             background-color: var(--green-60);
             color: var(--green-80);
@@ -279,10 +283,7 @@ export default function SharedButton(props: Props): ReactElement {
             height: 32px;
             font-size: 16px;
           }
-          .primaryGreen {
-            color: var(--hunter-green);
-            background-color: var(--trophy-gold);
-          }
+
           .warning {
             background-color: var(--attention);
           }

--- a/ui/components/SignTransaction/SignTransactionContainer.tsx
+++ b/ui/components/SignTransaction/SignTransactionContainer.tsx
@@ -72,23 +72,27 @@ export default function SignTransactionContainer({
     }
   }, [])
 
-  const onBlurFocusChange = useCallback(
-    (isFocus: boolean) => {
-      clearDelaySignButtonTimeout()
-      firstOpen.current = false
+  function onBlurFocusChange(isFocus: boolean) {
+    clearDelaySignButtonTimeout()
+    firstOpen.current = false
 
-      if (isFocus) {
-        delaySignButtonTimeout.current = window.setTimeout(() => {
-          setIsOnDelayToSign(false)
-          // Random delay between 0.5 and 2 seconds
-        }, Math.floor(Math.random() * (5 - 1) + 1) * 500)
-      } else {
-        setIsOnDelayToSign(true)
-        clearDelaySignButtonTimeout()
-      }
-    },
-    [clearDelaySignButtonTimeout]
-  )
+    if (isFocus) {
+      delaySignButtonTimeout.current = window.setTimeout(() => {
+        setIsOnDelayToSign(false)
+        // Random delay between 0.5 and 2 seconds
+      }, Math.floor(Math.random() * (5 - 1) + 1) * 500)
+    } else {
+      setIsOnDelayToSign(true)
+    }
+  }
+
+  function handleBlur() {
+    onBlurFocusChange(false)
+  }
+
+  function handleFocus() {
+    onBlurFocusChange(true)
+  }
 
   // Runs on updates
   useEffect(() => {
@@ -100,14 +104,14 @@ export default function SignTransactionContainer({
       onBlurFocusChange(true)
     }
 
-    window.addEventListener("focus", () => onBlurFocusChange(true))
-    window.addEventListener("blur", () => onBlurFocusChange(false))
+    window.addEventListener("focus", handleFocus)
+    window.addEventListener("blur", handleBlur)
 
     return () => {
-      window.removeEventListener("focus", () => onBlurFocusChange(true))
-      window.removeEventListener("blur", () => onBlurFocusChange(false))
+      window.removeEventListener("focus", handleFocus)
+      window.removeEventListener("blur", handleBlur)
     }
-  }, [onBlurFocusChange, reviewPanel])
+  }, [reviewPanel])
 
   return (
     <section>

--- a/ui/components/SignTransaction/SignTransactionContainer.tsx
+++ b/ui/components/SignTransaction/SignTransactionContainer.tsx
@@ -42,6 +42,7 @@ export default function SignTransactionContainer({
   const { signingMethod } = signerAccountTotal
   const [isSlideUpOpen, setSlideUpOpen] = useState(false)
   const [isOnDelayToSign, setIsOnDelayToSign] = useState(true)
+  const [focusChangeNonce, setFocusChangeNonce] = useState(0)
 
   const signingLedgerState = useSigningLedgerState(signingMethod ?? null)
 
@@ -70,7 +71,21 @@ export default function SignTransactionContainer({
     }
   }
 
-  function onBlurFocusChange() {
+  useEffect(() => {
+    const increaseFocusChangeNonce = () => {
+      setFocusChangeNonce((x) => x + 1)
+    }
+    window.addEventListener("focus", increaseFocusChangeNonce)
+    window.addEventListener("blur", increaseFocusChangeNonce)
+
+    return () => {
+      window.removeEventListener("focus", increaseFocusChangeNonce)
+      window.removeEventListener("blur", increaseFocusChangeNonce)
+    }
+  }, [])
+
+  // Runs on updates
+  useEffect(() => {
     clearDelaySignButtonTimeout()
 
     if (document.hasFocus()) {
@@ -81,22 +96,7 @@ export default function SignTransactionContainer({
     } else {
       setIsOnDelayToSign(true)
     }
-  }
-
-  useEffect(() => {
-    window.addEventListener("focus", onBlurFocusChange)
-    window.addEventListener("blur", onBlurFocusChange)
-
-    return () => {
-      window.removeEventListener("focus", onBlurFocusChange)
-      window.removeEventListener("blur", onBlurFocusChange)
-    }
-  }, [])
-
-  // Runs on updates
-  useEffect(() => {
-    onBlurFocusChange()
-  }, [reviewPanel])
+  }, [reviewPanel, focusChangeNonce])
 
   return (
     <section>


### PR DESCRIPTION
This PR adds a delay to enabling the sign button when opening a sign
transaction screen. Additionally, it aims to enable/disable the sign
transaction button depending on if the window is blurred or focused, or if the
transaction details change. The idea is to make sure the user has a chance to
review the transaction and confirm there's no shenanigans before pulling the
trigger. As for implementation, this is achieved with hooks
in`SignTransactionContainer.tsx`. Granted, this enable/disable logic isn't
neatly tucked away as a single new hook of its own. That said, the
implementation feels somewhat convoluted to me. Input is welcome!