### PR TITLE
🧑‍🤝‍🧑 My Best Friend - One active network per origin.

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -116,6 +116,7 @@ import {
   migrateReduxState,
   REDUX_STATE_VERSION,
 } from "./redux-slices/migrations"
+import { TALLY_INTERNAL_ORIGIN } from "./services/internal-ethereum-provider/constants"
 
 // This sanitizer runs on store and action data before serializing for remote
 // redux devtools. The goal is to end up with an object that is directly
@@ -1009,7 +1010,8 @@ export default class Main extends BaseService<never> {
     uiSliceEmitter.on("newSelectedNetwork", (network) => {
       this.internalEthereumProviderService.routeSafeRPCRequest(
         "wallet_switchEthereumChain",
-        [{ chainId: network.chainID }]
+        [{ chainId: network.chainID }],
+        TALLY_INTERNAL_ORIGIN
       )
       this.store.dispatch(clearCustomGas())
     })

--- a/background/services/internal-ethereum-provider/constants.ts
+++ b/background/services/internal-ethereum-provider/constants.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export const TALLY_INTERNAL_ORIGIN = "@tally-internal"

--- a/background/services/internal-ethereum-provider/db.ts
+++ b/background/services/internal-ethereum-provider/db.ts
@@ -1,10 +1,11 @@
 import Dexie from "dexie"
 import { TALLY_INTERNAL_ORIGIN } from "./constants"
 
-type ActiveChainId = {
+export type ActiveChainId = {
   chainId: string
   origin: string
 }
+
 export class InternalEthereumProviderDatabase extends Dexie {
   private activeChainId!: Dexie.Table<ActiveChainId, string>
 
@@ -22,12 +23,6 @@ export class InternalEthereumProviderDatabase extends Dexie {
     })
   }
 
-  private async getInternalActiveChain(): Promise<ActiveChainId> {
-    return this.activeChainId.get({
-      origin: TALLY_INTERNAL_ORIGIN,
-    }) as Promise<ActiveChainId>
-  }
-
   async setActiveChainIdForOrigin(
     chainId: string,
     origin: string
@@ -35,15 +30,10 @@ export class InternalEthereumProviderDatabase extends Dexie {
     return this.activeChainId.put({ origin, chainId })
   }
 
-  async getActiveChainIdForOrigin(origin: string): Promise<string> {
-    const activeChainId = await this.activeChainId.get({ origin })
-    if (!activeChainId) {
-      // If this is a new dapp or the dapp has not implemented wallet_switchEthereumChain
-      // use the default network.
-      const defaultChainId = (await this.getInternalActiveChain()).chainId
-      return defaultChainId
-    }
-    return activeChainId?.chainId
+  async getActiveChainIdForOrigin(
+    origin: string
+  ): Promise<ActiveChainId | undefined> {
+    return this.activeChainId.get({ origin })
   }
 }
 

--- a/background/services/internal-ethereum-provider/db.ts
+++ b/background/services/internal-ethereum-provider/db.ts
@@ -32,7 +32,6 @@ export class InternalEtheremProviderDatabase extends Dexie {
     chainId: string,
     origin: string
   ): Promise<string | undefined> {
-    await this.activeChainId.where({ origin }).delete()
     return this.activeChainId.put({ origin, chainId })
   }
 

--- a/background/services/internal-ethereum-provider/db.ts
+++ b/background/services/internal-ethereum-provider/db.ts
@@ -38,6 +38,8 @@ export class InternalEtheremProviderDatabase extends Dexie {
   async getActiveChainIdForOrigin(origin: string): Promise<string> {
     const activeChainId = await this.activeChainId.get({ origin })
     if (!activeChainId) {
+      // If this is a new dapp or the dapp has not implemented wallet_switchEthereumChain
+      // use the default network.
       const defaultChainId = (await this.getInternalActiveChain()).chainId
       return defaultChainId
     }

--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -146,7 +146,8 @@ export default class ProviderBridgeService extends BaseService<Events> {
       response.result = await this.routeContentScriptRPCRequest(
         originPermission,
         event.request.method,
-        event.request.params
+        event.request.params,
+        origin
       )
     } else if (event.request.method === "eth_requestAccounts") {
       // if it's external communication AND the dApp does not have permission BUT asks for it
@@ -176,7 +177,8 @@ export default class ProviderBridgeService extends BaseService<Events> {
         response.result = await this.routeContentScriptRPCRequest(
           persistedPermission,
           "eth_accounts",
-          event.request.params
+          event.request.params,
+          origin
         )
       } else {
         // if user does NOT agree, then reject
@@ -303,7 +305,8 @@ export default class ProviderBridgeService extends BaseService<Events> {
   async routeContentScriptRPCRequest(
     enablingPermission: PermissionRequest,
     method: string,
-    params: RPCRequest["params"]
+    params: RPCRequest["params"],
+    origin: string
   ): Promise<unknown> {
     try {
       switch (method) {
@@ -322,7 +325,7 @@ export default class ProviderBridgeService extends BaseService<Events> {
           return await this.routeSafeRequest(
             method,
             params,
-            enablingPermission.origin,
+            origin,
             showExtensionPopup(AllowedQueryParamPage.signData)
           )
         case "eth_sign":
@@ -331,7 +334,7 @@ export default class ProviderBridgeService extends BaseService<Events> {
           return await this.routeSafeRequest(
             method,
             params,
-            enablingPermission.origin,
+            origin,
             showExtensionPopup(AllowedQueryParamPage.personalSignData)
           )
         case "personal_sign":
@@ -340,7 +343,7 @@ export default class ProviderBridgeService extends BaseService<Events> {
           return await this.routeSafeRequest(
             method,
             params,
-            enablingPermission.origin,
+            origin,
             showExtensionPopup(AllowedQueryParamPage.personalSignData)
           )
         case "eth_signTransaction":
@@ -353,7 +356,7 @@ export default class ProviderBridgeService extends BaseService<Events> {
           return await this.routeSafeRequest(
             method,
             params,
-            enablingPermission.origin,
+            origin,
             showExtensionPopup(AllowedQueryParamPage.signTransaction)
           )
 
@@ -361,7 +364,7 @@ export default class ProviderBridgeService extends BaseService<Events> {
           return await this.internalEthereumProviderService.routeSafeRPCRequest(
             method,
             params,
-            enablingPermission.origin
+            origin
           )
         }
       }

--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -285,10 +285,11 @@ export default class ProviderBridgeService extends BaseService<Events> {
   async routeSafeRequest(
     method: string,
     params: unknown[],
+    origin: string,
     popupPromise: Promise<browser.Windows.Window>
   ): Promise<unknown> {
     const response = await this.internalEthereumProviderService
-      .routeSafeRPCRequest(method, params)
+      .routeSafeRPCRequest(method, params, origin)
       .finally(async () => {
         // Close the popup once we're done submitting.
         const popup = await popupPromise
@@ -321,6 +322,7 @@ export default class ProviderBridgeService extends BaseService<Events> {
           return await this.routeSafeRequest(
             method,
             params,
+            enablingPermission.origin,
             showExtensionPopup(AllowedQueryParamPage.signData)
           )
         case "eth_sign":
@@ -329,6 +331,7 @@ export default class ProviderBridgeService extends BaseService<Events> {
           return await this.routeSafeRequest(
             method,
             params,
+            enablingPermission.origin,
             showExtensionPopup(AllowedQueryParamPage.personalSignData)
           )
         case "personal_sign":
@@ -337,6 +340,7 @@ export default class ProviderBridgeService extends BaseService<Events> {
           return await this.routeSafeRequest(
             method,
             params,
+            enablingPermission.origin,
             showExtensionPopup(AllowedQueryParamPage.personalSignData)
           )
         case "eth_signTransaction":
@@ -349,13 +353,15 @@ export default class ProviderBridgeService extends BaseService<Events> {
           return await this.routeSafeRequest(
             method,
             params,
+            enablingPermission.origin,
             showExtensionPopup(AllowedQueryParamPage.signTransaction)
           )
 
         default: {
           return await this.internalEthereumProviderService.routeSafeRPCRequest(
             method,
-            params
+            params,
+            enablingPermission.origin
           )
         }
       }


### PR DESCRIPTION
This PR adds functionality to support 1 active chain per origin - allowing for a wonderful UX for people wanting to use mlutiple dapps on different chains at once.

Some key parts:
 - a given origin can only have 1 active chain (no chain-per-tab _yet_)
 - we have a special origin for our internal dapp
 
 Outstanding question - is this in-scope for Polygon launch?