### PR TITLE
Ξ -> ♾️  Switch to Polygon.

### DIFF
--- a/background/constants/networks.ts
+++ b/background/constants/networks.ts
@@ -18,7 +18,7 @@ export const POLYGON: EVMNetwork = {
 }
 
 export const ARBITRUM_ONE: EVMNetwork = {
-  name: "Arbitrum One",
+  name: "Arbitrum",
   baseAsset: ETH,
   chainID: "42161",
   family: "EVM",

--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -67,8 +67,17 @@ const uiSlice = createSlice({
       ...state,
       showingActivityDetailID: transactionID,
     }),
-    setSelectedAccount: (immerState, { payload: addressNetwork }) => {
+    setSelectedAccount: (
+      immerState,
+      { payload: addressNetwork }: { payload: AddressOnNetwork }
+    ) => {
       immerState.selectedAccount = addressNetwork
+    },
+    setSelectedNetwork: (
+      immerState,
+      { payload: network }: { payload: EVMNetwork }
+    ) => {
+      immerState.selectedAccount.network = network
     },
     initializationLoadingTimeHitLimit: (state) => ({
       ...state,
@@ -116,6 +125,7 @@ export const {
   setDefaultWallet,
   clearSnackbarMessage,
   setRouteHistoryEntries,
+  setSelectedNetwork,
 } = uiSlice.actions
 
 export default uiSlice.reducer

--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -72,12 +72,6 @@ const uiSlice = createSlice({
     ) => {
       immerState.selectedAccount = addressNetwork
     },
-    changeSelectedNetwork: (
-      immerState,
-      { payload: network }: { payload: EVMNetwork }
-    ) => {
-      immerState.selectedAccount.network = network
-    },
     initializationLoadingTimeHitLimit: (state) => ({
       ...state,
       initializationLoadingTimeExpired: true,
@@ -128,20 +122,6 @@ export const {
 
 export default uiSlice.reducer
 
-export const setSelectedNetwork = createBackgroundAsyncThunk(
-  "ui/setSelectedNetwork",
-  async (network: EVMNetwork, { getState, dispatch }) => {
-    const state = getState() as { ui: UIState; account: AccountState }
-    const { ui, account } = state
-    dispatch(uiSlice.actions.changeSelectedNetwork(network))
-    if (
-      !account.accountsData.evm[network.chainID]?.[ui.selectedAccount.address]
-    ) {
-      dispatch(addAddressNetwork({ ...ui.selectedAccount, network }))
-    }
-  }
-)
-
 // Async thunk to bubble the setNewDefaultWalletValue action from  store to emitter.
 export const setNewDefaultWalletValue = createBackgroundAsyncThunk(
   "ui/setNewDefaultWalletValue",
@@ -159,6 +139,20 @@ export const setNewSelectedAccount = createBackgroundAsyncThunk(
     await emitter.emit("newSelectedAccount", addressNetwork)
     // Once the default value has persisted, propagate to the store.
     dispatch(uiSlice.actions.setSelectedAccount(addressNetwork))
+  }
+)
+
+export const setSelectedNetwork = createBackgroundAsyncThunk(
+  "ui/setSelectedNetwork",
+  async (network: EVMNetwork, { getState, dispatch }) => {
+    const state = getState() as { ui: UIState; account: AccountState }
+    const { ui, account } = state
+    dispatch(setNewSelectedAccount({ ...ui.selectedAccount, network }))
+    if (
+      !account.accountsData.evm[network.chainID]?.[ui.selectedAccount.address]
+    ) {
+      dispatch(addAddressNetwork({ ...ui.selectedAccount, network }))
+    }
   }
 )
 

--- a/ui/components/TopMenu/TopMenuProfileButton.tsx
+++ b/ui/components/TopMenu/TopMenuProfileButton.tsx
@@ -1,4 +1,7 @@
-import { selectCurrentAccountTotal } from "@tallyho/tally-background/redux-slices/selectors"
+import {
+  selectCurrentAccount,
+  selectCurrentAccountTotal,
+} from "@tallyho/tally-background/redux-slices/selectors"
 import { setSnackbarMessage } from "@tallyho/tally-background/redux-slices/ui"
 import React, { ReactElement, useState, useRef } from "react"
 import { useDispatch } from "react-redux"
@@ -12,8 +15,10 @@ export default function TopMenuProfileButton(props: {
   onClick?: () => void
 }): ReactElement {
   const dispatch = useDispatch()
-  const { shortenedAddress, name, avatarURL, address } =
+  const { name, avatarURL, address } =
     useBackgroundSelector(selectCurrentAccountTotal) ?? {}
+
+  const { truncatedAddress } = useBackgroundSelector(selectCurrentAccount) ?? {}
 
   const [shouldDisplayTooltip, setShouldDisplayTooltip] = useState(false)
   const timerRef = useRef<number | undefined>(undefined)
@@ -51,12 +56,12 @@ export default function TopMenuProfileButton(props: {
         onClick={handleClick}
         onMouseEnter={showTooltip}
       >
-        {typeof shortenedAddress === "undefined" ? (
+        {typeof truncatedAddress === "undefined" ? (
           <></>
         ) : (
           <>
             <SharedCurrentAccountInformation
-              shortenedAddress={shortenedAddress}
+              shortenedAddress={truncatedAddress}
               name={name}
               avatarURL={avatarURL}
               showHoverStyle

--- a/ui/components/TopMenu/TopMenuProtocolList.tsx
+++ b/ui/components/TopMenu/TopMenuProtocolList.tsx
@@ -1,27 +1,36 @@
+import {
+  ARBITRUM_ONE,
+  ETHEREUM,
+  OPTIMISM,
+  POLYGON,
+} from "@tallyho/tally-background/constants"
+import { sameNetwork } from "@tallyho/tally-background/networks"
+import { selectCurrentNetwork } from "@tallyho/tally-background/redux-slices/selectors"
 import React, { ReactElement } from "react"
+import { useBackgroundSelector } from "../../hooks"
 import TopMenuProtocolListItem from "./TopMenuProtocolListItem"
 
 const networks = [
   {
-    name: "Ethereum",
+    ...ETHEREUM,
     info: "Mainnet",
     width: 18,
     height: 29,
   },
   {
-    name: "Polygon",
+    ...POLYGON,
     info: /* ( ͡° ͜ʖ ͡°) */ "L2 scaling solution",
     width: 24,
     height: 24,
   },
   {
-    name: "Arbitrum",
+    ...ARBITRUM_ONE,
     info: "L2 scaling solution",
     width: 23.2,
     height: 26,
   },
   {
-    name: "Optimism",
+    ...OPTIMISM,
     info: "L2 scaling solution",
     width: 24,
     height: 24,
@@ -41,12 +50,14 @@ const networks = [
 ]
 
 export default function TopMenuProtocolList(): ReactElement {
+  const currentNetwork = useBackgroundSelector(selectCurrentNetwork)
+
   return (
     <div className="standard_width_padded center_horizontal">
       <ul>
-        {networks.map((network, index) => (
+        {networks.map((network) => (
           <TopMenuProtocolListItem
-            isSelected={index === 0}
+            isSelected={sameNetwork(currentNetwork, network)}
             key={network.name}
             name={network.name}
             info={network.info}
@@ -54,15 +65,6 @@ export default function TopMenuProtocolList(): ReactElement {
             height={network.height}
           />
         ))}
-        {/* <li className="divider">
-          <div className="divider_label">Testnet</div>
-          <div className="divider_line" />
-        </li>
-        {Array(3)
-          .fill("")
-          .map((_, index) => (
-            <TopMenuProtocolListItem key={index.toString()} />
-          ))} */}
       </ul>
       <style jsx>
         {`

--- a/ui/components/TopMenu/TopMenuProtocolList.tsx
+++ b/ui/components/TopMenu/TopMenuProtocolList.tsx
@@ -19,7 +19,7 @@ const listItemInfo = [
   },
   {
     network: POLYGON,
-    info: /* ( ͡° ͜ʖ ͡°) */ "L2 scaling solution",
+    info: "L2 scaling solution",
     width: 24,
     height: 24,
   },

--- a/ui/components/TopMenu/TopMenuProtocolList.tsx
+++ b/ui/components/TopMenu/TopMenuProtocolList.tsx
@@ -10,27 +10,27 @@ import React, { ReactElement } from "react"
 import { useBackgroundSelector } from "../../hooks"
 import TopMenuProtocolListItem from "./TopMenuProtocolListItem"
 
-const networks = [
+const listItemInfo = [
   {
-    ...ETHEREUM,
+    network: ETHEREUM,
     info: "Mainnet",
     width: 18,
     height: 29,
   },
   {
-    ...POLYGON,
+    network: POLYGON,
     info: /* ( ͡° ͜ʖ ͡°) */ "L2 scaling solution",
     width: 24,
     height: 24,
   },
   {
-    ...ARBITRUM_ONE,
+    network: ARBITRUM_ONE,
     info: "L2 scaling solution",
     width: 23.2,
     height: 26,
   },
   {
-    ...OPTIMISM,
+    network: OPTIMISM,
     info: "L2 scaling solution",
     width: 24,
     height: 24,
@@ -55,14 +55,14 @@ export default function TopMenuProtocolList(): ReactElement {
   return (
     <div className="standard_width_padded center_horizontal">
       <ul>
-        {networks.map((network) => (
+        {listItemInfo.map((info) => (
           <TopMenuProtocolListItem
-            isSelected={sameNetwork(currentNetwork, network)}
-            key={network.name}
-            name={network.name}
-            info={network.info}
-            width={network.width}
-            height={network.height}
+            isSelected={sameNetwork(currentNetwork, info.network)}
+            key={info.network.name}
+            network={info.network}
+            height={info.height}
+            width={info.width}
+            info={info.info}
           />
         ))}
       </ul>

--- a/ui/components/TopMenu/TopMenuProtocolListItem.tsx
+++ b/ui/components/TopMenu/TopMenuProtocolListItem.tsx
@@ -1,26 +1,37 @@
 import React, { ReactElement } from "react"
 import classNames from "classnames"
+import { useDispatch } from "react-redux"
+import { setSelectedNetwork } from "@tallyho/tally-background/redux-slices/ui"
+import { EVMNetwork } from "@tallyho/tally-background/networks"
 
 interface Props {
-  name: string
   info: string
   width: number
   height: number
+  network: EVMNetwork
   isSelected: boolean
 }
 
 export default function TopMenuProtocolListItem(props: Props): ReactElement {
-  const { name, width, height, info, isSelected } = props
+  const { width, height, info, isSelected, network } = props
+
+  const dispatch = useDispatch()
 
   return (
-    <li className={classNames({ select: isSelected })}>
+    <li
+      className={classNames({ select: isSelected })}
+      onClick={() => {
+        dispatch(setSelectedNetwork(network))
+      }}
+      role="presentation"
+    >
       <div className="left">
         <div className="icon_wrap">
           <span className="icon" />
         </div>
       </div>
       <div className="right">
-        <div className="title">{name}</div>
+        <div className="title">{network.name}</div>
         <div className="sub_title">
           {info}
           {isSelected && <span className="status">Connected</span>}
@@ -43,7 +54,7 @@ export default function TopMenuProtocolListItem(props: Props): ReactElement {
             margin-left: 8px;
           }
           .icon {
-            background: url("./images/${name
+            background: url("./images/${network.name
               .replaceAll(" ", "")
               .toLowerCase()}@2x.png");
             background-size: cover;

--- a/ui/components/TopMenu/TopMenuProtocolSwitcher.tsx
+++ b/ui/components/TopMenu/TopMenuProtocolSwitcher.tsx
@@ -1,4 +1,6 @@
 import React, { ReactElement } from "react"
+import { selectCurrentNetwork } from "@tallyho/tally-background/redux-slices/selectors"
+import { useBackgroundSelector } from "../../hooks"
 
 type Props = {
   onClick?: () => void
@@ -9,9 +11,10 @@ export default function TopMenuProtocolSwitcher({
   onClick,
   enabled,
 }: Props): ReactElement {
+  const currentNetwork = useBackgroundSelector(selectCurrentNetwork)
   return (
     <button type="button" onClick={() => enabled && onClick?.()}>
-      Ethereum
+      {currentNetwork.name}
       {enabled && <span className="icon_chevron_down" />}
       <style jsx>
         {`


### PR DESCRIPTION
This PR allows users to use the top menu protocol switcher to switch between Ethereum & Polygon and see their network balance on the corresponding network.

https://user-images.githubusercontent.com/94649004/168637792-048443f3-1e20-4371-b428-f49c497590b1.mov

### To Test
- Compile the extension with MULTI_NETWORK=true in your `.env` file.
- Import a wallet to the extension.
- Note balance on Polygon (import should default to this chain when MULTI_NETWORK=true).
- Use top switcher to switch to Ethereum.
- Your ETH balance should load quickly and your token balances should load over time.
- Switching back and forth between Polygon and Ethereum should correctly show your balance on the respective chain.