### PR TITLE
🗑  Fix selecting other address if current one is removed

### DIFF
--- a/ui/components/AccountItem/AccountItemRemovalConfirm.tsx
+++ b/ui/components/AccountItem/AccountItemRemovalConfirm.tsx
@@ -94,13 +94,13 @@ export default function AccountItemRemovalConfirm({
             if (readOnlyAccount || areKeyringsUnlocked) {
               dispatch(removeAccount({ address, network }))
               if (sameEVMAddress(selectedAddress, address)) {
-                const newAddress = Object.keys(accountsData).find(
-                  (accountAddress) => accountAddress !== address
-                )
+                const newAddress = Object.keys(
+                  accountsData.evm[network.chainID]
+                ).find((accountAddress) => accountAddress !== address)
                 if (newAddress) {
                   dispatch(
                     setSelectedAccount({
-                      address,
+                      address: newAddress,
                       network,
                     })
                   )


### PR DESCRIPTION
Resolves #1497

### Testing

1. Add a few addresses 
2. Remove the currently selected address

**Expected result:** extension will switch selected account to another address