### PR TITLE
⚡️ Replace use of fleek's gateway to silly avoid virus scanner block

### DIFF
--- a/background/services/preferences/db.ts
+++ b/background/services/preferences/db.ts
@@ -98,7 +98,7 @@ export class PreferenceDatabase extends Dexie {
             storedPreferences.tokenLists = {
               ...storedPreferences.tokenLists,
               urls: [
-                "https://ipfs.fleek.co/ipfs/bafybeicovpqvb533alo5scf7vg34z6fjspdytbzsa2es2lz35sw3ksh2la",
+                "https://ipfs.io/ipfs/bafybeicovpqvb533alo5scf7vg34z6fjspdytbzsa2es2lz35sw3ksh2la",
                 ...storedPreferences.tokenLists.urls,
               ],
             }

--- a/background/services/preferences/defaults.ts
+++ b/background/services/preferences/defaults.ts
@@ -1,11 +1,16 @@
 import { ETHEREUM, USD } from "../../constants"
+import { storageGatewayURL } from "../../lib/storage-gateway"
 import { Preferences } from "./types"
 
 const defaultPreferences: Preferences = {
   tokenLists: {
     autoUpdate: false,
     urls: [
-      "https://ipfs.fleek.co/ipfs/bafybeicovpqvb533alo5scf7vg34z6fjspdytbzsa2es2lz35sw3ksh2la", // the Tally community-curated list
+      storageGatewayURL(
+        new URL(
+          "ipfs://bafybeicovpqvb533alo5scf7vg34z6fjspdytbzsa2es2lz35sw3ksh2la"
+        )
+      ).href, // the Tally community-curated list
       "https://gateway.ipfs.io/ipns/tokens.uniswap.org", // the Uniswap default list
       "https://yearn.science/static/tokenlist.json", // the Yearn list
       "https://messari.io/tokenlist/messari-verified", // Messari-verified projects


### PR DESCRIPTION
> I just tried to install the Firefox extension off the tally.cash site and my antivirus (Avast) complained it needed to abort the connection to ipfs.fleek.co due to URL:Mal threat

Fixes #1320

<table>
  <tbody>
    <tr>
      <td>Before</td>
      <td>After</td>
    </tr>
    <tr>
      <td>
        <img width="1322" alt="scan 1" src="https://user-images.githubusercontent.com/1918798/164081921-0df122d0-ef69-487e-bef6-de23b0008a75.png">
      </td>
      <td>
        <img width="1146" alt="scan 2" src="https://user-images.githubusercontent.com/1918798/164081947-9c3b1fd2-ae8a-4e88-a28f-e753fc8625b0.png">
      </td>
    </tr>
  </tbody>
</table>