### PR TITLE
Properly cleanup event listeners on the Internal Provider.

### DIFF
--- a/background/redux-slices/utils/contract-utils.ts
+++ b/background/redux-slices/utils/contract-utils.ts
@@ -19,7 +19,7 @@ export const internalProviderPort = {
     this.listeners.push(listener)
   },
   removeEventListener(toRemove: (message: any) => unknown): void {
-    this.listeners.filter((listener) => listener !== toRemove)
+    this.listeners = this.listeners.filter((listener) => listener !== toRemove)
   },
   origin: window.location.origin,
   postMessage(message: any): void {


### PR DESCRIPTION
We had a small memory leak that became especially apparent when the app was disconnected and attempting to reconnect and call `eth_chainID` over long periods of time.

This issue _might_ be related to https://github.com/tallycash/extension/issues/1158 