### PR TITLE
🌅 Fix old fee preview w/ a deprecated fee settings text component 

### DIFF
--- a/background/constants/network-fees.ts
+++ b/background/constants/network-fees.ts
@@ -5,6 +5,14 @@ export const ESTIMATED_FEE_MULTIPLIERS: { [confidence: number]: bigint } = {
   0: 20n,
 }
 
+export const ESTIMATED_FEE_MULTIPLIERS_BY_TYPE: {
+  [feeType: string]: bigint
+} = {
+  regular: 11n,
+  express: 13n,
+  instant: 18n,
+}
+
 export const MAX_FEE_MULTIPLIER: { [confidence: number]: bigint } = {
   70: 13n,
   95: 15n,

--- a/ui/components/NetworkFees/FeeSettingsTextDeprecated.tsx
+++ b/ui/components/NetworkFees/FeeSettingsTextDeprecated.tsx
@@ -1,0 +1,93 @@
+import { ESTIMATED_FEE_MULTIPLIERS_BY_TYPE } from "@tallyho/tally-background/constants/network-fees"
+import {
+  truncateDecimalAmount,
+  weiToGwei,
+} from "@tallyho/tally-background/lib/utils"
+import { NetworkFeeSettings } from "@tallyho/tally-background/redux-slices/transaction-construction"
+import {
+  selectDefaultNetworkFeeSettings,
+  selectEstimatedFeesPerGas,
+  selectFeeType,
+} from "@tallyho/tally-background/redux-slices/selectors/transactionConstructionSelectors"
+import {
+  selectCurrentNetwork,
+  selectMainCurrencyPricePoint,
+} from "@tallyho/tally-background/redux-slices/selectors"
+import { enrichAssetAmountWithMainCurrencyValues } from "@tallyho/tally-background/redux-slices/utils/asset-utils"
+import { PricePoint } from "@tallyho/tally-background/assets"
+import React, { ReactElement } from "react"
+import { useBackgroundSelector } from "../../hooks"
+
+const getFeeDollarValue = (
+  currencyPrice: PricePoint | undefined,
+  networkSettings: NetworkFeeSettings
+): string | undefined => {
+  const {
+    values: { maxFeePerGas, maxPriorityFeePerGas },
+  } = networkSettings
+  const gasLimit = networkSettings.gasLimit ?? networkSettings.suggestedGasLimit
+
+  if (!gasLimit || !currencyPrice) return undefined
+
+  const [asset] = currencyPrice.pair
+  const { localizedMainCurrencyAmount } =
+    enrichAssetAmountWithMainCurrencyValues(
+      {
+        asset,
+        amount: (maxFeePerGas + maxPriorityFeePerGas) * gasLimit,
+      },
+      currencyPrice,
+      2
+    )
+
+  return localizedMainCurrencyAmount
+}
+
+export default function FeeSettingsTextDeprecated(): ReactElement {
+  const currentNetwork = useBackgroundSelector(selectCurrentNetwork)
+  const estimatedFeesPerGas = useBackgroundSelector(selectEstimatedFeesPerGas)
+  const selectedFeeType = useBackgroundSelector(selectFeeType)
+  const networkSettings = useBackgroundSelector(selectDefaultNetworkFeeSettings)
+  const mainCurrencyPricePoint = useBackgroundSelector(
+    selectMainCurrencyPricePoint
+  )
+  const baseFeePerGas =
+    useBackgroundSelector((state) => {
+      return state.networks.evm[currentNetwork.chainID].baseFeePerGas
+    }) ??
+    networkSettings.values?.baseFeePerGas ??
+    0n
+
+  const estimatedGweiAmount =
+    typeof estimatedFeesPerGas !== "undefined" &&
+    typeof selectedFeeType !== "undefined"
+      ? truncateDecimalAmount(
+          weiToGwei(
+            ((baseFeePerGas ?? 0n) *
+              ESTIMATED_FEE_MULTIPLIERS_BY_TYPE[selectedFeeType]) /
+              10n
+          ),
+          0
+        )
+      : ""
+
+  if (typeof estimatedFeesPerGas === "undefined") return <div>Unknown</div>
+
+  const gweiValue = `${estimatedGweiAmount} Gwei`
+  const dollarValue = getFeeDollarValue(mainCurrencyPricePoint, networkSettings)
+
+  if (!dollarValue) return <div>~{gweiValue}</div>
+
+  return (
+    <div>
+      ~${dollarValue}
+      <span className="fee_gwei">({gweiValue})</span>
+      <style jsx>{`
+        .fee_gwei {
+          color: var(--green-60);
+          margin-left: 5px;
+        }
+      `}</style>
+    </div>
+  )
+}


### PR DESCRIPTION
This PR adds an updated version of the old fee settings text. Our fee settings
text got updated to work with the new gas selection screen, but left the old
screen behind. This is added to make sure the feature flag provides a working
experience.