### PR TITLE
Require users to use strong(er) passwords

### DIFF
--- a/ui/components/Keyring/KeyringSetPassword.tsx
+++ b/ui/components/Keyring/KeyringSetPassword.tsx
@@ -5,6 +5,7 @@ import {
   selectDefaultWallet,
 } from "@tallyho/tally-background/redux-slices/ui"
 import { useHistory } from "react-router-dom"
+import zxcvbn from "zxcvbn"
 import {
   useBackgroundDispatch,
   useAreKeyringsUnlocked,
@@ -35,12 +36,19 @@ export default function KeyringSetPassword(): ReactElement {
   }, [history, areKeyringsUnlocked])
 
   const validatePassword = (): boolean => {
-    if (password.length < 8) {
-      setPasswordErrorMessage("Must be at least 8 characters")
+    if (password.length < 12) {
+      // Less than 12 won't reliably give users a score of 3 or more.
+      setPasswordErrorMessage("Must be at least 12 characters")
       return false
     }
     if (password !== passwordConfirmation) {
       setPasswordErrorMessage("Passwords don’t match")
+      return false
+    }
+    const evaluation = zxcvbn(password)
+
+    if (evaluation.score < 3) {
+      setPasswordErrorMessage("Password too weak")
       return false
     }
     return true

--- a/ui/package.json
+++ b/ui/package.json
@@ -45,11 +45,13 @@
     "react-router-dom": "^5.3.0",
     "react-transition-group": "^4.4.2",
     "redux": "^4.1.0",
-    "webextension-polyfill": "^0.8.0"
+    "webextension-polyfill": "^0.8.0",
+    "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
     "@types/react-dom": "^17.0.9",
     "@types/react-transition-group": "^4.4.4",
+    "@types/zxcvbn": "^4.4.1",
     "webext-redux": "^2.1.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3593,6 +3593,11 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/zxcvbn@^4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@types/zxcvbn/-/zxcvbn-4.4.1.tgz#46e42cbdcee681b22181478feaf4af2bc4c1abd2"
+  integrity sha512-3NoqvZC2W5gAC5DZbTpCeJ251vGQmgcWIHQJGq2J240HY6ErQ9aWKkwfoKJlHLx+A83WPNTZ9+3cd2ILxbvr1w==
+
 "@typescript-eslint/eslint-plugin@^4.28.4":
   version "4.30.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.30.0.tgz#4a0c1ae96b953f4e67435e20248d812bfa55e4fb"
@@ -12949,3 +12954,8 @@ zip-stream@^4.1.0:
     archiver-utils "^2.1.0"
     compress-commons "^4.1.0"
     readable-stream "^3.6.0"
+
+zxcvbn@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/zxcvbn/-/zxcvbn-4.4.2.tgz#28ec17cf09743edcab056ddd8b1b06262cc73c30"
+  integrity sha1-KOwXzwl0PtyrBW3dixsGJizHPDA=


### PR DESCRIPTION
Closes #1329 

This PR requires users to have create a somewhat-strong password to use the extension.  

<img width="297" alt="image" src="https://user-images.githubusercontent.com/94649004/172711286-5f2e0ec1-46b0-4c08-b4d8-e69eec85000e.png">


How strong of a password? 
`3` strong of a password!  
How strong is 3?
Well - the tool we're using has the following scale:

```
 // 0 - too guessable: risky password. (guesses < 10^3)
 // 1 - very guessable: protection from throttled online attacks. (guesses < 10^6)
 // 2 - somewhat guessable: protection from unthrottled online attacks. (guesses < 10^8)
 // 3 - safely unguessable: moderate protection from offline slow-hash scenario. (guesses < 10^10)
 // 4 - very unguessable: strong protection from offline slow-hash scenario. (guesses >= 10^10)
```

While we all want to be good security-conscious citizens of the web I do think that requiring users to have complex passwords of more than 16 characters (anecdotally what it seems to take to score 4) might cause a bit of friction.  @mhluongo @mr-michael what do you think?