### PR TITLE
🪦 Remove `ESTIMATED_FEE_MULTIPLIERS_BY_TYPE`

### DIFF
--- a/background/constants/network-fees.ts
+++ b/background/constants/network-fees.ts
@@ -5,15 +5,6 @@ export const ESTIMATED_FEE_MULTIPLIERS: { [confidence: number]: bigint } = {
   0: 20n,
 }
 
-export const ESTIMATED_FEE_MULTIPLIERS_BY_TYPE: {
-  [feeType: string]: bigint
-} = {
-  regular: 11n,
-  express: 13n,
-  instant: 18n,
-  custom: 20n,
-}
-
 export const MAX_FEE_MULTIPLIER: { [confidence: number]: bigint } = {
   70: 13n,
   95: 15n,


### PR DESCRIPTION
`ESTIMATED_FEE_MULTIPLIERS_BY_TYPE` was previously used, essentially
arbitrarily, with the idea that estimated network fees should change depending
on the max fee selected. This is only partly true. The part of the max fee that
impacts the estimated network fee is only the max priority fee, since it's
completely used in almost all cases. So we removed the multiplier from the
network fee display, but left the constant here. This PR is just housekeeping
to remove the constant and a PR with some context.