### PR TITLE
👁 Fix new gas preview dollar estimate

### DIFF
--- a/ui/components/NetworkFees/FeeSettingsText.tsx
+++ b/ui/components/NetworkFees/FeeSettingsText.tsx
@@ -33,9 +33,7 @@ const getFeeDollarValue = (
       enrichAssetAmountWithMainCurrencyValues(
         {
           asset,
-          amount:
-            estimatedSpendPerGas +
-            BigInt(networkSettings.values.maxPriorityFeePerGas) * gasLimit,
+          amount: estimatedSpendPerGas * gasLimit,
         },
         currencyPrice,
         2

--- a/ui/components/NetworkFees/FeeSettingsText.tsx
+++ b/ui/components/NetworkFees/FeeSettingsText.tsx
@@ -22,12 +22,10 @@ import FeeSettingsTextDeprecated from "./FeeSettingsTextDeprecated"
 const getFeeDollarValue = (
   currencyPrice: PricePoint | undefined,
   networkSettings: NetworkFeeSettings,
+  gasLimit?: bigint,
   estimatedSpendPerGas?: bigint
 ): string | undefined => {
   if (estimatedSpendPerGas) {
-    const gasLimit =
-      networkSettings.gasLimit ?? networkSettings.suggestedGasLimit
-
     if (!gasLimit || !currencyPrice) return undefined
 
     const [asset] = currencyPrice.pair
@@ -83,6 +81,7 @@ export default function FeeSettingsText({
   const dollarValue = getFeeDollarValue(
     mainCurrencyPricePoint,
     networkSettings,
+    gasLimit,
     estimatedSpendPerGas
   )
 

--- a/ui/components/NetworkFees/FeeSettingsText.tsx
+++ b/ui/components/NetworkFees/FeeSettingsText.tsx
@@ -21,7 +21,6 @@ import FeeSettingsTextDeprecated from "./FeeSettingsTextDeprecated"
 
 const getFeeDollarValue = (
   currencyPrice: PricePoint | undefined,
-  networkSettings: NetworkFeeSettings,
   gasLimit?: bigint,
   estimatedSpendPerGas?: bigint
 ): string | undefined => {
@@ -78,7 +77,6 @@ export default function FeeSettingsText({
   const gweiValue = `${estimatedGweiAmount} Gwei`
   const dollarValue = getFeeDollarValue(
     mainCurrencyPricePoint,
-    networkSettings,
     gasLimit,
     estimatedSpendPerGas
   )


### PR DESCRIPTION
Dollar values were very low because of an order of operations issue that
appeared when `estimatedSpendPerGas` was added. This resolves that issue and
cleans things up a bit.