### PR TITLE
📜 Fix scroll in core page which fixes overview tab

### DIFF
--- a/ui/components/Core/CorePage.tsx
+++ b/ui/components/Core/CorePage.tsx
@@ -3,11 +3,22 @@ import Snackbar from "../Snackbar/Snackbar"
 
 interface Props {
   children: React.ReactNode
-  hasTopBar: boolean
+  hasTopBar?: boolean
+  hasTabBar?: boolean
 }
 
 export default function CorePage(props: Props): ReactElement {
-  const { children, hasTopBar } = props
+  const { children, hasTopBar, hasTabBar } = props
+
+  let barSpace = 0
+  if (hasTabBar) {
+    // Tab bar is given 56px of height
+    barSpace += 56
+  }
+  if (hasTopBar) {
+    // Top bar is given 64px of height
+    barSpace += 64
+  }
 
   return (
     <main>
@@ -25,7 +36,7 @@ export default function CorePage(props: Props): ReactElement {
             align-items: center;
             background-color: var(--hunter-green);
             z-index: 10;
-            height: ${hasTopBar ? "480px" : "100vh"};
+            height: calc(100vh - ${barSpace}px);
             margin-top: ${hasTopBar ? "0px" : "-64px"};
           }
           .top_menu_wrap {

--- a/ui/pages/Popup.tsx
+++ b/ui/pages/Popup.tsx
@@ -187,17 +187,24 @@ export function Main(): ReactElement {
                     </div>
                     {/* @ts-expect-error TODO: fix the typing when the feature works */}
                     <Switch location={transformedLocation}>
-                      {pageList.map(({ path, Component, hasTopBar }) => {
-                        return (
-                          <Route path={path} key={path}>
-                            <CorePage hasTopBar={hasTopBar}>
-                              <ErrorBoundary FallbackComponent={ErrorFallback}>
-                                <Component location={transformedLocation} />
-                              </ErrorBoundary>
-                            </CorePage>
-                          </Route>
-                        )
-                      })}
+                      {pageList.map(
+                        ({ path, Component, hasTopBar, hasTabBar }) => {
+                          return (
+                            <Route path={path} key={path}>
+                              <CorePage
+                                hasTopBar={hasTopBar}
+                                hasTabBar={hasTabBar}
+                              >
+                                <ErrorBoundary
+                                  FallbackComponent={ErrorFallback}
+                                >
+                                  <Component location={transformedLocation} />
+                                </ErrorBoundary>
+                              </CorePage>
+                            </Route>
+                          )
+                        }
+                      )}
                     </Switch>
                   </div>
                 </CSSTransition>


### PR DESCRIPTION
Turns out the missing asset on the overview tab was just hidden behind the tab
bar basically.  The height on the content area only adjusted to having a top
bar or not w/ a tab bar, but didn't handle a tab bar w/o the top bar. This PR
solves the issue by passing the bar settings into the core page component to
set the styles.

<img width="320" alt="overview" src="https://user-images.githubusercontent.com/1918798/175142836-44923afd-15f1-49df-b5ee-9733418ccd5e.png">


Closes #1362

🤘