### PR TITLE
Don't send an empty array when calling alchemy_getTokenBalances.

### DIFF
--- a/background/lib/alchemy.ts
+++ b/background/lib/alchemy.ts
@@ -141,7 +141,7 @@ export async function getTokenBalances(
 
   const json: unknown = await provider.send("alchemy_getTokenBalances", [
     address,
-    uniqueTokens || "DEFAULT_TOKENS",
+    uniqueTokens.length > 0 ? uniqueTokens : "DEFAULT_TOKENS",
   ])
 
   if (!isValidAlchemyTokenBalanceResponse(json)) {


### PR DESCRIPTION
Sending an empty array results in the following error: 
`Error: invalid 2nd argument: contract_addresses was not a valid contract address array or string literal 'DEFAULT_TOKENS'`


### To Test
- [ ] Balances should show up on adding a new wallet.