### PR TITLE
💬 Improve SharedAssetInput with text truncation

### DIFF
--- a/ui/components/Shared/SharedAssetInput.tsx
+++ b/ui/components/Shared/SharedAssetInput.tsx
@@ -538,6 +538,7 @@ export default function SharedAssetInput<T extends AnyAsset>(
             font-weight: 500;
             line-height: 32px;
             text-align: right;
+            text-overflow: ellipsis;
           }
           input::-webkit-outer-spin-button,
           input::-webkit-inner-spin-button {


### PR DESCRIPTION
So it's obvious that we have more digits to show.

![CleanShot 2022-06-16 at 10 28 35](https://user-images.githubusercontent.com/7690112/174028592-e2e9602c-1421-4bc9-897a-a469fc685106.gif)

Closes #1595 (if it's ok with product)