### PR TITLE
Refresh the base asset along with tokens when refreshing token balances.

### DIFF
--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -671,6 +671,7 @@ export default class IndexingService extends BaseService<Events> {
         await this.chainService.getAccountsToTrack()
       ).map(async (addressOnNetwork) => {
         await this.retrieveTokenBalances(addressOnNetwork, activeAssetsToTrack)
+        await this.chainService.getLatestBaseAccountBalance(addressOnNetwork)
       })
     )
   }


### PR DESCRIPTION
This change makes it so that ETH balance update on our 1-minute balance update alarm.

### To Test
- disconnect from internet
- clean install the extension
- import an account
- Stay disconnected for ~1-2 minutes
- Connect to internet
- [ ] ETH balance should show up in the wallet within about 1 minute of reconnecting.

This is related to https://github.com/tallycash/extension/issues/1158
