### PR TITLE
Grant permission to polygon apps even if polygon support is not enabled.

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -108,7 +108,7 @@ import {
   setDeviceConnectionStatus,
   setUsbDeviceCount,
 } from "./redux-slices/ledger"
-import { ETHEREUM } from "./constants"
+import { ETHEREUM, POLYGON } from "./constants"
 import { clearApprovalInProgress, clearSwapQuote } from "./redux-slices/0x-swap"
 import { SignatureResponse, TXSignatureResponse } from "./services/signing"
 import { ReferrerStats } from "./services/doggo/db"
@@ -1075,7 +1075,7 @@ export default class Main extends BaseService<never> {
 
     providerBridgeSliceEmitter.on("grantPermission", async (permission) => {
       await Promise.all(
-        this.chainService.supportedNetworks.map(async (network) => {
+        [ETHEREUM, POLYGON].map(async (network) => {
           await this.providerBridgeService.grantPermission({
             ...permission,
             chainID: network.chainID,


### PR DESCRIPTION
Since we granted permission to polygon applications as part of [our latest provider-bridge db migration](https://github.com/tallycash/extension/pull/1580/commits/86639b0c1839d5fa735660456cc25f70d3ca9642) even if polygon support is not enabled - we should be consistent and grant permission to polygon applications when a user grants permission to a dapp even if polygon support is not enabled.