### PR TITLE
🦑 Squid Game: Improvements to swap state handling

### DIFF
--- a/ui/hooks/index.ts
+++ b/ui/hooks/index.ts
@@ -32,3 +32,17 @@ export function useRunOnFirstRender(func: () => void): void {
     func()
   }
 }
+
+export function useSkipFirstRenderEffect(
+  func: () => void,
+  deps: unknown[] = []
+): void {
+  const didMount = useRef(false)
+
+  useEffect(() => {
+    if (didMount.current) func()
+    else didMount.current = true
+    // We are passing in the dependencies when we initialize this hook, so we can not know what it will be exactly and it's ok.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps)
+}

--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -129,21 +129,24 @@ export default function Swap(): ReactElement {
     assets: { sellAsset: locationAsset },
   }
 
-  const [sellAsset, setSellAsset] = useState<
-    FungibleAsset | SmartContractFungibleAsset | undefined
-  >(undefined)
-  const [buyAsset, setBuyAsset] = useState<
-    FungibleAsset | SmartContractFungibleAsset | undefined
-  >(undefined)
-  const [sellAmount, setSellAmount] = useState("")
-  const [buyAmount, setBuyAmount] = useState("")
+  const [sellAsset, setSellAsset] = useState(savedSellAsset)
+  const [buyAsset, setBuyAsset] = useState(savedBuyAsset)
+  const [sellAmount, setSellAmount] = useState(
+    typeof savedSwapAmount !== "undefined" && "sellAmount" in savedSwapAmount
+      ? savedSwapAmount.sellAmount
+      : ""
+  )
+  const [buyAmount, setBuyAmount] = useState(
+    typeof savedSwapAmount !== "undefined" && "buyAmount" in savedSwapAmount
+      ? savedSwapAmount.buyAmount
+      : ""
+  )
   const [needsApproval, setNeedsApproval] = useState(false)
   const [approvalTarget, setApprovalTarget] = useState<string | undefined>(
     undefined
   )
 
   useEffect(() => {
-    dispatch(clearSwapQuote())
     setSellAsset(undefined)
     setBuyAsset(undefined)
     setSellAmount("")

--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -408,20 +408,26 @@ export default function Swap(): ReactElement {
   const updateSellAsset = useCallback(
     (asset: SmartContractFungibleAsset | FungibleAsset) => {
       setSellAsset(asset)
-      // Updating the sell asset quotes the new sell asset against the existing
-      // buy amount.
-      updateSwapData("buy", buyAmount, asset)
+
+      if (buyAsset && buyAmount !== "") {
+        // Updating the sell asset quotes the new sell asset against the existing
+        // buy amount.
+        updateSwapData("buy", buyAmount, asset)
+      }
     },
-    [buyAmount, updateSwapData]
+    [buyAmount, buyAsset, updateSwapData]
   )
   const updateBuyAsset = useCallback(
     (asset: SmartContractFungibleAsset | FungibleAsset) => {
       setBuyAsset(asset)
-      // Updating the buy asset quotes the new buy asset against the existing
-      // sell amount.
-      updateSwapData("sell", sellAmount, asset)
+
+      if (sellAsset && sellAmount !== "") {
+        // Updating the buy asset quotes the new buy asset against the existing
+        // sell amount.
+        updateSwapData("sell", sellAmount, asset)
+      }
     },
-    [sellAmount, updateSwapData]
+    [sellAmount, sellAsset, updateSwapData]
   )
 
   const flipSwap = useCallback(() => {

--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -129,24 +129,21 @@ export default function Swap(): ReactElement {
     assets: { sellAsset: locationAsset },
   }
 
-  const [sellAsset, setSellAsset] = useState(savedSellAsset)
-  const [buyAsset, setBuyAsset] = useState(savedBuyAsset)
-  const [sellAmount, setSellAmount] = useState(
-    typeof savedSwapAmount !== "undefined" && "sellAmount" in savedSwapAmount
-      ? savedSwapAmount.sellAmount
-      : ""
-  )
-  const [buyAmount, setBuyAmount] = useState(
-    typeof savedSwapAmount !== "undefined" && "buyAmount" in savedSwapAmount
-      ? savedSwapAmount.buyAmount
-      : ""
-  )
+  const [sellAsset, setSellAsset] = useState<
+    FungibleAsset | SmartContractFungibleAsset | undefined
+  >(undefined)
+  const [buyAsset, setBuyAsset] = useState<
+    FungibleAsset | SmartContractFungibleAsset | undefined
+  >(undefined)
+  const [sellAmount, setSellAmount] = useState("")
+  const [buyAmount, setBuyAmount] = useState("")
   const [needsApproval, setNeedsApproval] = useState(false)
   const [approvalTarget, setApprovalTarget] = useState<string | undefined>(
     undefined
   )
 
   useEffect(() => {
+    dispatch(clearSwapQuote())
     setSellAsset(undefined)
     setBuyAsset(undefined)
     setSellAmount("")

--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -151,7 +151,7 @@ export default function Swap(): ReactElement {
     setBuyAsset(undefined)
     setSellAmount("")
     setBuyAmount("")
-  }, [currentNetwork])
+  }, [currentNetwork.chainID, dispatch])
 
   const buyAssets = useBackgroundSelector((state) => {
     // Some type massaging needed to remind TypeScript how these types fit

--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -17,6 +17,7 @@ import {
 import {
   HIDE_SWAP_REWARDS,
   HIDE_TOKEN_FEATURES,
+  SUPPORT_POLYGON,
 } from "@tallyho/tally-background/features"
 import {
   selectCurrentAccountBalances,
@@ -44,7 +45,11 @@ import SharedSlideUpMenu from "../components/Shared/SharedSlideUpMenu"
 import SwapQuote from "../components/Swap/SwapQuote"
 import SharedActivityHeader from "../components/Shared/SharedActivityHeader"
 import SwapTransactionSettingsChooser from "../components/Swap/SwapTransactionSettingsChooser"
-import { useBackgroundDispatch, useBackgroundSelector } from "../hooks"
+import {
+  useBackgroundDispatch,
+  useBackgroundSelector,
+  useSkipFirstRenderEffect,
+} from "../hooks"
 import SwapRewardsCard from "../components/Swap/SwapRewardsCard"
 import SharedIcon from "../components/Shared/SharedIcon"
 import SharedBanner from "../components/Shared/SharedBanner"
@@ -146,11 +151,13 @@ export default function Swap(): ReactElement {
     undefined
   )
 
-  useEffect(() => {
-    setSellAsset(undefined)
-    setBuyAsset(undefined)
-    setSellAmount("")
-    setBuyAmount("")
+  useSkipFirstRenderEffect(() => {
+    if (SUPPORT_POLYGON) {
+      setSellAsset(undefined)
+      setBuyAsset(undefined)
+      setSellAmount("")
+      setBuyAmount("")
+    }
   }, [currentNetwork.chainID, dispatch])
 
   const buyAssets = useBackgroundSelector((state) => {

--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -592,7 +592,10 @@ export default function Swap(): ReactElement {
                     isDisabled={
                       typeof latestQuoteRequest.current === "undefined" ||
                       sellAmountLoading ||
-                      buyAmountLoading
+                      buyAmountLoading ||
+                      !sellAsset ||
+                      !sellAmount ||
+                      !buyAsset
                     }
                     onClick={getFinalQuote}
                     showLoadingOnClick={!confirmationMenu}


### PR DESCRIPTION
> Let's win the swap game or die! - Greg

This PR:
- updates the disable state of the final quote button
- restricts quote updates to happen only when we have all the input data
- fix a weird behaviour that is happening because of `webext-redux`
- ~~start every swap with a clean slate~~ keep the persisted state functionality

# Test

Try to swap, and it should work as expected. 

~~When `Approve asset` happens, the swap page will NOT be repopulated with the previous settings.~~

Closes #1587 