### PR TITLE
Only lookup names for relevant ERC20 transfers

### DIFF
--- a/background/services/enrichment/utils.ts
+++ b/background/services/enrichment/utils.ts
@@ -6,6 +6,7 @@ import NameService from "../name"
 import { EIP712TypedData } from "../../types"
 import { EIP2612TypedData } from "../../utils/signing"
 import { ERC20TransferLog } from "../../lib/erc20"
+import { normalizeEVMAddress } from "../../lib/utils"
 
 export function isEIP2612TypedData(
   typedData: EIP712TypedData
@@ -80,4 +81,19 @@ export function getDistinctRecipentAddressesFromERC20Logs(
   logs: ERC20TransferLog[]
 ): string[] {
   return [...new Set([...logs.map(({ recipientAddress }) => recipientAddress)])]
+}
+
+export const getERC20LogsForAddresses = (
+  logs: ERC20TransferLog[],
+  addresses: string[]
+): ERC20TransferLog[] => {
+  const relevantAddresses = Object.fromEntries(
+    addresses.map((address) => [address, true])
+  )
+
+  return logs.filter(
+    (log) =>
+      relevantAddresses[log.recipientAddress] ||
+      relevantAddresses[log.senderAddress]
+  )
 }

--- a/background/services/enrichment/utils.ts
+++ b/background/services/enrichment/utils.ts
@@ -93,7 +93,7 @@ export const getERC20LogsForAddresses = (
 
   return logs.filter(
     (log) =>
-      relevantAddresses[log.recipientAddress] ||
-      relevantAddresses[log.senderAddress]
+      relevantAddresses[normalizeEVMAddress(log.recipientAddress)] ||
+      relevantAddresses[normalizeEVMAddress(log.senderAddress)]
   )
 }


### PR DESCRIPTION
This PR resolves the issue of name service lookups temporarily bringing the application to a halt.

### To Test
- Load the extension, add an account, open the background logs
- Go do something else for ~4 minutes
- Come back - focus all your energy on testing this ticket
- [ ] The background logs should not be full of `ERR_INSUFFICIENT_RESOURCES` errors as pictured below:

<img width="1276" alt="image" src="https://user-images.githubusercontent.com/94649004/178519826-abda203e-a27e-44c6-bbc8-a6d88746afd9.png">
