### PR TITLE
😵 Let me be clear: Adding sqlite3 as an explicit devDependency

### DIFF
--- a/background/package.json
+++ b/background/package.json
@@ -64,6 +64,7 @@
     "mockzilla": "^0.12.0",
     "mockzilla-webextension": "^0.13.0",
     "redux": "^4.1.1",
+    "sqlite3": "^5.0.8",
     "ts-node": "^10.4.0",
     "webext-redux": "^2.1.7"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11642,7 +11642,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sqlite3@^5.0.2:
+sqlite3@^5.0.2, sqlite3@^5.0.8:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-5.0.8.tgz#b4b7eab7156debec80866ef492e01165b4688272"
   integrity sha512-f2ACsbSyb2D1qFFcqIXPfFscLtPVOWJr5GmUzYxf4W+0qelu5MWrR+FAQE1d5IUArEltBrzSDxDORG8P/IkqyQ==


### PR DESCRIPTION
@redux-devtools depends on sqlite3 but when
installing as a dependency of that package it
wants to compile from source through node-gyp
which fails.

But if sqlite3 is declared as a standalone
devDependency then it installs without any issue.