### PR TITLE
Properly log objects in exported logs.

### DIFF
--- a/background/lib/logger.ts
+++ b/background/lib/logger.ts
@@ -74,11 +74,24 @@ function saveLog(
   input: unknown[],
   stackTrace: string[] | undefined
 ) {
+  const formattedInput = input
+  for (let i = 0; i < input.length; i += 1) {
+    const log = input[i]
+    if (log instanceof Object) {
+      try {
+        formattedInput[i] = JSON.stringify(log)
+      } catch (e) {
+        // if we can't stringify thats OK
+      }
+    }
+  }
   localStorage.setItem(
     "logs",
     `${(localStorage.getItem("logs") ?? "").slice(
       -50000
-    )}${purgeSensitiveFailSafe(`${logLabel}\n${input}\n${stackTrace}`)}\n\n`
+    )}${purgeSensitiveFailSafe(
+      `${logLabel}\n${formattedInput}\n${stackTrace}`
+    )}\n\n`
   )
 }
 

--- a/background/lib/logger.ts
+++ b/background/lib/logger.ts
@@ -77,11 +77,11 @@ function saveLog(
   const formattedInput = input
   for (let i = 0; i < input.length; i += 1) {
     const log = input[i]
-    if (log instanceof Object) {
+    if (typeof log === "object") {
       try {
         formattedInput[i] = JSON.stringify(log)
       } catch (e) {
-        // if we can't stringify thats OK
+        // if we can't stringify thats OK, we'll still see [object Object] in the logs.
       }
     }
   }


### PR DESCRIPTION
Before: 

```
chrome-extension://licmhmlaminmlpcdkobcjofpnchdlacg/background.js:61926:63
Error fetching, validating, and saving token list https://yearn.science/static/tokenlist.json,[object Object]
    at chrome-extension://licmhmlaminmlpcdkobcjofpnchdlacg/background.js:61926:63 
```

Note the `[object Object]`

After:

```
chrome-extension://licmhmlaminmlpcdkobcjofpnchdlacg/background.js:61939:63
Error fetching, validating, and saving token list https://yearn.science/static/tokenlist.json,{"foo":"bar"}
    at chrome-extension://licmhmlaminmlpcdkobcjofpnchdlacg/background.js:61939:63 
```

As a result of the following line of code: 

```
logger.error(`Error fetching, validating, and saving token list ${url}`, { foo: "bar" })
 ```
 
 This will make logs that users export for us a lot more useful - especially when looking at internal ethereum provider logs.