### PR TITLE
Add the .vscode folder to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ app/extension-scripts/api/playground/
 .env
 *.rest
 .DS_Store
+.vscode


### PR DESCRIPTION
Reasoning here is that we should allow developers to customize their development environment while developing without forcing a particular set of settings onto anyone or cluttering up the filesystem of developers who do not use vscode.