### PR TITLE
🐾 Update `isTrackingAsset` to match intent

### DIFF
--- a/background/services/indexing/db.ts
+++ b/background/services/indexing/db.ts
@@ -219,6 +219,16 @@ export class IndexingDatabase extends Dexie {
       .first()
   }
 
+  async getTrackedAssetByAddressAndNetwork(
+    network: Network,
+    contractAddress: string
+  ): Promise<SmartContractFungibleAsset | undefined> {
+    return this.assetsToTrack
+      .where("[contractAddress+homeNetwork.name]")
+      .equals([network.name, contractAddress])
+      .first()
+  }
+
   async addCustomAsset(asset: SmartContractFungibleAsset): Promise<void> {
     this.customAssets.put(asset)
   }

--- a/background/services/indexing/db.ts
+++ b/background/services/indexing/db.ts
@@ -193,7 +193,7 @@ export class IndexingDatabase extends Dexie {
 
   async isTrackingAsset(asset: SmartContractFungibleAsset): Promise<boolean> {
     return (
-      (await this.getCustomAssetByAddressAndNetwork(
+      (await this.getTrackedAssetByAddressAndNetwork(
         asset.homeNetwork,
         asset.contractAddress
       )) !== undefined


### PR DESCRIPTION
We track more than custom assets, but custom assets were the only assets being
checked by `isTrackingAsset`. Although all custom assets are tracked, this can
exclude non-custom tracked assets. This PR updates `isTrackingAsset` to
match the expected behavior of returning `true` on all tracked assets.