### PR TITLE
Explicitly check chain id and if actually allowed when checking for permissions.

### DIFF
--- a/background/services/provider-bridge/authorization.ts
+++ b/background/services/provider-bridge/authorization.ts
@@ -5,13 +5,17 @@ import {
   PermissionRequest,
 } from "@tallyho/provider-bridge-shared"
 import { sameEVMAddress } from "../../lib/utils"
+import { toHexChainID } from "../../networks"
 import { HexString } from "../../types"
 
 export function checkPermissionSignTypedData(
   walletAddress: HexString,
   enablingPermission: PermissionRequest
 ): void {
-  if (!sameEVMAddress(walletAddress, enablingPermission.accountAddress)) {
+  if (
+    enablingPermission.state !== "allow" ||
+    !sameEVMAddress(walletAddress, enablingPermission.accountAddress)
+  ) {
     throw new EIP1193Error(EIP1193_ERROR_CODES.unauthorized)
   }
 }
@@ -20,7 +24,10 @@ export function checkPermissionSign(
   walletAddress: HexString,
   enablingPermission: PermissionRequest
 ): void {
-  if (!sameEVMAddress(walletAddress, enablingPermission.accountAddress)) {
+  if (
+    enablingPermission.state !== "allow" ||
+    !sameEVMAddress(walletAddress, enablingPermission.accountAddress)
+  ) {
     throw new EIP1193Error(EIP1193_ERROR_CODES.unauthorized)
   }
 }
@@ -29,7 +36,16 @@ export function checkPermissionSignTransaction(
   transactionRequest: EthersTransactionRequest,
   enablingPermission: PermissionRequest
 ): void {
+  if (typeof transactionRequest.chainId !== "undefined") {
+    if (
+      toHexChainID(transactionRequest.chainId) !==
+      toHexChainID(enablingPermission.chainID)
+    ) {
+      throw new EIP1193Error(EIP1193_ERROR_CODES.unauthorized)
+    }
+  }
   if (
+    enablingPermission.state !== "allow" ||
     !sameEVMAddress(transactionRequest.from, enablingPermission.accountAddress)
   ) {
     throw new EIP1193Error(EIP1193_ERROR_CODES.unauthorized)


### PR DESCRIPTION
### To Test

No great way to test the denial now (because we auth dapps for both polygon & eth  for now) but being able to sign a transaction (for example a quickswap swap) should be a good enough test that this works.