### PR TITLE
⚠️ Prevent `undefined reading toLowerCase` in uiSelector

### DIFF
--- a/background/redux-slices/selectors/uiSelectors.ts
+++ b/background/redux-slices/selectors/uiSelectors.ts
@@ -30,7 +30,7 @@ export const selectCurrentAccount = createSelector(
   ({ address, network }) => ({
     address,
     network,
-    truncatedAddress: address.toLowerCase().slice(0, 7),
+    truncatedAddress: address?.toLowerCase().slice(0, 7),
   })
 )
 


### PR DESCRIPTION
An error here was reported when experiencing a green screen of death. This
doesn't address the root cause but hopefully is an immediate remedy. I haven't
been able to reproduce the issue.

Here's some context,
<img width="622" alt="message one" src="https://user-images.githubusercontent.com/1918798/175614412-7ad80a76-fdda-470c-959e-067e3cdcb44f.png">
<img width="528" alt="message two" src="https://user-images.githubusercontent.com/1918798/175614432-97183400-f17b-4fdf-8e5d-12a2e806ef33.png">
<img width="554" alt="message three" src="https://user-images.githubusercontent.com/1918798/175614445-6cbf1a18-abab-4a45-bd49-5a489d060c40.png">
<img width="980" alt="console" src="https://user-images.githubusercontent.com/1918798/175614455-5469bd37-9b5f-4889-8482-4ef89c554719.png">

https://discord.com/channels/808358975287722045/888500174685614090/989593132045848596
