### PR TITLE
💚 Update `SharedButton` default text color to dark green

### DIFF
--- a/ui/components/Shared/SharedButton.tsx
+++ b/ui/components/Shared/SharedButton.tsx
@@ -190,7 +190,7 @@ export default function SharedButton(
             display: flex;
             align-items: center;
             justify-content: space-between;
-            color: #ffffff;
+            color: var(--hunter-green);
             font-size: 16px;
             font-weight: 600;
             letter-spacing: 0.48px;
@@ -222,7 +222,7 @@ export default function SharedButton(
             width: 16px;
             height: 16px;
             margin-left: 9px;
-            background-color: #ffffff;
+            background-color: var(--hunter-green);
             display: inline-block;
             margin-top: -1px;
           }


### PR DESCRIPTION
For example,

<img width="184" alt="example one" src="https://user-images.githubusercontent.com/1918798/165706806-543fd75b-8dbb-4e8e-bbca-9b83eb2134c7.png">
<img width="141" alt="example two" src="https://user-images.githubusercontent.com/1918798/165706809-f9f4c1b1-34b3-4922-a5e6-eee0ede644ef.png">
<img width="303" alt="example three" src="https://user-images.githubusercontent.com/1918798/165706811-bc83cc2e-c65e-4bf7-88ea-b1e0d5df7ce3.png">


Closes #1297