### PR TITLE
1 Thing You Should Never Buy Used - Use newAmount when setting the buy asset's quantity.

### DIFF
--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -470,7 +470,7 @@ export default function Swap(): ReactElement {
                 showMaxButton={false}
                 onAssetSelect={updateBuyAsset}
                 onAmountChange={(newAmount, error) => {
-                  setBuyAmount(buyAmount)
+                  setBuyAmount(newAmount)
                   if (typeof error === "undefined") {
                     updateSwapData("buy", newAmount)
                   }


### PR DESCRIPTION
This PR fixes a bug where users would seemingly lose control of the buy asset's input when trying to change the buy quantity during a swap.

### To Test

- Open up the Swap page
- Select a buy asset and sell asset
- Enter a quantity for the buy asset (the lower input)
- At this point you should see the quantity you entered - and the sell asset quantity should automatically populate.