### PR TITLE
Fallback to sendAsync inside of window-provider's send method

### DIFF
--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -140,10 +140,7 @@ export default class TallyWindowProvider extends EventEmitter {
     }
 
     if (isObject(methodOrRequest) && typeof paramsOrCallback === "function") {
-      return this.request(methodOrRequest).then(
-        (response) => paramsOrCallback(null, response),
-        (error) => paramsOrCallback(error, null)
-      )
+      return this.sendAsync(methodOrRequest, paramsOrCallback)
     }
 
     return Promise.reject(new Error("Unsupported function parameters"))


### PR DESCRIPTION
Closes https://github.com/tallycash/extension/issues/1736

Evidence of bridge working: 
Approval: https://etherscan.io/tx/0xae3dd5f15036b1359faf712e5c4c0272d444927eeaef92d605c625b0353f619e
Bridge Transaction: https://etherscan.io/tx/0x8c4a3701d38085ecd06d3a4b8fab161eac59924d89a2ee2dc0fb0fe7c84d716b

So it appears what was happening was that https://wallet.polygon.technology/bridge/ was calling `send` but expecting the response to their call to be in the shape of a `sendAsync` response.

Question to @greg-nagy or @Shadowfiend  - do we think this breaks existing functionality - or is the conditional branch inside of the `if` statement on line 142 something that has never worked?

If we think it will break existing functionality - I fear we may need some sort of whitelist for dapps that require the response to be 1 way vs the other.