### PR TITLE
❤️‍🩹 Patch: Feature flag the removal of the swap fee chooser's row padding

### DIFF
--- a/ui/components/Swap/SwapTransactionSettingsChooser.tsx
+++ b/ui/components/Swap/SwapTransactionSettingsChooser.tsx
@@ -9,6 +9,7 @@ import {
 
 import React, { ReactElement, useState } from "react"
 import { SWAP_FEE } from "@tallyho/tally-background/redux-slices/0x-swap"
+import { CUSTOM_GAS_SELECT } from "@tallyho/tally-background/features"
 import SharedSlideUpMenu from "../Shared/SharedSlideUpMenu"
 import SharedButton from "../Shared/SharedButton"
 import { useBackgroundDispatch, useBackgroundSelector } from "../../hooks"
@@ -143,6 +144,7 @@ export default function SwapTransactionSettingsChooser({
             flex-grow: 2;
           }
           .row {
+            padding: ${CUSTOM_GAS_SELECT ? "unset" : "15px 0px"};
             display: flex;
             align-items: center;
           }


### PR DESCRIPTION
When adding the new gas picker, unfortunately, I removed padding even for the
older/published version, which resulted in some ugliness. This PR puts the
removal of the chooser's padding behind a feature flag. That said, this is only
bringing the older gas picker to its original iffy look. The overhauled version is
behind a feature flag.

<table>
  <tbody>
    <tr>
      <td>Before 😬</td>
      <td>After ✨</td>
    </tr>
    <tr>
      <td>
<img width="300" alt="before gas" src="https://user-images.githubusercontent.com/1918798/172877636-5104d508-c239-481e-adf4-3d7226056222.png">
</td>
      <td>
<img width="300" alt="after gas" src="https://user-images.githubusercontent.com/1918798/172877694-82434daf-68b8-4e92-b4b8-e89ac10696ea.png">
</td>
    </tr>
  </tbody>
</table>

🤘