### PR TITLE
💎 Fix displaying ETH asset icon

### DIFF
--- a/ui/components/Shared/SharedAssetIcon.tsx
+++ b/ui/components/Shared/SharedAssetIcon.tsx
@@ -26,9 +26,11 @@ export default function SharedAssetIcon(props: Props): ReactElement {
 
   const httpURL = getAsHttpURL(logoURL)
 
+  const shouldDisplayTokenIcon = Boolean(httpURL || hasHardcodedIcon)
+
   return (
     <div className={`token_icon_wrap ${size}`}>
-      {httpURL ? (
+      {shouldDisplayTokenIcon ? (
         <div className="token_icon" />
       ) : (
         <div className={`token_icon_fallback ${size}`}>


### PR DESCRIPTION
When I updated our IPFS support in asset icons, I broke the logic that determined when to display a hardcoded asset icon 😬. This should fix it!

<img width="300" alt="ETH icon" src="https://user-images.githubusercontent.com/1918798/164085676-2b414721-e041-484b-b008-e2f071f350aa.png">


Closes #1333