### PR TITLE
🫥 Fix linter warnings

### DIFF
--- a/src/window-provider.ts
+++ b/src/window-provider.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import {
   WindowListener,
   WindowRequestEvent,
@@ -88,12 +87,23 @@ if (!window.walletRouter) {
 
 Object.defineProperty(window, "ethereum", {
   get() {
-    return new Proxy(window.walletRouter!.currentProvider, {
+    if (!window.walletRouter) {
+      throw new Error(
+        "window.walletRouter is expected to be set to change the injected provider on window.ethereum."
+      )
+    }
+
+    return new Proxy(window.walletRouter.currentProvider, {
       get(target, prop, receiver) {
+        if (!window.walletRouter) {
+          throw new Error(
+            "window.walletRouter is expected to be set to change the injected provider on window.ethereum."
+          )
+        }
+
         if (
-          window.walletRouter &&
-          !(prop in window.walletRouter!.currentProvider) &&
-          prop in window.walletRouter!
+          !(prop in window.walletRouter.currentProvider) &&
+          prop in window.walletRouter
         ) {
           // let's publish the api of `window.walletRoute` also on `window.ethereum` for better discoverability
 

--- a/src/window-provider.ts
+++ b/src/window-provider.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import {
   WindowListener,
   WindowRequestEvent,

--- a/src/window-provider.ts
+++ b/src/window-provider.ts
@@ -95,13 +95,8 @@ Object.defineProperty(window, "ethereum", {
 
     return new Proxy(window.walletRouter.currentProvider, {
       get(target, prop, receiver) {
-        if (!window.walletRouter) {
-          throw new Error(
-            "window.walletRouter is expected to be set to change the injected provider on window.ethereum."
-          )
-        }
-
         if (
+          window.walletRouter &&
           !(prop in window.walletRouter.currentProvider) &&
           prop in window.walletRouter
         ) {

--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -94,8 +94,12 @@ export default class TallyWindowProvider extends EventEmitter {
           if (
             !window.walletRouter?.hasProvider(this.providerInfo.checkIdentity)
           ) {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            window.walletRouter?.addProvider(window.tally!)
+            if (!window.tally) {
+              throw new Error(
+                "Expected window.tally to be set but it is not. Tally Ho provider configured incorrectly."
+              )
+            }
+            window.walletRouter?.addProvider(window.tally)
           }
 
           window.walletRouter?.setCurrentProvider(

--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -94,6 +94,7 @@ export default class TallyWindowProvider extends EventEmitter {
           if (
             !window.walletRouter?.hasProvider(this.providerInfo.checkIdentity)
           ) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             window.walletRouter?.addProvider(window.tally!)
           }
 


### PR DESCRIPTION
Disable the linter `no-non-null-assertion` rule where it is needed.