### PR TITLE
Allow string chainId for EIP712TypedData

### DIFF
--- a/background/services/signing/index.ts
+++ b/background/services/signing/index.ts
@@ -195,12 +195,17 @@ export default class SigningService extends BaseService<Events> {
   }): Promise<string> {
     try {
       let signedData: string
+      const chainId =
+        typeof typedData.domain.chainId === "string"
+          ? // eslint-disable-next-line radix
+            parseInt(typedData.domain.chainId)
+          : typedData.domain.chainId
       if (
         typedData.domain.chainId !== undefined &&
         // Let parseInt infer radix by prefix; chainID can be hex or decimal,
         // though it should generally be hex.
         // eslint-disable-next-line radix
-        typedData.domain.chainId !== parseInt(account.network.chainID)
+        chainId !== parseInt(account.network.chainID)
       ) {
         throw new Error(
           "Attempting to sign typed data with mismatched chain IDs."


### PR DESCRIPTION
There is a need to allow typedData.domain.chainId to be a string.

"Why? Doesn't EIP-712 indicate this should be uint256?" you might ask. :smile: 

Yes, but certain programming languages have limitations that keep them from reaching anywhere near the max value:

```
> JSON.parse('{"chainId":9007199254740993}').chainId
9007199254740992
```

This also benefits us on the pawdnerships side. (e.g. it allows us to work on CowSwap)

For this PR I only made minimal changes to allow the functionality on dapps that send such values.

Would using bignumber or some other solution here be better? (in the long term avoiding parseInt for risk of incompatible values)