### PR TITLE
Adjust source map configs for performance and reproducibility

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -19,7 +19,7 @@ const supportedBrowsers = ["brave", "chrome", "edge", "firefox", "opera"]
 
 // Replicated and adjusted for each target browser and the current build mode.
 const baseConfig: Configuration = {
-  devtool: "eval",
+  devtool: "source-map",
   stats: "errors-only",
   entry: {
     ui: "./src/ui.ts",


### PR DESCRIPTION
Switch to eval source maps in development builds, which webpack claims
are more performant for rebuilds. At the same time, turn off source maps
for Firefox production builds, since these need to be fully reproducible
by the FF add-on verification team, and source maps currently inject
absolute path data into the packaged files, which makes the build
non-reproducible in a different environment.

Future work would ideally allow investigating how to have source maps
without injecting absolute paths.

## Testing

Run `yarn build --config-name firefox` in your clone. Then, clone to a
completely different place, maybe even on a different machine, and do the
same. Then check the generated ZIP files to ensure their unzipped contents
are textually identical (I used [`ksdiff`](https://kaleidoscope.app) for this step).