### PR TITLE
Move the referral bridge to first claim step

### DIFF
--- a/ui/components/Claim/ClaimIntro.tsx
+++ b/ui/components/Claim/ClaimIntro.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from "react"
 import ClaimAmountBanner from "./ClaimAmountBanner"
+import ClaimReferralBridge from "./ClaimReferralBridge"
 
 export default function ClaimIntro(props: {
   claimAmount: number
@@ -8,6 +9,7 @@ export default function ClaimIntro(props: {
 
   return (
     <div className="claim standard_width">
+      <ClaimReferralBridge />
       <div className="title">You’re about to claim</div>
       <ClaimAmountBanner amount={claimAmount} />
       <p className="list_title">Here are your next steps:</p>

--- a/ui/pages/Claiming/Eligible.tsx
+++ b/ui/pages/Claiming/Eligible.tsx
@@ -20,7 +20,6 @@ import SharedSlideUpMenu from "../../components/Shared/SharedSlideUpMenu"
 import { doggoTokenDecimalDigits } from "../../utils/constants"
 import TopMenuProfileButton from "../../components/TopMenu/TopMenuProfileButton"
 import SharedBackButton from "../../components/Shared/SharedBackButton"
-import ClaimReferralBridge from "../../components/Claim/ClaimReferralBridge"
 
 export default function Eligible(): ReactElement {
   const dispatch = useBackgroundDispatch()
@@ -123,7 +122,6 @@ export default function Eligible(): ReactElement {
 
   return (
     <div className="wrap">
-      <ClaimReferralBridge />
       {infoModalVisible ? (
         <ClaimInfoModal setModalVisible={setInfoModalVisible} />
       ) : null}


### PR DESCRIPTION
We used to set the referral on each visit to the claim container
component, which caused the referrer to be re-set after we come
back from signing delegation. Now unless users go back to the
first step the referred variable will stay removed.

https://user-images.githubusercontent.com/61434499/168087395-a50c17e2-e48b-40c8-b369-7ee0e45f15ec.mov


