### PR TITLE
Operation Unifier: Make transactions follow the SignOperation<T> contract

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -632,13 +632,10 @@ export default class Main extends BaseService<never> {
 
     transactionConstructionSliceEmitter.on(
       "requestSignature",
-      async ({ transaction, accountSigner }) => {
+      async ({ request, accountSigner }) => {
         try {
           const signedTransactionResult =
-            await this.signingService.signTransaction(
-              transaction,
-              accountSigner
-            )
+            await this.signingService.signTransaction(request, accountSigner)
           await this.store.dispatch(transactionSigned(signedTransactionResult))
         } catch (exception) {
           logger.error("Error signing transaction", exception)

--- a/background/redux-slices/signing.ts
+++ b/background/redux-slices/signing.ts
@@ -11,8 +11,22 @@ import { EnrichedSignTypedDataRequest } from "../services/enrichment"
 import { EIP712TypedData } from "../types"
 import { AddressOnNetwork } from "../accounts"
 import { AccountSigner } from "../services/signing"
+import { EIP1559TransactionRequest } from "../networks"
 
-export type SignOperation<T> = {
+/**
+ * The different types of SignOperations that can be executed. These types
+ * correspond to the signature requests that they carry.
+ */
+export type SignOperationType =
+  | SignDataRequest
+  | SignTypedDataRequest
+  | EIP1559TransactionRequest
+
+/**
+ * A request for a signing operation carrying the AccountSigner whose signature
+ * is requested and the request itself.
+ */
+export type SignOperation<T extends SignOperationType> = {
   request: T
   accountSigner: AccountSigner
 }

--- a/background/redux-slices/transaction-construction.ts
+++ b/background/redux-slices/transaction-construction.ts
@@ -22,7 +22,7 @@ import {
 } from "../services/enrichment"
 
 import { createBackgroundAsyncThunk } from "./utils"
-import { AccountSigner } from "../services/signing"
+import { SignOperation } from "./signing"
 
 export const enum TransactionConstructionStatus {
   Idle = "idle",
@@ -84,14 +84,9 @@ export const initialState: TransactionConstruction = {
   lastGasEstimatesRefreshed: Date.now(),
 }
 
-export type SignatureRequest = {
-  transaction: EIP1559TransactionRequest
-  accountSigner: AccountSigner
-}
-
 export type Events = {
   updateTransaction: EnrichedEVMTransactionSignatureRequest
-  requestSignature: SignatureRequest
+  requestSignature: SignOperation<EIP1559TransactionRequest>
   signatureRejected: never
   broadcastSignedTransaction: SignedEVMTransaction
 }
@@ -151,9 +146,9 @@ export const updateTransactionData = createBackgroundAsyncThunk(
 
 export const signTransaction = createBackgroundAsyncThunk(
   "transaction-construction/sign",
-  async (request: SignatureRequest) => {
+  async (request: SignOperation<EIP1559TransactionRequest>) => {
     if (USE_MAINNET_FORK) {
-      request.transaction.chainID = FORK.chainID
+      request.request.chainID = FORK.chainID
     }
 
     await emitter.emit("requestSignature", request)

--- a/ui/pages/SignTransaction.tsx
+++ b/ui/pages/SignTransaction.tsx
@@ -59,7 +59,7 @@ export default function SignTransaction(): ReactElement {
     ) {
       dispatch(
         signTransaction({
-          transaction: transactionDetails,
+          request: transactionDetails,
           accountSigner,
         })
       )


### PR DESCRIPTION
> [**Operation Unifier**, also known as **Canadian Armed Forces Joint Task Force-Ukraine**, is the Canadian Armed Forces contribution to the security of Ukraine in coordination with the Ukrainian Armed Forces. It also includes a small Swedish contingent. It was begun in light of fomentation by separatist sentiments in the Donetsk and Luhansk and Crimean regions of Ukraine after the 2014 Ukrainian revolution and the 2014 pro-Russian unrest in Ukraine.](https://en.wikipedia.org/wiki/Operation_Unifier)

Transaction signing requests were of type `SignatureRequest`, which
predates the `SignOperation<T>` type that unifies typed data and message
signing requests. To unify all signing and make progress towards moving
all signing management into the signing slice, signing operations are
now all represented by `SignOperation<T>`, and the T type parameter is
restricted to the known types of signing requests the wallet can handle.

The changes are minimal, since `SignatureRequest` was very close in
structure already to `SignOperation`.

## Testing

- [ ] Test transaction signing for internal dApps (send ETH, send tokens, swaps).
- [ ] Test transaction signing for external dApps.
- [ ] Test other types of signing (data, typed data), though they should not be on any of the updated paths here.