### PR TITLE
Deeply Diffed: Move webext-redux updatesto deep-diff strategy

### DIFF
--- a/background/index.ts
+++ b/background/index.ts
@@ -1,6 +1,7 @@
 import browser from "webextension-polyfill"
 
 import { Store as ProxyStore } from "webext-redux"
+import patchDeepDiff from "webext-redux/lib/strategies/deepDiff/patch"
 import { AnyAction } from "@reduxjs/toolkit"
 
 import Main from "./main"
@@ -29,6 +30,7 @@ export async function newProxyStore(): Promise<
   const proxyStore = new ProxyStore({
     serializer: encodeJSON,
     deserializer: decodeJSON,
+    patchStrategy: patchDeepDiff,
   })
   await proxyStore.ready()
 

--- a/background/main.ts
+++ b/background/main.ts
@@ -1,5 +1,6 @@
 import browser, { runtime } from "webextension-polyfill"
 import { alias, wrapStore } from "webext-redux"
+import deepDiff from "webext-redux/lib/strategies/deepDiff/diff"
 import { configureStore, isPlain, Middleware } from "@reduxjs/toolkit"
 import { devToolsEnhancer } from "@redux-devtools/remote"
 import { PermissionRequest } from "@tallyho/provider-bridge-shared"
@@ -367,6 +368,7 @@ export default class Main extends BaseService<never> {
     wrapStore(this.store, {
       serializer: encodeJSON,
       deserializer: decodeJSON,
+      diffStrategy: deepDiff,
       dispatchResponder: async (
         dispatchResult: Promise<unknown>,
         send: (param: { error: string | null; value: unknown | null }) => void

--- a/env.d.ts
+++ b/env.d.ts
@@ -1,5 +1,17 @@
 /// <reference types="styled-jsx" />
 
+declare module "webext-redux/lib/strategies/deepDiff/diff" {
+  // This should be : DiffStrategy, but importing webext-redux to reuse
+  // DiffStrategy results in an error augmenting the diff module.
+  export default function (): (oldObj: unknown, newObj: unknown) => unknown
+}
+
+declare module "webext-redux/lib/strategies/deepDiff/patch" {
+  // This should be : DiffStrategy, but importing webext-redux to reuse
+  // DiffStrategy results in an error augmenting the patch module.
+  export default function (): (oldObj: unknown, newObj: unknown) => unknown
+}
+
 // Although you would expect this file to be unnecessary, removing it will
 // result in a handful of type errors. See PR #196.
 


### PR DESCRIPTION
This strategy only sends the actual changed areas across the port, but
more importantly it only changes the objects that need to be changed in
the proxy store. This leads to less rerendering in the extension popup.

This is something I noticed while debugging a network-switching-related
issue, where rerenders were triggering certain `useEffect`s rather
unexpectedly, because of how objects are compared. This should make object
comparisons and resulting invalidation of any dependencies work a little
more predictably/like we might expect.