### PR TITLE
Uh Oh - Arbitrary extension version is enabled - Fix redux-state migration.

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -212,14 +212,23 @@ const REDUX_MIGRATIONS: { [version: number]: Migration } = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   6: (prevState: any) => {
     const { ...newState } = prevState
-    // If a user is upgrading from pre 0.11.0.  They will not have `ledger` in their redux store - so we need to check that it exists.
-    if (newState.ledger) {
-      Object.keys(newState.ledger.devices).forEach((deviceId) => {
-        ;(newState.ledger as LedgerState).devices[
-          deviceId
-        ].isArbitraryDataSigningEnabled = false
-      })
+
+    // A user might be upgrading from version without the `ledger` key in the redux store - so we
+    // initialize it here if that is the case.
+    if (!newState.ledger) {
+      newState.ledger = {
+        currentDeviceID: null,
+        devices: {},
+        usbDeviceCount: 0,
+      }
+      return newState
     }
+
+    Object.keys(newState.ledger.devices).forEach((deviceId) => {
+      ;(newState.ledger as LedgerState).devices[
+        deviceId
+      ].isArbitraryDataSigningEnabled = false
+    })
 
     return newState
   },

--- a/background/main.ts
+++ b/background/main.ts
@@ -85,6 +85,7 @@ import {
   SignDataRequest,
 } from "./utils/signing"
 import {
+  LedgerState,
   resetLedgerState,
   setDeviceConnectionStatus,
   setUsbDeviceCount,
@@ -211,7 +212,14 @@ const REDUX_MIGRATIONS: { [version: number]: Migration } = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   6: (prevState: any) => {
     const { ...newState } = prevState
-    newState.ledger.isArbitraryDataSigningEnabled = false
+    // If a user is upgrading from pre 0.11.0.  They will not have `ledger` in their redux store - so we need to check that it exists.
+    if (newState.ledger) {
+      Object.keys(newState.ledger.devices).forEach((deviceId) => {
+        ;(newState.ledger as LedgerState).devices[
+          deviceId
+        ].isArbitraryDataSigningEnabled = false
+      })
+    }
 
     return newState
   },


### PR DESCRIPTION
This PR addresses two bugs:

The first is a bug where we were assigning `isArbitraryDatSigningEnabled` to the root LedgerState rather than assigning it to the state of each connected device.  This did not seem to have any adverse effect on the application but it did not conform to our typing.

The second is a much rarer bug where if a user was upgrading to version 0.13.0 from a pre 0.11.0 version of tally the application would become unresponsive due to pre 0.11.0 redux-states not having the "ledger" property.

### To Test:
-  uninstall tally extension
- `git checkout c88495eba2299771bb8be785d99832a0a89a6e0c` (version 0.10.0)
-  build it and add it to chrome
- open it up - add a wallet (preview is fine)
- `git checkout fix-migration-six`
-  update the wallet in chrome://extensions - version should change to 0.13.0.
-  you should _not_ get a black screen and the wallet should be useable.