### PR TITLE
Explicit error logging inside of chainService.addAccountToTrack

### DIFF
--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -517,9 +517,24 @@ export default class ChainService extends BaseService<Events> {
   async addAccountToTrack(addressNetwork: AddressOnNetwork): Promise<void> {
     await this.db.addAccountToTrack(addressNetwork)
     this.emitter.emit("newAccountToTrack", addressNetwork)
-    this.getLatestBaseAccountBalance(addressNetwork)
-    this.subscribeToAccountTransactions(addressNetwork)
-    this.loadRecentAssetTransfers(addressNetwork)
+    this.getLatestBaseAccountBalance(addressNetwork).catch((e) => {
+      logger.error(
+        "chainService/addAccountToTrack: Error getting latestBaseAccountBalance",
+        e
+      )
+    })
+    this.subscribeToAccountTransactions(addressNetwork).catch((e) => {
+      logger.error(
+        "chainService/addAccountToTrack: Error subscribing to account transactions",
+        e
+      )
+    })
+    this.loadRecentAssetTransfers(addressNetwork).catch((e) => {
+      logger.error(
+        "chainService/addAccountToTrack: Error loading recent asset transfers",
+        e
+      )
+    })
   }
 
   async getBlockHeight(network: EVMNetwork): Promise<number> {


### PR DESCRIPTION
Since we invoke some async functions without awaiting them inside of chain service's addAccountToTrack - any errors in those functions are swallowed without being logged. 

Adding these catch's at least lets us log the errors - although unfortunately we do not get a relevant stack trace so extra labeling of the logs is necessary.


### To Test
- disconnect from internet
- install tally
- import a new wallet
- [ ] You should see the three new errors in the background log since we expect those functions to fail.