### PR TITLE
Remove unused getNonce function.

### DIFF
--- a/background/redux-slices/utils/contract-utils.ts
+++ b/background/redux-slices/utils/contract-utils.ts
@@ -53,14 +53,6 @@ export const getSignerAddress = async (): Promise<string> => {
   return signerAddress
 }
 
-export const getNonce = async (): Promise<number> => {
-  const provider = getProvider()
-  const signer = provider.getSigner()
-  const signerAddress = await signer.getAddress()
-  const nonce = provider.getTransactionCount(signerAddress)
-  return nonce
-}
-
 export const getCurrentTimestamp = async (): Promise<number> => {
   const provider = getProvider()
   const { timestamp } = await provider.getBlock(provider.getBlockNumber())


### PR DESCRIPTION
Nonce logic should automatically be handled by the provider or inside of chain service.  This function is unused and can potentially be harmful if accidentally used to manually set a nonce.

### To Test
- compile the extension.