### PR TITLE
Remove Unneeded Polygon Defaults

### DIFF
--- a/ui/hooks/validation-hooks.ts
+++ b/ui/hooks/validation-hooks.ts
@@ -1,6 +1,4 @@
 import { AddressOnNetwork } from "@tallyho/tally-background/accounts"
-import { POLYGON } from "@tallyho/tally-background/constants"
-import { SUPPORT_POLYGON } from "@tallyho/tally-background/features"
 import { isProbablyEVMAddress } from "@tallyho/tally-background/lib/utils"
 import { resolveNameOnNetwork } from "@tallyho/tally-background/redux-slices/accounts"
 import { selectCurrentAccount } from "@tallyho/tally-background/redux-slices/selectors"
@@ -147,11 +145,7 @@ export const useAddressOrNameValidation: AsyncValidationHook<
   const validatingValue = useRef<string | undefined>(undefined)
   const dispatch = useBackgroundDispatch()
 
-  let { network } = useBackgroundSelector(selectCurrentAccount)
-
-  if (SUPPORT_POLYGON) {
-    network = POLYGON
-  }
+  const { network } = useBackgroundSelector(selectCurrentAccount)
 
   const handleInputChange = async (newValue: string) => {
     setRawValue(newValue)

--- a/ui/pages/Onboarding/OnboardingViewOnlyWallet.tsx
+++ b/ui/pages/Onboarding/OnboardingViewOnlyWallet.tsx
@@ -5,8 +5,6 @@ import { setNewSelectedAccount } from "@tallyho/tally-background/redux-slices/ui
 import { HexString } from "@tallyho/tally-background/types"
 import { AddressOnNetwork } from "@tallyho/tally-background/accounts"
 import { selectCurrentAccount } from "@tallyho/tally-background/redux-slices/selectors"
-import { SUPPORT_POLYGON } from "@tallyho/tally-background/features"
-import { POLYGON } from "@tallyho/tally-background/constants"
 import { useBackgroundDispatch, useBackgroundSelector } from "../../hooks"
 import SharedButton from "../../components/Shared/SharedButton"
 import SharedBackButton from "../../components/Shared/SharedBackButton"
@@ -19,11 +17,7 @@ export default function OnboardingViewOnlyWallet(): ReactElement {
     AddressOnNetwork | undefined
   >(undefined)
 
-  let { network } = useBackgroundSelector(selectCurrentAccount)
-
-  if (SUPPORT_POLYGON) {
-    network = POLYGON
-  }
+  const { network } = useBackgroundSelector(selectCurrentAccount)
 
   const handleNewAddress = (
     value: { address: HexString; name?: string } | undefined


### PR DESCRIPTION
These defaults are cruft from a version of the extension that did not yet have a network switcher.

Now that the user can switch networks through the TopMenu there's no reason to have them.