### PR TITLE
Fix overview address count

### DIFF
--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -414,7 +414,9 @@ export const selectCurrentAccountTotal = createSelector(
 export const getAddressCount = createSelector(
   (state: RootState) => state.account.accountsData,
   (accountsData) =>
-    Object.values(accountsData.evm).flatMap((chainAddresses) =>
-      Object.keys(chainAddresses)
-    ).length
+    new Set(
+      Object.values(accountsData.evm).flatMap((chainAddresses) =>
+        Object.keys(chainAddresses)
+      )
+    ).size
 )


### PR DESCRIPTION
Fixes https://github.com/tallycash/extension/issues/1700

To Test:
- Ensure that the overview address count is not double the number of addresses in your address list.
- Adding an address should increase the address count by 1
- Removing an address should decrease the address count by 1