### PR TITLE
🤏 Fix enrichment service's insufficient funds warning calc

### DIFF
--- a/background/services/enrichment/index.ts
+++ b/background/services/enrichment/index.ts
@@ -129,7 +129,7 @@ export default class EnrichmentService extends BaseService<Events> {
       transaction
 
     if (gasLimit && maxFeePerGas && maxPriorityFeePerGas) {
-      const gasFee = gasLimit * (maxFeePerGas + maxPriorityFeePerGas)
+      const gasFee = gasLimit * maxFeePerGas
       const {
         assetAmount: { amount: baseAssetBalance },
       } = await this.chainService.getLatestBaseAccountBalance({

--- a/ui/components/NetworkFees/NetworkSettingsSelect.tsx
+++ b/ui/components/NetworkFees/NetworkSettingsSelect.tsx
@@ -58,7 +58,7 @@ const gasOptionFromEstimate = (
       ? enrichAssetAmountWithMainCurrencyValues(
           {
             asset: ETH,
-            amount: (maxFeePerGas + maxPriorityFeePerGas) * gasLimit,
+            amount: maxFeePerGas * gasLimit,
           },
           mainCurrencyPricePoint,
           2


### PR DESCRIPTION
We should not do `(maxFeePerGas + maxPriorityFeePerGas)` because `maxPriorityFeePerGas` is included in `maxFeePerGas`.

This also fixes the dollar calc in `NetworkSettingsSelect`, although I don't believe that's used anywhere at the moment.