### PR TITLE
🧚 Minor transaction and gas improvements

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -69,7 +69,7 @@ import {
   estimatedFeesPerGas,
   emitter as transactionConstructionSliceEmitter,
   transactionRequest,
-  updateTransactionOptions,
+  updateTransactionData,
   clearTransactionState,
   TransactionConstructionStatus,
   rejectTransactionSignature,
@@ -557,45 +557,55 @@ export default class Main extends BaseService<never> {
       )
     })
 
-    transactionConstructionSliceEmitter.on("updateOptions", async (options) => {
-      const { network } = options
+    transactionConstructionSliceEmitter.on(
+      "updateTransaction",
+      async (options) => {
+        const { network } = options
 
-      const {
-        values: { maxFeePerGas, maxPriorityFeePerGas },
-      } = selectDefaultNetworkFeeSettings(this.store.getState())
+        const {
+          values: { maxFeePerGas, maxPriorityFeePerGas },
+        } = selectDefaultNetworkFeeSettings(this.store.getState())
 
-      const { transactionRequest: populatedRequest, gasEstimationError } =
-        await this.chainService.populatePartialEVMTransactionRequest(network, {
-          ...options,
-          maxFeePerGas: options.maxFeePerGas ?? maxFeePerGas,
-          maxPriorityFeePerGas:
-            options.maxPriorityFeePerGas ?? maxPriorityFeePerGas,
-        })
+        const { transactionRequest: populatedRequest, gasEstimationError } =
+          await this.chainService.populatePartialEVMTransactionRequest(
+            network,
+            {
+              ...options,
+              maxFeePerGas: options.maxFeePerGas ?? maxFeePerGas,
+              maxPriorityFeePerGas:
+                options.maxPriorityFeePerGas ?? maxPriorityFeePerGas,
+            }
+          )
 
-      const { annotation } =
-        await this.enrichmentService.enrichTransactionSignature(
-          network,
-          populatedRequest,
-          2 /* TODO desiredDecimals should be configurable */
-        )
-      const enrichedPopulatedRequest = { ...populatedRequest, annotation }
+        const { annotation } =
+          await this.enrichmentService.enrichTransactionSignature(
+            network,
+            populatedRequest,
+            2 /* TODO desiredDecimals should be configurable */
+          )
 
-      if (typeof gasEstimationError === "undefined") {
-        this.store.dispatch(
-          transactionRequest({
-            transactionRequest: enrichedPopulatedRequest,
-            transactionLikelyFails: false,
-          })
-        )
-      } else {
-        this.store.dispatch(
-          transactionRequest({
-            transactionRequest: enrichedPopulatedRequest,
-            transactionLikelyFails: true,
-          })
-        )
+        const enrichedPopulatedRequest = {
+          ...populatedRequest,
+          annotation,
+        }
+
+        if (typeof gasEstimationError === "undefined") {
+          this.store.dispatch(
+            transactionRequest({
+              transactionRequest: enrichedPopulatedRequest,
+              transactionLikelyFails: false,
+            })
+          )
+        } else {
+          this.store.dispatch(
+            transactionRequest({
+              transactionRequest: enrichedPopulatedRequest,
+              transactionLikelyFails: true,
+            })
+          )
+        }
       }
-    })
+    )
 
     transactionConstructionSliceEmitter.on(
       "broadcastSignedTransaction",
@@ -858,7 +868,7 @@ export default class Main extends BaseService<never> {
         this.store.dispatch(
           clearTransactionState(TransactionConstructionStatus.Pending)
         )
-        this.store.dispatch(updateTransactionOptions(payload))
+        this.store.dispatch(updateTransactionData(payload))
 
         const clear = () => {
           // Mutual dependency to handleAndClear.

--- a/background/redux-slices/selectors/transactionConstructionSelectors.ts
+++ b/background/redux-slices/selectors/transactionConstructionSelectors.ts
@@ -1,5 +1,6 @@
 import { createSelector } from "@reduxjs/toolkit"
 import { selectCurrentNetwork } from "."
+import { NetworksState } from "../networks"
 import {
   TransactionConstruction,
   NetworkFeeSettings,
@@ -8,10 +9,11 @@ import {
 export const selectDefaultNetworkFeeSettings = createSelector(
   (state: { transactionConstruction: TransactionConstruction }) =>
     state.transactionConstruction,
+  (state: { networks: NetworksState }) => state.networks,
   selectCurrentNetwork,
-  (transactionConstruction, network): NetworkFeeSettings => {
+  (transactionConstruction, networks, currentNetwork): NetworkFeeSettings => {
     const selectedFeesPerGas =
-      transactionConstruction.estimatedFeesPerGas?.[network.chainID]?.[
+      transactionConstruction.estimatedFeesPerGas?.[currentNetwork.chainID]?.[
         transactionConstruction.feeTypeSelected
       ]
     return {
@@ -21,6 +23,8 @@ export const selectDefaultNetworkFeeSettings = createSelector(
       values: {
         maxFeePerGas: selectedFeesPerGas?.maxFeePerGas ?? 0n,
         maxPriorityFeePerGas: selectedFeesPerGas?.maxPriorityFeePerGas ?? 0n,
+        baseFeePerGas:
+          networks.evm[currentNetwork.chainID].baseFeePerGas ?? undefined, // @TODO: Support multi-network
       },
     }
   }

--- a/background/redux-slices/transaction-construction.ts
+++ b/background/redux-slices/transaction-construction.ts
@@ -1,4 +1,4 @@
-import { createSlice, createSelector } from "@reduxjs/toolkit"
+import { createSlice } from "@reduxjs/toolkit"
 import Emittery from "emittery"
 import { FORK } from "../constants"
 import {
@@ -16,7 +16,6 @@ import {
   EVMNetwork,
   SignedEVMTransaction,
 } from "../networks"
-import { NetworksState } from "./networks"
 import {
   EnrichedEIP1559TransactionRequest,
   EnrichedEVMTransactionSignatureRequest,
@@ -312,37 +311,4 @@ export const rejectTransactionSignature = createBackgroundAsyncThunk(
       )
     )
   }
-)
-
-export const selectDefaultNetworkFeeSettings = createSelector(
-  ({
-    transactionConstruction,
-    networks,
-  }: {
-    transactionConstruction: TransactionConstruction
-    networks: NetworksState
-  }) => ({
-    feeType: transactionConstruction.feeTypeSelected,
-    selectedFeesPerGas:
-      transactionConstruction.estimatedFeesPerGas?.[
-        transactionConstruction.feeTypeSelected
-      ],
-    suggestedGasLimit: transactionConstruction.transactionRequest?.gasLimit,
-    baseFeePerGas: networks.evm[1].baseFeePerGas, // @TODO: Support multi-network
-  }),
-  ({
-    feeType,
-    selectedFeesPerGas,
-    suggestedGasLimit,
-    baseFeePerGas,
-  }): NetworkFeeSettings => ({
-    feeType,
-    gasLimit: undefined,
-    suggestedGasLimit,
-    values: {
-      maxFeePerGas: selectedFeesPerGas?.maxFeePerGas ?? 0n,
-      maxPriorityFeePerGas: selectedFeesPerGas?.maxPriorityFeePerGas ?? 0n,
-      baseFeePerGas: baseFeePerGas ?? undefined,
-    },
-  })
 )

--- a/background/redux-slices/transaction-construction.ts
+++ b/background/redux-slices/transaction-construction.ts
@@ -90,7 +90,7 @@ export interface SignatureRequest {
 }
 
 export type Events = {
-  updateOptions: EnrichedEVMTransactionSignatureRequest
+  updateTransaction: EnrichedEVMTransactionSignatureRequest
   requestSignature: SignatureRequest
   signatureRejected: never
   broadcastSignedTransaction: SignedEVMTransaction
@@ -134,10 +134,10 @@ const makeBlockEstimate = (
 }
 
 // Async thunk to pass transaction options from the store to the background via an event
-export const updateTransactionOptions = createBackgroundAsyncThunk(
-  "transaction-construction/update-options",
+export const updateTransactionData = createBackgroundAsyncThunk(
+  "transaction-construction/update-transaction",
   async (options: EnrichedEVMTransactionSignatureRequest) => {
-    await emitter.emit("updateOptions", options)
+    await emitter.emit("updateTransaction", options)
   }
 )
 
@@ -257,7 +257,7 @@ const transactionSlice = createSlice({
     },
   },
   extraReducers: (builder) => {
-    builder.addCase(updateTransactionOptions.pending, (immerState) => {
+    builder.addCase(updateTransactionData.pending, (immerState) => {
       immerState.status = TransactionConstructionStatus.Pending
       immerState.signedTransaction = undefined
     })

--- a/ui/components/NetworkFees/FeeSettingsText.tsx
+++ b/ui/components/NetworkFees/FeeSettingsText.tsx
@@ -62,6 +62,7 @@ export default function FeeSettingsText({
   const mainCurrencyPricePoint = useBackgroundSelector(
     selectMainCurrencyPricePoint
   )
+  const gasLimit = networkSettings.gasLimit ?? networkSettings.suggestedGasLimit
 
   const estimatedGweiAmount =
     typeof estimatedFeesPerGas !== "undefined" &&
@@ -82,7 +83,7 @@ export default function FeeSettingsText({
 
   return (
     <div>
-      {!networkSettings.gasLimit && CUSTOM_GAS_SELECT ? (
+      {!gasLimit && CUSTOM_GAS_SELECT ? (
         <>TBD</>
       ) : (
         <>

--- a/ui/components/SignTransaction/SignTransactionDetailPanel.tsx
+++ b/ui/components/SignTransaction/SignTransactionDetailPanel.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useState } from "react"
 import {
   NetworkFeeSettings,
-  updateTransactionOptions,
+  updateTransactionData,
 } from "@tallyho/tally-background/redux-slices/transaction-construction"
 import {
   selectEstimatedFeesPerGas,
@@ -25,7 +25,7 @@ export default function SignTransactionDetailPanel(): ReactElement {
 
   const networkSettingsSaved = async (networkSetting: NetworkFeeSettings) => {
     dispatch(
-      updateTransactionOptions({
+      updateTransactionData({
         ...transactionDetails,
         gasLimit: networkSetting.gasLimit ?? transactionDetails.gasLimit,
       })

--- a/ui/components/SignTransaction/SignTransactionSpendAssetInfoProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionSpendAssetInfoProvider.tsx
@@ -8,7 +8,7 @@ import {
   parseToFixedPointNumber,
 } from "@tallyho/tally-background/lib/fixed-point"
 import { isMaxUint256 } from "@tallyho/tally-background/lib/utils"
-import { updateTransactionOptions } from "@tallyho/tally-background/redux-slices/transaction-construction"
+import { updateTransactionData } from "@tallyho/tally-background/redux-slices/transaction-construction"
 import { AssetApproval } from "@tallyho/tally-background/services/enrichment"
 import { ethers } from "ethers"
 import { hexlify } from "ethers/lib/utils"
@@ -99,7 +99,7 @@ export default function SignTransactionSpendAssetInfoProvider({
       [spenderAddress, hexlify(bigintAmount)]
     )
     dispatch(
-      updateTransactionOptions({
+      updateTransactionData({
         ...transactionDetails,
         input: updatedInput,
       })


### PR DESCRIPTION
### What has changed

- renamed `updateOptions` to `updateTransaction` as we are not only updating transaction's options (what options? network/gas options?) but this function is updating a whole set of transaction data
- removed duplicated gas settings redux selector - selector `selectDefaultNetworkFeeSettings` has been duplicated but only one function has been used. Removed unused one and moved the missing `baseFeePerGas` field to the other selector
- fixed showing gas price instead of `TBD` - If we know gas limit by suggested gas limit or selected by a user then we
should show the estimated gas value in the network settings selector button