### PR TITLE
🐾 Also check if asset known

### DIFF
--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -277,7 +277,10 @@ export default class IndexingService extends BaseService<Events> {
         // (e.g. via a previously baseline-trusted interaction or via a token
         // list) OR the sender is a tracked address.
         const baselineTrustedAsset =
-          (await this.db.isTrackingAsset(asset)) ||
+          (await this.getKnownSmartContractAsset(
+            enrichedEVMTransaction.network,
+            asset.contractAddress
+          )) ||
           (
             await this.chainService.filterTrackedAddressesOnNetworks([
               {

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -277,10 +277,11 @@ export default class IndexingService extends BaseService<Events> {
         // (e.g. via a previously baseline-trusted interaction or via a token
         // list) OR the sender is a tracked address.
         const baselineTrustedAsset =
-          (await this.getKnownSmartContractAsset(
+          typeof (await this.getKnownSmartContractAsset(
             enrichedEVMTransaction.network,
             asset.contractAddress
-          )) ||
+          )) !== "undefined" ||
+          (await this.db.isTrackingAsset(asset)) ||
           (
             await this.chainService.filterTrackedAddressesOnNetworks([
               {


### PR DESCRIPTION
https://github.com/tallycash/extension/pull/1788/commits/2564d140e633bf4853073224d452ce7a451cf0d5 states, 

> Baseline trust is currently defined as a token that was SENT BY an address that is being tracked
(i.e., an account the user has added to the wallet) OR that is already
known (typically via a token list).

So it looks like the idea is to check if an asset is known, not just if it's tracked.
This PR adds checking if an asset is known to the baseline trust check.