### PR TITLE
fix: use Tally Ho instead of TallyHo for content

### DIFF
--- a/ui/pages/Onboarding/OnboardingInfoIntro.tsx
+++ b/ui/pages/Onboarding/OnboardingInfoIntro.tsx
@@ -45,8 +45,8 @@ const steps = [
       fileName: "illustration_onboarding_default",
       extraStyles: `margin-top: 21px;`,
     },
-    title: "TallyHo set as default",
-    body: `TallyHo will open any time you connect to a dapp — even if you select MetaMask. You can disable this anytime from Settings.`,
+    title: "Tally Ho set as default",
+    body: `Tally Ho will open any time you connect to a dapp — even if you select MetaMask. You can disable this anytime from Settings.`,
     buttonCopy: "Get started",
   },
 ]


### PR DESCRIPTION
## Summary
close #1145 
Simply replace "TallyHo" with "Tally Ho"
## Test
test in local build with firefox
<img width="401" alt="image" src="https://user-images.githubusercontent.com/3824034/163676347-f046a5ea-86cb-434f-a9f6-25b42415f9f0.png">

## Reviewers
@henryboldi @VladUXUI 