### PR TITLE
:fire: Keep Feeling the Yearn: Update the Yearn token list URL

### DIFF
--- a/background/services/preferences/defaults.ts
+++ b/background/services/preferences/defaults.ts
@@ -12,7 +12,7 @@ const defaultPreferences: Preferences = {
         )
       ).href, // the Tally community-curated list
       "https://gateway.ipfs.io/ipns/tokens.uniswap.org", // the Uniswap default list
-      "https://yearn.science/static/tokenlist.json", // the Yearn list
+      "https://meta.yearn.finance/api/tokens/list", // the Yearn list
       "https://messari.io/tokenlist/messari-verified", // Messari-verified projects
       "https://wrapped.tokensoft.eth.link", // Wrapped tokens
       "https://tokenlist.aave.eth.link", // Aave-listed tokens and interest-bearing assets


### PR DESCRIPTION
The old URL is no longer maintained.

Refs https://github.com/Uniswap/tokenlists-org/pull/1422

To test
=====

- [ ] Load a fresh extension install
- [ ] Confirm there aren't any background script errors related to the Yearn token list 
- [ ] Confirm Yearn vault tokens show up on the Swap page 