### PR TITLE
Fix: search icon overlap

### DIFF
--- a/ui/components/Shared/SharedAssetInput.tsx
+++ b/ui/components/Shared/SharedAssetInput.tsx
@@ -197,6 +197,7 @@ function SelectAssetMenuContent<T extends AnyAsset>(
             border-radius: 4px;
             border: 1px solid var(--green-60);
             padding-left: 16px;
+            padding-right: 56px;
             box-sizing: border-box;
             color: var(--green-40);
           }


### PR DESCRIPTION
close #1149

<img width="408" alt="image" src="https://user-images.githubusercontent.com/3824034/167682107-aaa07120-7e56-4fdb-92ca-5ccfdbc29265.png">
cc @henryboldi 