### PR TITLE
🫓 Fuckin' NaN: Fix long-tail token price bug

### DIFF
--- a/background/lib/prices.ts
+++ b/background/lib/prices.ts
@@ -127,12 +127,20 @@ export async function getEthereumTokenPrices(
     const price: number = Number.parseFloat(
       priceDetails[fiatSymbol.toLowerCase()]
     )
-    prices[address] = {
-      unitPrice: {
-        asset: fiatCurrency,
-        amount: BigInt(Math.trunc(price * 10 ** fiatCurrency.decimals)),
-      },
-      time: priceDetails.last_updated_at,
+    if (!Number.isNaN(price)) {
+      prices[address] = {
+        unitPrice: {
+          asset: fiatCurrency,
+          amount: BigInt(Math.trunc(price * 10 ** fiatCurrency.decimals)),
+        },
+        time: priceDetails.last_updated_at,
+      }
+    } else {
+      logger.warn(
+        "Price for Ethereum token from CoinGecko cannot be parsed.",
+        address,
+        priceDetails
+      )
     }
   })
   return prices


### PR DESCRIPTION
If a token without a fiat pair was being price checked, the error prevented other tokens from getting a price.

Closes https://github.com/tallycash/extension/issues/1206

# To test

- [ ] Load a new wallet with many tokens
- [ ] Wait 10 minutes to see if prices are pulled. The bug would only allow the price of ETH through rather than many ERC-20s.