### PR TITLE
Fix sign data displayed message

### DIFF
--- a/background/services/internal-ethereum-provider/index.ts
+++ b/background/services/internal-ethereum-provider/index.ts
@@ -229,7 +229,7 @@ export default class InternalEthereumProviderService extends BaseService<Events>
       case "eth_sign": // --- important wallet methods ---
         return this.signData(
           {
-            hexData: params[1] as string,
+            input: params[1] as string,
             account: params[0] as string,
           },
           origin
@@ -237,7 +237,7 @@ export default class InternalEthereumProviderService extends BaseService<Events>
       case "personal_sign":
         return this.signData(
           {
-            hexData: params[0] as string,
+            input: params[0] as string,
             account: params[1] as string,
           },
           origin
@@ -355,15 +355,15 @@ export default class InternalEthereumProviderService extends BaseService<Events>
 
   private async signData(
     {
-      hexData,
+      input,
       account,
     }: {
-      hexData: string
+      input: string
       account: string
     },
     origin: string
   ) {
-    const asciiData = hexToAscii(hexData)
+    const asciiData = input.startsWith("0x") ? hexToAscii(input) : input
     const { data, type } = parseSigningData(asciiData)
     const activeNetwork = await this.getActiveOrDefaultNetwork(origin)
 

--- a/ui/components/SignData/EIP191Info.tsx
+++ b/ui/components/SignData/EIP191Info.tsx
@@ -36,6 +36,7 @@ const EIP191Info: React.FC<{
         }
         .light {
           color: #ccd3d3;
+          white-space: pre-wrap;
         }
         .label {
           color: var(--green-40);


### PR DESCRIPTION
Resolves #1590

### What
Some dApps are sending sign data in plain text, not hex as expected. We should check if a sign message input is actually in hex format before decoding.

### Testing
Try to sign EIP191 message - for example, sign in to https://passport.gitcoin.co/#/