### PR TITLE
🧹 Add linting error for (and fix) unused imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -92,6 +92,8 @@ module.exports = {
         ],
       },
     ],
+    "@typescript-eslint/no-unused-vars": "error",
+    "no-unused-vars": "off",
   },
   ignorePatterns: [
     "dist/",

--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -2,10 +2,9 @@ import { createSlice, createSelector } from "@reduxjs/toolkit"
 import Emittery from "emittery"
 import { AddressOnNetwork } from "../accounts"
 import { ETHEREUM } from "../constants"
-import { EVMNetwork, toHexChainID } from "../networks"
+import { EVMNetwork } from "../networks"
 import { AccountState, addAddressNetwork } from "./accounts"
 import { createBackgroundAsyncThunk } from "./utils"
-import { getProvider } from "./utils/contract-utils"
 
 const defaultSettings = {
   hideDust: false,

--- a/ui/components/Earn/Clock.tsx
+++ b/ui/components/Earn/Clock.tsx
@@ -1,11 +1,13 @@
 import React, { ReactElement } from "react"
 
 // TODO: get numbers and labels from timeLeft
-export default function Clock({
-  timeLeft,
-}: {
-  timeLeft?: number
-}): ReactElement {
+
+// {
+//   timeLeft,
+// }: {
+//   timeLeft?: number
+// }
+export default function Clock(): ReactElement {
   return (
     <div className="clock">
       <div className="clock_segment">

--- a/ui/components/NetworkFees/NetworkSettingsSelect.tsx
+++ b/ui/components/NetworkFees/NetworkSettingsSelect.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement, useCallback, useEffect, useState } from "react"
 import { BlockEstimate } from "@tallyho/tally-background/networks"
-import { selectLastGasEstimatesRefreshTime } from "@tallyho/tally-background/redux-slices/selectors/transactionConstructionSelectors"
 import {
   ESTIMATED_FEE_MULTIPLIERS,
   ESTIMATED_SPEED_IN_READABLE_FORMAT_RELATIVE_TO_CONFIDENCE_LEVEL,
@@ -14,10 +13,7 @@ import {
   GasOption,
 } from "@tallyho/tally-background/redux-slices/transaction-construction"
 
-import {
-  selectCurrentNetwork,
-  selectMainCurrencyPricePoint,
-} from "@tallyho/tally-background/redux-slices/selectors"
+import { selectMainCurrencyPricePoint } from "@tallyho/tally-background/redux-slices/selectors"
 import { weiToGwei } from "@tallyho/tally-background/lib/utils"
 import { ETH } from "@tallyho/tally-background/constants"
 import { PricePoint } from "@tallyho/tally-background/assets"

--- a/ui/components/NetworkFees/NetworkSettingsSelect.tsx
+++ b/ui/components/NetworkFees/NetworkSettingsSelect.tsx
@@ -83,34 +83,6 @@ const gasOptionFromEstimate = (
   }
 }
 
-function EstimateRefreshCountdownDivider() {
-  const [timeRemaining, setTimeRemaining] = useState(0)
-  const gasTime = useBackgroundSelector(selectLastGasEstimatesRefreshTime)
-
-  const getSecondsTillGasUpdate = useCallback(() => {
-    const now = Date.now()
-    setTimeRemaining(Number((120 - (now - gasTime) / 1000).toFixed()))
-  }, [gasTime])
-
-  useEffect(() => {
-    getSecondsTillGasUpdate()
-    const interval = setTimeout(getSecondsTillGasUpdate, 1000)
-    return () => {
-      clearTimeout(interval)
-    }
-  })
-
-  return (
-    <div className="divider">
-      <div className="divider-background" />
-      <div
-        className="divider-cover"
-        style={{ left: -384 + (384 - timeRemaining * (384 / 120)) }}
-      />
-    </div>
-  )
-}
-
 export default function NetworkSettingsSelect({
   // FIXME Map this to GasOption[] in a selector.
   estimatedFeesPerGas,
@@ -120,7 +92,6 @@ export default function NetworkSettingsSelect({
   const dispatch = useBackgroundDispatch()
 
   const [gasOptions, setGasOptions] = useState<GasOption[]>([])
-  const selectedNetwork = useBackgroundSelector(selectCurrentNetwork)
   const customGas = useBackgroundSelector((state) => {
     return state.transactionConstruction.customFeesPerGas
   })

--- a/ui/components/NetworkFees/NetworkSettingsSelectDeprecated.tsx
+++ b/ui/components/NetworkFees/NetworkSettingsSelectDeprecated.tsx
@@ -38,7 +38,7 @@ const gasOptionFromEstimate = (
   mainCurrencyPricePoint: PricePoint | undefined,
   baseFeePerGas: bigint,
   gasLimit: bigint | undefined,
-  { confidence, price, maxFeePerGas, maxPriorityFeePerGas }: BlockEstimate
+  { confidence, maxFeePerGas, maxPriorityFeePerGas }: BlockEstimate
 ): GasOption => {
   const feeOptionData: {
     [confidence: number]: NetworkFeeTypeChosen

--- a/ui/components/NetworkFees/NetworkSettingsSelectOptionButtons.tsx
+++ b/ui/components/NetworkFees/NetworkSettingsSelectOptionButtons.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, useState } from "react"
 import { GasOption } from "@tallyho/tally-background/redux-slices/transaction-construction"
 import { selectCurrentNetwork } from "@tallyho/tally-background/redux-slices/selectors"
 import capitalize from "../../utils/capitalize"
-import SharedInput, { SharedTypedInput } from "../Shared/SharedInput"
+import SharedInput from "../Shared/SharedInput"
 import { useBackgroundSelector } from "../../hooks"
 
 function gweiFloatToWei(float: number): bigint {


### PR DESCRIPTION
The impetus here is me not removing a few unused imports lately 🙈. And the
title of the PR is slightly misleading because this is implemented by using the
`@typescript-eslint/no-unused-vars` rule. So **it covers all unused vars, not
just imports.**