### PR TITLE
Properly initialize internal active network.

### DIFF
--- a/background/services/internal-ethereum-provider/db.ts
+++ b/background/services/internal-ethereum-provider/db.ts
@@ -18,16 +18,11 @@ export class InternalEthereumProviderDatabase extends Dexie {
       activeNetwork: "&origin,chainId,network, address",
     })
 
-    this.initialize()
-  }
-
-  async initialize(): Promise<void> {
-    const existingActiveNetwork = await this.activeNetwork.get({
-      origin: TALLY_INTERNAL_ORIGIN,
+    this.on("populate", (tx) => {
+      return tx.db
+        .table("activeNetwork")
+        .add({ origin: TALLY_INTERNAL_ORIGIN, ETHEREUM })
     })
-    if (!existingActiveNetwork) {
-      await this.setActiveChainIdForOrigin(TALLY_INTERNAL_ORIGIN, ETHEREUM)
-    }
   }
 
   async setActiveChainIdForOrigin(

--- a/background/services/internal-ethereum-provider/db.ts
+++ b/background/services/internal-ethereum-provider/db.ts
@@ -1,7 +1,5 @@
 import Dexie from "dexie"
-import { ETHEREUM } from "../../constants"
 import { EVMNetwork } from "../../networks"
-import { TALLY_INTERNAL_ORIGIN } from "./constants"
 
 export type ActiveNetwork = {
   origin: string
@@ -14,17 +12,9 @@ export class InternalEthereumProviderDatabase extends Dexie {
   constructor() {
     super("tally/internal-ethereum-provider")
 
-    this.version(1)
-      .stores({
-        activeNetwork: "&origin,chainId,network, address",
-      })
-      .upgrade((tx) => {
-        return tx.table("activeNetwork").put({
-          origin: TALLY_INTERNAL_ORIGIN,
-          // New installs will default to having `Ethereum` as their active chain.
-          network: ETHEREUM,
-        })
-      })
+    this.version(1).stores({
+      activeNetwork: "&origin,chainId,network, address",
+    })
   }
 
   async setActiveChainIdForOrigin(

--- a/background/services/internal-ethereum-provider/db.ts
+++ b/background/services/internal-ethereum-provider/db.ts
@@ -22,11 +22,11 @@ export class InternalEthereumProviderDatabase extends Dexie {
   }
 
   async initialize(): Promise<void> {
-    const existingActiveNetwork = await this.activeNetwork.where({
+    const existingActiveNetwork = await this.activeNetwork.get({
       origin: TALLY_INTERNAL_ORIGIN,
     })
     if (!existingActiveNetwork) {
-      this.setActiveChainIdForOrigin(TALLY_INTERNAL_ORIGIN, ETHEREUM)
+      await this.setActiveChainIdForOrigin(TALLY_INTERNAL_ORIGIN, ETHEREUM)
     }
   }
 

--- a/background/services/internal-ethereum-provider/db.ts
+++ b/background/services/internal-ethereum-provider/db.ts
@@ -21,7 +21,7 @@ export class InternalEthereumProviderDatabase extends Dexie {
     this.on("populate", (tx) => {
       return tx.db
         .table("activeNetwork")
-        .add({ origin: TALLY_INTERNAL_ORIGIN, ETHEREUM })
+        .add({ origin: TALLY_INTERNAL_ORIGIN, network: ETHEREUM })
     })
   }
 

--- a/background/services/internal-ethereum-provider/db.ts
+++ b/background/services/internal-ethereum-provider/db.ts
@@ -1,5 +1,7 @@
 import Dexie from "dexie"
+import { ETHEREUM } from "../../constants"
 import { EVMNetwork } from "../../networks"
+import { TALLY_INTERNAL_ORIGIN } from "./constants"
 
 export type ActiveNetwork = {
   origin: string
@@ -15,6 +17,17 @@ export class InternalEthereumProviderDatabase extends Dexie {
     this.version(1).stores({
       activeNetwork: "&origin,chainId,network, address",
     })
+
+    this.initialize()
+  }
+
+  async initialize(): Promise<void> {
+    const existingActiveNetwork = await this.activeNetwork.where({
+      origin: TALLY_INTERNAL_ORIGIN,
+    })
+    if (!existingActiveNetwork) {
+      this.setActiveChainIdForOrigin(TALLY_INTERNAL_ORIGIN, ETHEREUM)
+    }
   }
 
   async setActiveChainIdForOrigin(


### PR DESCRIPTION
@greg-nagy's [comment](https://github.com/tallycash/extension/pull/1609#discussion_r901790735) turned out to be prescient.  The current implementation causes inconsistent behavior when SUPPORT_POLYGON is set to true.

### To Test

Attempt to buy a polygon NFT (for example[ this one](https://opensea.io/assets/matic/0x66194b1abcbfbedd83841775404b245c8f9e4183/210624583337114373395836055367340864637790190801098222508621988249)).  You should be able to do so successfully.