### PR TITLE
Error Vector Magnitude: Light refactoring for multi-network handling

### DIFF
--- a/background/networks.ts
+++ b/background/networks.ts
@@ -128,7 +128,7 @@ export type LegacyEVMTransaction = EVMTransaction & {
  */
 export type LegacyEVMTransactionRequest = Pick<
   LegacyEVMTransaction,
-  "gasPrice" | "type" | "nonce" | "from" | "to" | "input" | "value"
+  "gasPrice" | "type" | "nonce" | "from" | "to" | "input" | "value" | "network"
 > & {
   chainID: LegacyEVMTransaction["network"]["chainID"]
   gasLimit: bigint
@@ -164,6 +164,7 @@ export type EIP1559TransactionRequest = Pick<
   | "value"
   | "maxFeePerGas"
   | "maxPriorityFeePerGas"
+  | "network"
 > & {
   gasLimit: bigint
   chainID: EIP1559Transaction["network"]["chainID"]

--- a/background/services/ledger/index.ts
+++ b/background/services/ledger/index.ts
@@ -319,7 +319,6 @@ export default class LedgerService extends BaseService<Events> {
   }
 
   async signTransaction(
-    network: EVMNetwork,
     transactionRequest: EIP1559TransactionRequest & { nonce: number },
     deviceID: string,
     path: string
@@ -395,8 +394,8 @@ export default class LedgerService extends BaseService<Events> {
 
           blockHash: null,
           blockHeight: null,
-          asset: ETH,
-          network,
+          asset: transactionRequest.network.baseAsset,
+          network: transactionRequest.network,
         }
 
         return signedTx

--- a/background/services/signing/index.ts
+++ b/background/services/signing/index.ts
@@ -115,21 +115,22 @@ export default class SigningService extends BaseService<Events> {
   }
 
   private async signTransactionWithNonce(
-    network: EVMNetwork,
     transactionWithNonce: EIP1559TransactionRequest & { nonce: number },
     signingMethod: SigningMethod
   ): Promise<SignedEVMTransaction> {
     switch (signingMethod.type) {
       case "ledger":
         return this.ledgerService.signTransaction(
-          network,
           transactionWithNonce,
           signingMethod.deviceID,
           signingMethod.path
         )
       case "keyring":
         return this.keyringService.signTransaction(
-          { address: transactionWithNonce.from, network },
+          {
+            address: transactionWithNonce.from,
+            network: transactionWithNonce.network,
+          },
           transactionWithNonce
         )
       default:
@@ -157,20 +158,11 @@ export default class SigningService extends BaseService<Events> {
     transactionRequest: EIP1559TransactionRequest,
     signingMethod: SigningMethod
   ): Promise<SignedEVMTransaction> {
-    const network = USE_MAINNET_FORK
-      ? FORK
-      : EVM_NETWORKS_BY_CHAIN_ID[transactionRequest.chainID]
-
-    if (typeof network === "undefined") {
-      throw new Error(`Unknown chain ID ${transactionRequest.chainID}.`)
-    }
-
     const transactionWithNonce =
       await this.chainService.populateEVMTransactionNonce(transactionRequest)
 
     try {
       const signedTx = await this.signTransactionWithNonce(
-        network,
         transactionWithNonce,
         signingMethod
       )

--- a/background/tests/keyring-integration.test.ts
+++ b/background/tests/keyring-integration.test.ts
@@ -10,7 +10,7 @@ import KeyringService, {
 } from "../services/keyring"
 import { KeyringTypes } from "../types"
 import { EIP1559TransactionRequest } from "../networks"
-import { ETHEREUM } from "../constants"
+import { ETH, ETHEREUM } from "../constants"
 import logger from "../lib/logger"
 
 const originalCrypto = global.crypto
@@ -51,6 +51,7 @@ const validTransactionRequests: {
     maxPriorityFeePerGas: 0n,
     gasLimit: 0n,
     chainID: "0",
+    network: { name: "none", chainID: "0", baseAsset: ETH, family: "EVM" },
   },
 }
 


### PR DESCRIPTION
This implements queued transaction lookups for all networks with a
provider available, factors the provider tracking in `ChainService`
to follow the pattern from elsewhere of nesting all EVM chains under
an `evm` property for future work, and adds network tracking to
transaction requests.

## Testing

Things to be tested here:
- [ ] Transaction history population, as well as lookups for newly
      created transactions, continue to work properly on mainnet.
- [ ] Transactions can still be created, signed, etc.
- [ ] Mainnet fork still works as expected when USE_MAINNET_FORK is
      enabled; in particular, transactions can still be signed and
      mined on the mainnet fork.