### PR TITLE
🌊 OpenSea interactions

### DIFF
--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -149,12 +149,19 @@ export default class TallyWindowProvider extends EventEmitter {
     return Promise.reject(new Error("Unsupported function parameters"))
   }
 
+  // deprecated EIP-1193 method
+  // added as some dapps are still using it
   sendAsync(
-    request: RequestArgument,
+    request: RequestArgument & { id?: number; jsonrpc?: string },
     callback: (error: unknown, response: unknown) => void
   ): Promise<unknown> | void {
     return this.request(request).then(
-      (response) => callback(null, { result: response }),
+      (response) =>
+        callback(null, {
+          result: response,
+          id: request.id,
+          jsonrpc: request.jsonrpc,
+        }),
       (error) => callback(error, null)
     )
   }

--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -149,6 +149,16 @@ export default class TallyWindowProvider extends EventEmitter {
     return Promise.reject(new Error("Unsupported function parameters"))
   }
 
+  sendAsync(
+    request: RequestArgument,
+    callback: (error: unknown, response: unknown) => void
+  ): Promise<unknown> | void {
+    return this.request(request).then(
+      (response) => callback(null, { result: response }),
+      (error) => callback(error, null)
+    )
+  }
+
   // Provider-wide counter for requests.
   private requestID = 0n
 


### PR DESCRIPTION
Resolves https://github.com/tallycash/extension/issues/1251

### What

Allow to connect wallet, buy and list NFTs on OpenSea. 

![image](https://user-images.githubusercontent.com/20949277/174797245-b4a90209-fa9a-438d-ba39-4622d650215b.png)

### How

Added `sendAsync` method, despite it being deprecated some dapps are still using it. OpenSea was throwing errors and warnings as we were not sending the expected response format.

### Testing

1. Connect wallet with OpenSea
2. Buy NFT (you can use [this lamb](https://opensea.io/assets/ethereum/0xd1e5b0ff1287aa9f9a268759062e4ab08b9dacbe/36415121617891189491210625105620328235501305871961131031012756619587371395219) as I was using it for testing)
3. List NFT for sale
4. Make an offer **Note**: last time I was testing making an offer it was broken on both TallyHo and MetaMask so I assume it's on their side.