### PR TITLE
Bugfix: Swapping tokens w/ same name & symbol but different networks no longer allowed.

### DIFF
--- a/background/redux-slices/utils/asset-utils.ts
+++ b/background/redux-slices/utils/asset-utils.ts
@@ -36,7 +36,7 @@ export type AssetDecimalAmount = {
 }
 
 function isBaseAsset(asset: AnyAsset): asset is NetworkBaseAsset {
-  return !("homeNetwork" in asset)
+  return "coinType" in asset
 }
 
 /**

--- a/background/redux-slices/utils/asset-utils.ts
+++ b/background/redux-slices/utils/asset-utils.ts
@@ -10,7 +10,7 @@ import {
   AnyAsset,
 } from "../../assets"
 import { fromFixedPointNumber } from "../../lib/fixed-point"
-import { AnyNetwork } from "../../networks"
+import { AnyNetwork, NetworkBaseAsset } from "../../networks"
 
 /**
  * Adds user-specific amounts based on preferences. This is the combination of
@@ -35,6 +35,10 @@ export type AssetDecimalAmount = {
   localizedDecimalAmount: string
 }
 
+function isBaseAsset(asset: AnyAsset): asset is NetworkBaseAsset {
+  return !("homeNetwork" in asset)
+}
+
 /**
  * Given an asset and a network, determines whether the given asset is the base
  * asset for the given network. Used to special-case transactions that should
@@ -48,12 +52,12 @@ export type AssetDecimalAmount = {
 export function isNetworkBaseAsset(
   asset: AnyAsset,
   network: AnyNetwork
-): boolean {
+): asset is NetworkBaseAsset {
   return (
-    !("homeNetwork" in asset) &&
-    "family" in network &&
-    network.family === "EVM" &&
-    asset.symbol === network.baseAsset.symbol
+    isBaseAsset(asset) &&
+    asset.symbol === network.baseAsset.symbol &&
+    asset.coinType === network.baseAsset.coinType &&
+    asset.name === network.baseAsset.name
   )
 }
 

--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -27,7 +27,6 @@ import {
 import {
   AnyAsset,
   FungibleAsset,
-  isFungibleAsset,
   isSmartContractFungibleAsset,
   SmartContractFungibleAsset,
 } from "@tallyho/tally-background/assets"
@@ -40,6 +39,7 @@ import { CompleteAssetAmount } from "@tallyho/tally-background/redux-slices/acco
 import { sameNetwork } from "@tallyho/tally-background/networks"
 import { selectDefaultNetworkFeeSettings } from "@tallyho/tally-background/redux-slices/selectors/transactionConstructionSelectors"
 import { selectSlippageTolerance } from "@tallyho/tally-background/redux-slices/ui"
+import { isNetworkBaseAsset } from "@tallyho/tally-background/redux-slices/utils/asset-utils"
 import CorePage from "../components/Core/CorePage"
 import SharedAssetInput from "../components/Shared/SharedAssetInput"
 import SharedButton from "../components/Shared/SharedButton"
@@ -180,9 +180,7 @@ export default function Swap(): ReactElement {
         }
         if (
           // Explicitly add a network's base asset.
-          isFungibleAsset(asset) &&
-          // Just checking on symbol is a pretty weak check - can we do better?
-          asset.symbol === currentNetwork.baseAsset.symbol
+          isNetworkBaseAsset(asset, currentNetwork)
         ) {
           return true
         }


### PR DESCRIPTION
Closes https://github.com/tallycash/extension/issues/1703.

<img width="387" alt="image" src="https://user-images.githubusercontent.com/94649004/177019289-1d11a96a-9b1c-4367-ada6-5f5e47ed965d.png">

## To Test
- Open SWAP menu on ethereum network
- searching for ETH should no longer show `Ether - PoS` in the buy token list