### PR TITLE
🍁 420: Add commit hash to versions on menu page 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
       env:
         ALCHEMY_KEY: ${{ secrets.DEV_ALCHEMY_API_KEY || 'oV1Rtjh61hGa97X2MTqMY9kEUcpxP-6K' }}
         BLOCKNATIVE_API_KEY: ${{ secrets.DEV_BLOCKNATIVE_API_KEY || 'f60816ff-da02-463f-87a6-67a09c6d53fa' }}
+        COMMIT_SHA: ${{ github.sha }}
     - name: Production build
       if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
       run: yarn build
@@ -37,6 +38,7 @@ jobs:
         ALCHEMY_KEY: ${{ secrets.ALCHEMY_API_KEY }}
         BLOCKNATIVE_API_KEY: ${{ secrets.BLOCKNATIVE_API_KEY }}
         ZEROX_API_KEY: ${{ secrets.ZEROX_API_KEY }}
+        COMMIT_SHA: ${{ github.sha }}
     - name: Upload build asset
       if: ${{ !startsWith(github.ref, 'refs/tags/') }}
       uses: actions/upload-artifact@v2

--- a/ui/pages/Menu.tsx
+++ b/ui/pages/Menu.tsx
@@ -142,7 +142,8 @@ export default function Menu(): ReactElement {
           </SharedButton>
         </div>
         <div className="version">
-          Version: {process.env.VERSION ?? `<unknown>`}
+          Version: {process.env.VERSION ?? `<unknown>`}_
+          {process.env.COMMIT_SHA?.slice(0, 7) ?? `<unknown>`}
         </div>
       </section>
       <style jsx>


### PR DESCRIPTION
By setting an env variable via the build GitHub action, this PR adds displaying
the first 7 digits of the triggering commit's SHA on the menu page. As we move
towards continuous deployment, some folks are doing QA on main via an artifact.
Since `main` is fluid between versions, using just the current version number
is insufficient to specify a build for a bug report.

<img width="377" alt="version" src="https://user-images.githubusercontent.com/1918798/164382257-e6f0ea23-0c9c-43ca-94e7-a48b916c3011.png">

