### PR TITLE
Notify the internal ethereum provider directly about network changes.

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -1009,6 +1009,13 @@ export default class Main extends BaseService<never> {
         signingSliceEmitter.on("signatureRejected", rejectAndClear)
       }
     )
+
+    uiSliceEmitter.on("newSelectedNetwork", (network) => {
+      this.internalEthereumProviderService.routeSafeRPCRequest(
+        "wallet_switchEthereumChain",
+        [{ chainId: network.chainID }]
+      )
+    })
   }
 
   async connectProviderBridgeService(): Promise<void> {

--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -150,12 +150,7 @@ export const setSelectedNetwork = createBackgroundAsyncThunk(
     const { ui, account } = state
     dispatch(setNewSelectedAccount({ ...ui.selectedAccount, network }))
     const provider = getProvider()
-    // dogfood our switchEthereumChain handler
-    provider.send("wallet_switchEthereumChain", [
-      {
-        chainId: toHexChainID(network.chainID),
-      },
-    ])
+    await provider.switchChain(network)
     if (
       !account.accountsData.evm[network.chainID]?.[ui.selectedAccount.address]
     ) {

--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -32,6 +32,7 @@ export type Events = {
   newDefaultWalletValue: boolean
   refreshBackgroundPage: null
   newSelectedAccount: AddressOnNetwork
+  newSelectedNetwork: EVMNetwork
 }
 
 export const emitter = new Emittery<Events>()
@@ -146,11 +147,10 @@ export const setNewSelectedAccount = createBackgroundAsyncThunk(
 export const setSelectedNetwork = createBackgroundAsyncThunk(
   "ui/setSelectedNetwork",
   async (network: EVMNetwork, { getState, dispatch }) => {
+    emitter.emit("newSelectedNetwork", network)
     const state = getState() as { ui: UIState; account: AccountState }
     const { ui, account } = state
     dispatch(setNewSelectedAccount({ ...ui.selectedAccount, network }))
-    const provider = getProvider()
-    await provider.switchChain(network)
     if (
       !account.accountsData.evm[network.chainID]?.[ui.selectedAccount.address]
     ) {

--- a/background/redux-slices/utils/contract-utils.ts
+++ b/background/redux-slices/utils/contract-utils.ts
@@ -1,7 +1,7 @@
-import { Web3Provider } from "@ethersproject/providers"
 import TallyWindowProvider from "@tallyho/window-provider"
 import { Contract, ethers, ContractInterface } from "ethers"
 import Emittery from "emittery"
+import TallyWeb3Provider from "../../tally-provider"
 
 type InternalProviderPortEvents = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -33,8 +33,8 @@ export const internalProviderPort = {
 
 export const internalProvider = new TallyWindowProvider(internalProviderPort)
 
-export function getProvider(this: unknown): Web3Provider {
-  return new Web3Provider(internalProvider)
+export function getProvider(this: unknown): TallyWeb3Provider {
+  return new TallyWeb3Provider(internalProvider)
 }
 
 export const getContract = async (

--- a/background/tally-provider.ts
+++ b/background/tally-provider.ts
@@ -1,0 +1,13 @@
+import { Web3Provider } from "@ethersproject/providers"
+import { toHexChainID, EVMNetwork } from "./networks"
+
+// Not sure the best place to put this in but it feels like it deserves its own file.
+export default class TallyWeb3Provider extends Web3Provider {
+  switchChain(network: EVMNetwork): Promise<unknown> {
+    return this.send("wallet_switchEthereumChain", [
+      {
+        chainId: toHexChainID(network.chainID),
+      },
+    ])
+  }
+}


### PR DESCRIPTION
Closes #1508 

Do not merge until #1483 makes it into main.

### To Test
- [ ] switching from ethereum to polygon and back still works.

Also - I'm not sure of the utility of the `switchChain` extension of the provider if we notify directly through main - would you mind commenting @Shadowfiend 