### PR TITLE
Richness not Flatness: Don't flatten recipients in internal log recipient lookups

### DIFF
--- a/background/services/enrichment/index.ts
+++ b/background/services/enrichment/index.ts
@@ -270,11 +270,11 @@ export default class EnrichmentService extends BaseService<Events> {
         (
           await Promise.allSettled(
             [
-              ...new Set(
+              ...new Set([
                 ...erc20TransferLogs.map(
                   ({ recipientAddress }) => recipientAddress
-                )
-              ),
+                ),
+              ]),
             ].map(
               async (address) =>
                 [


### PR DESCRIPTION
To preserve uniqueness, the transfer log recipient addresses are
extracted and then passed through a Set. Due to a small error in how
the recipient addresses were being fed to the Set, the addresses were
being fully flattened into individual characters instead of addresses,
leading to very incorrect and extra-repetitive naming lookups.

Closes #1430 .