### PR TITLE
Persist default account names across chains.

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -103,7 +103,6 @@ import {
   setVaultsAsStale,
 } from "./redux-slices/earn"
 import {
-  LedgerState,
   resetLedgerState,
   setDeviceConnectionStatus,
   setUsbDeviceCount,

--- a/background/redux-slices/accounts.ts
+++ b/background/redux-slices/accounts.ts
@@ -8,7 +8,7 @@ import {
   AssetDecimalAmount,
 } from "./utils/asset-utils"
 import { DomainName, HexString, URI } from "../types"
-import { normalizeEVMAddress, sameEVMAddress } from "../lib/utils"
+import { normalizeEVMAddress } from "../lib/utils"
 
 /**
  * The set of available UI account types. These may or may not map 1-to-1 to

--- a/background/redux-slices/accounts.ts
+++ b/background/redux-slices/accounts.ts
@@ -126,15 +126,20 @@ function newAccountData(
 }
 
 function getOrCreateAccountData(
-  data: AccountData | "loading",
+  accountsState: AccountState,
   account: HexString,
-  network: EVMNetwork,
-  existingAccountsCount: number
+  network: EVMNetwork
 ): AccountData {
-  if (data === "loading" || !data) {
+  const accountData = accountsState.accountsData.evm[network.chainID][account]
+
+  const existingAccountsCount = Object.keys(
+    accountsState.accountsData.evm[network.chainID]
+  ).filter((key) => key !== account).length
+
+  if (accountData === "loading" || !accountData) {
     return newAccountData(account, network, existingAccountsCount)
   }
-  return data
+  return accountData
 }
 
 // TODO Much of the combinedData bits should probably be done in a Reselect
@@ -282,12 +287,9 @@ const accountSlice = createSlice({
       const baseAccountData = getOrCreateAccountData(
         // TODO Figure out the best way to handle default name assignment
         // TODO across networks.
-        immerState.accountsData.evm[network.chainID][normalizedAddress],
+        immerState,
         normalizedAddress,
-        network,
-        Object.keys(immerState.accountsData.evm[network.chainID]).filter(
-          (key) => key !== normalizedAddress
-        ).length
+        network
       )
 
       immerState.accountsData.evm[network.chainID][normalizedAddress] = {
@@ -317,12 +319,9 @@ const accountSlice = createSlice({
       // TODO Figure out the best way to handle default name assignment
       // TODO across networks.
       const baseAccountData = getOrCreateAccountData(
-        immerState.accountsData.evm[network.chainID][normalizedAddress],
+        immerState,
         normalizedAddress,
-        network,
-        Object.keys(immerState.accountsData.evm[network.chainID]).filter(
-          (key) => key !== normalizedAddress
-        ).length
+        network
       )
 
       immerState.accountsData.evm[network.chainID][normalizedAddress] = {


### PR DESCRIPTION
Closes #1502.

Note that this is different from - and a precursor to #1501.

This PR persists the default name of an account when switching to a new network.

### To Test `(MULTI_NETWORK=true)`
- [ ] import a wallet
- [ ] Take note of the name of the account (e.g. Sport)
- [ ] Switch to another network - the name of the wallet and avatar should not have changed.

