### PR TITLE
Remove unused addOrEditAddressName event in ui redux slice.

### DIFF
--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -31,7 +31,6 @@ export type Events = {
   newDefaultWalletValue: boolean
   refreshBackgroundPage: null
   newSelectedAccount: AddressOnNetwork
-  addOrEditAddressName: { name: string; address: HexString }
 }
 
 export const emitter = new Emittery<Events>()


### PR DESCRIPTION
This seems to be a holdover from a previous implementation attempt - discarded in favor of the [addOrEditAddressName](https://github.com/tallycash/extension/blob/main/background/redux-slices/accounts.ts#L325) function.