### PR TITLE
✍️ Contract interaction sign page

### DIFF
--- a/ui/components/SignTransaction/SignTransactionContractInteractionProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionContractInteractionProvider.tsx
@@ -1,0 +1,83 @@
+import React, { ReactElement } from "react"
+import SharedAddress from "../Shared/SharedAddress"
+import TransactionDetailAddressValue from "../TransactionDetail/TransactionDetailAddressValue"
+import TransactionDetailContainer from "../TransactionDetail/TransactionDetailContainer"
+import TransactionDetailItem from "../TransactionDetail/TransactionDetailItem"
+import SignTransactionBaseInfoProvider, {
+  SignTransactionInfoProviderProps,
+} from "./SignTransactionInfoBaseProvider"
+
+export default function SignTransactionContractInteractionProvider({
+  transactionDetails,
+  annotation,
+  inner,
+}: SignTransactionInfoProviderProps): ReactElement {
+  return (
+    <SignTransactionBaseInfoProvider
+      title="Contract interaction"
+      infoBlock={
+        <div className="info_block">
+          <div className="container">
+            {typeof transactionDetails.to === "undefined" ? (
+              <>
+                <div className="label">Send to</div>
+                <div className="send_to">Contract creation</div>
+              </>
+            ) : (
+              <>
+                <div className="label">Interacting with</div>
+                <SharedAddress
+                  address={transactionDetails.to}
+                  name={
+                    annotation !== undefined && "contractName" in annotation
+                      ? annotation.contractName
+                      : undefined
+                  }
+                />
+              </>
+            )}
+          </div>
+          <style jsx>
+            {`
+              .info_block {
+                display: flex;
+                width: 100%;
+                flex-direction: column;
+                align-items: center;
+              }
+              .label {
+                color: var(--green-40);
+                font-size: 16px;
+                line-height: 24px;
+                margin-bottom: 4px;
+              }
+              .container {
+                display: flex;
+                margin: 20px 0;
+                flex-direction: column;
+                align-items: center;
+              }
+            `}
+          </style>
+        </div>
+      }
+      textualInfoBlock={
+        <TransactionDetailContainer>
+          <TransactionDetailItem name="Type" value="Sign" />
+          <TransactionDetailItem
+            name="To:"
+            value={
+              transactionDetails.to && (
+                <TransactionDetailAddressValue
+                  address={transactionDetails.to}
+                />
+              )
+            }
+          />
+        </TransactionDetailContainer>
+      }
+      confirmButtonLabel="Confirm"
+      inner={inner}
+    />
+  )
+}

--- a/ui/components/SignTransaction/SignTransactionInfoBaseProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionInfoBaseProvider.tsx
@@ -3,7 +3,18 @@ import { TransactionAnnotation } from "@tallyho/tally-background/services/enrich
 import { ReactElement, ReactNode } from "react"
 
 export interface SignTransactionInfo {
-  title: ReactNode
+  title:
+    | "Contract interaction"
+    | "Activate blind signing"
+    | "Ledger is busy"
+    | "Connect to Ledger"
+    | "Multiple Ledgers are connected"
+    | "Sign Transaction"
+    | "Approve asset spend"
+    | "Swap assets"
+    | "Sign assets"
+    | "Sign Transfer"
+    | "Wrong Ledger"
   infoBlock: ReactNode
   textualInfoBlock: ReactNode
   confirmButtonLabel: ReactNode

--- a/ui/components/SignTransaction/SignTransactionInfoProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionInfoProvider.tsx
@@ -4,6 +4,7 @@ import { useBackgroundSelector } from "../../hooks"
 import { SignTransactionInfo } from "./SignTransactionInfoBaseProvider"
 import SignTransactionLoader from "./SignTransactionLoader"
 import SignTransactionSignInfoProvider from "./SignTransactionSignInfoProvider"
+import SignTransactionContractInteractionProvider from "./SignTransactionContractInteractionProvider"
 import SignTransactionSpendAssetInfoProvider from "./SignTransactionSpendAssetInfoProvider"
 import SignTransactionSwapAssetInfoProvider from "./SignTransactionSwapAssetInfoProvider"
 import SignTransactionTransferInfoProvider from "./SignTransactionTransferInfoProvider"
@@ -49,6 +50,24 @@ export default function SignTransactionInfoProvider({
           transactionDetails={transactionDetails}
           annotation={annotation}
         />
+      )
+    case "contract-interaction":
+      return (
+        <>
+          {transactionDetails.value === BigInt(0) ? (
+            <SignTransactionContractInteractionProvider
+              inner={children}
+              transactionDetails={transactionDetails}
+              annotation={annotation}
+            />
+          ) : (
+            <SignTransactionSignInfoProvider
+              inner={children}
+              transactionDetails={transactionDetails}
+              annotation={annotation}
+            />
+          )}
+        </>
       )
     default:
       return (

--- a/ui/components/SignTransaction/SignTransactionLoader.tsx
+++ b/ui/components/SignTransaction/SignTransactionLoader.tsx
@@ -4,7 +4,9 @@ import SharedSkeletonLoader from "../Shared/SharedSkeletonLoader"
 export default function SignTransactionLoader(): ReactElement {
   return (
     <div className="loading_transaction">
-      <div className="header serif_header">Sign Transaction</div>
+      <div className="header">
+        <SharedSkeletonLoader height={44} width={235} />
+      </div>
       <div className="container">
         <SharedSkeletonLoader height={32} />
         <SharedSkeletonLoader height={42} />
@@ -18,11 +20,8 @@ export default function SignTransactionLoader(): ReactElement {
           padding-top: 64px;
         }
         .header {
-          color: var(--trophy-gold);
-          font-size: 36px;
-          font-weight: 500;
-          line-height: 42px;
-          text-align: center;
+          display: flex;
+          justify-content: center;
         }
         .container {
           border-radius: 16px;

--- a/ui/components/SignTransaction/SignTransactionPanelCombined.tsx
+++ b/ui/components/SignTransaction/SignTransactionPanelCombined.tsx
@@ -1,0 +1,12 @@
+import React, { ReactElement } from "react"
+import SignTransactionDetailPanel from "./SignTransactionDetailPanel"
+import SignTransactionRawDataPanel from "./SignTransactionRawDataPanel"
+
+export default function SignTransactionPanelCombined(): ReactElement {
+  return (
+    <>
+      <SignTransactionDetailPanel />
+      <SignTransactionRawDataPanel />
+    </>
+  )
+}

--- a/ui/components/SignTransaction/SignTransactionSignInfoProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionSignInfoProvider.tsx
@@ -54,24 +54,15 @@ export default function SignTransactionSignInfoProvider({
       infoBlock={
         <div className="sign_block">
           <div className="container">
-            {typeof transactionDetails.to === "undefined" ? (
-              <>
-                <div className="label">Send to</div>
-                <div className="send_to">Contract creation</div>
-              </>
-            ) : (
-              <>
-                <div className="label">Send to</div>
-                <SharedAddress
-                  address={transactionDetails.to}
-                  name={
-                    annotation !== undefined && "contractName" in annotation
-                      ? annotation.contractName
-                      : undefined
-                  }
-                />
-              </>
-            )}
+            <div className="label">Send to</div>
+            <SharedAddress
+              address={transactionDetails.to ?? ""}
+              name={
+                annotation !== undefined && "contractName" in annotation
+                  ? annotation.contractName
+                  : undefined
+              }
+            />
           </div>
           <div className="divider" />
           <div className="container">

--- a/ui/pages/SignTransaction.tsx
+++ b/ui/pages/SignTransaction.tsx
@@ -14,6 +14,7 @@ import {
 import SignTransactionContainer from "../components/SignTransaction/SignTransactionContainer"
 import SignTransactionInfoProvider from "../components/SignTransaction/SignTransactionInfoProvider"
 import SignTransactionPanelSwitcher from "../components/SignTransaction/SignTransactionPanelSwitcher"
+import SignTransactionPanelCombined from "../components/SignTransaction/SignTransactionPanelCombined"
 
 export default function SignTransaction(): ReactElement {
   const dispatch = useBackgroundDispatch()
@@ -68,7 +69,13 @@ export default function SignTransaction(): ReactElement {
           handleReject={handleReject}
           detailPanel={infoBlock}
           reviewPanel={textualInfoBlock}
-          extraPanel={<SignTransactionPanelSwitcher />}
+          extraPanel={
+            title === "Contract interaction" ? (
+              <SignTransactionPanelCombined />
+            ) : (
+              <SignTransactionPanelSwitcher />
+            )
+          }
           isTransactionSigning={isTransactionSigning}
           isArbitraryDataSigningRequired={
             !!(transactionDetails?.input ?? false)


### PR DESCRIPTION
⚠️ I haven't written a proper description here yet, but feel free to review it anyway! Each of the commit messages include some additional explanation.


### Testing steps
1. Try to swap ETH on Uniswap for any token. The "sign transaction" version should appear with the spend amount
2. Try to swap BAL (any besides ETH) on Uniswap for another token. The "contract interaction" screen should appear like in the screenshot below.

Ideally, all sign transaction types should be tested. That said, these two steps cover what's meant to have been changed.

<hr/>

If we don't have the relevant token spend amount on a contract interaction, after this PR it'll display:
<img width="360" alt="Contract interaction" src="https://user-images.githubusercontent.com/1918798/165707514-39c9cb1c-6e58-4dc7-96fd-fdd8d21eac96.png">


Closes #1271 