### PR TITLE
FF store updates: update Dockerfile and build steps for ff

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,14 @@ FROM node:16-alpine
 
 WORKDIR /tally-ho
 
-COPY . . 
+COPY . .
 
 RUN mv .env.prod .env
 RUN apk add --no-cache python3 py3-pip git make bash && ln -sf python3 /usr/bin/python
-# sqlite compile throws an error during install, but it does not cause any problem so we are ignoring it
-RUN yarn install --frozen-lockfile || true
+# remotedev-server is using sqlite3 which fails to install/compile at the moment
+# I have a hunch that because it fails the postinstall is not run and the patches are not applied
+# As a short term workaround we just remove this dependency here, because we don't need it to build 
+# It's used only for server
+RUN sed -i '/remotedev-server/d' ./background/package.json
+RUN yarn install --frozen-lockfile 
 RUN yarn build --config-name firefox

--- a/README.md
+++ b/README.md
@@ -332,14 +332,47 @@ ui/ # @tallyho/tally-ui package
 
 Firefox requires to upload source code if minifier is used and to be able to compile identical output to the uploaded package. Our builds are environment dependent at the moment because of the minification and source map process. Long term solution will be to upgrade our build process to be able to produce identical file assets, but until then we use Docker.
 
+### Prepare source zip
+
 - install and setup docker: https://docs.docker.com/get-docker/
 - git clone git@github.com:tallycash/extension.git tallyho-firefox
 - cd tallyho-firefox
 - git checkout tags/latest_release-tag
 - .env.prod: fill in the prod API keys
-- `./firefox-build.sh`
-- mv firefox.zip ../
-- git clean -fdx
 - rm -rf .git
+- zip -r ff-source.zip .
+- mv ff-source.zip ../
 - cd ..
-- zip -r tallyho-firefox.zip tallyho-firefox
+
+### Create actual build
+
+- mkdir build
+- cp ff-source.zip build
+- cd build
+- unzip ff-source.zip
+- rm ff-source.zip
+- ./firefox-build.sh
+- mv firefox.zip ../ff-build.zip
+
+### Firefox notes to reviewer
+
+Docker is required for this build to work
+
+Steps to build the extension
+
+- mkdir build
+- cp ff-source.zip build
+- cd build
+- unzip ff-source.zip
+- rm ff-source.zip
+- ./firefox-build.sh
+
+- mkdir out
+- cp firefox.zip out
+- cd out
+- unzip firefox.zip
+- rm firefox.zip
+- diff ./ /path/to/downloaded/and/unzip/extension
+
+The firefox.zip is the extension code that I have submitted and used, so they should be the same.
+I have tried the above method a couple of times and it resulted in an empty diff so it should be good to go.


### PR DESCRIPTION
> This is just to document the exact steps I took to submit the current v0.13.3 build to ff and to support @henryboldi 
> - The sqllite workaround should be removed when the dependency is fixed
> - The build steps should be automated if they work
> But I kept them as is, because not sure that they will work. They should but we had that thought a couple of time already... 


I have a hunch that because of sqlite3
install failure the postinstall script
is not run and our patches are not applied.
So just removed the remotedev-server from
the background package for build as quick
and hacky workaround until we solve the
issue properly. We don't need it for build
so it's a safe corner to cut here.

Also wanted to record the exact steps
to prepare the source and the output
for submission.