### PR TITLE
Fix meshswap dapp connection

### DIFF
--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -240,6 +240,9 @@ export default class TallyWindowProvider extends EventEmitter {
         ) {
           // null result indicates successful chain change https://eips.ethereum.org/EIPS/eip-3326#specification
           if (result === null) {
+            this.chainId = (
+              sendData.request.params[0] as { chainId: string }
+            ).chainId
             this.emit(
               "chainChanged",
               (sendData.request.params[0] as { chainId: string }).chainId

--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -33,6 +33,8 @@ export default class TallyWindowProvider extends EventEmitter {
 
   isMetaMask = false
 
+  isWeb3 = true
+
   bridgeListeners = new Map()
 
   providerInfo = {


### PR DESCRIPTION
- adding isWeb3 flag to `window-provider`
- saving the chainId on the `window-provider` in case of `wallet_switchEthereumChain` || `wallet_addEthereumChain`

Note: on the initial connection, a `wrong network` error will be shown. 
Fixing this would require white-labeling meshswap which is probably not a good idea. 
This behavior is identical with MM. 

Closes #1761 