### PR TITLE
Fix read-only accounts

### DIFF
--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -297,7 +297,7 @@ const getAccountType = (
     [address: string]: "import" | "internal"
   }
 ): AccountType => {
-  if (signer == null) {
+  if (signer === ReadOnlyAccountSigner) {
     return AccountType.ReadOnly
   }
   if (signerTypeToAccountType[signer.type] === "ledger") {

--- a/ui/components/SignTransaction/SignTransactionContainer.tsx
+++ b/ui/components/SignTransaction/SignTransactionContainer.tsx
@@ -7,6 +7,7 @@ import React, {
 } from "react"
 import { AccountTotal } from "@tallyho/tally-background/redux-slices/selectors"
 import { Warning } from "@tallyho/tally-background/services/enrichment"
+import { ReadOnlyAccountSigner } from "@tallyho/tally-background/services/signing"
 import SharedButton from "../Shared/SharedButton"
 import SharedSkeletonLoader from "../Shared/SharedSkeletonLoader"
 import SharedSlideUpMenu from "../Shared/SharedSlideUpMenu"
@@ -135,32 +136,33 @@ export default function SignTransactionContainer({
               Reject
             </SharedButton>
             {/* TODO: split into different components depending on signing method, to avoid convoluted logic below */}
-            {accountSigner &&
-              (isLedgerSigning && !canLedgerSign ? (
-                <SharedButton
-                  type="primaryGreen"
-                  size="large"
-                  onClick={() => {
-                    setSlideUpOpen(true)
-                  }}
-                >
-                  Check Ledger
-                </SharedButton>
-              ) : (
-                <SharedButton
-                  type="primaryGreen"
-                  size="large"
-                  onClick={handleConfirm}
-                  showLoadingOnClick
-                  isDisabled={
-                    isOnDelayToSign || warnings.includes("insufficient-funds")
-                  }
-                >
-                  {confirmButtonLabel}
-                </SharedButton>
-              ))}
-            {accountSigner === null && (
+            {accountSigner === ReadOnlyAccountSigner && (
               <span className="no-signing">Read-only accounts cannot sign</span>
+            )}
+            {isLedgerSigning && !canLedgerSign && (
+              <SharedButton
+                type="primaryGreen"
+                size="large"
+                onClick={() => {
+                  setSlideUpOpen(true)
+                }}
+              >
+                Check Ledger
+              </SharedButton>
+            )}
+            {((isLedgerSigning && canLedgerSign) ||
+              accountSigner?.type === "keyring") && (
+              <SharedButton
+                type="primaryGreen"
+                size="large"
+                onClick={handleConfirm}
+                showLoadingOnClick
+                isDisabled={
+                  isOnDelayToSign || warnings.includes("insufficient-funds")
+                }
+              >
+                {confirmButtonLabel}
+              </SharedButton>
             )}
           </div>
         </>

--- a/ui/components/Wallet/WalletAccountBalanceControl.tsx
+++ b/ui/components/Wallet/WalletAccountBalanceControl.tsx
@@ -4,6 +4,7 @@ import classNames from "classnames"
 import { useDispatch } from "react-redux"
 import { refreshBackgroundPage } from "@tallyho/tally-background/redux-slices/ui"
 import { selectCurrentAccountSigner } from "@tallyho/tally-background/redux-slices/selectors"
+import { ReadOnlyAccountSigner } from "@tallyho/tally-background/services/signing"
 import { useBackgroundSelector, useLocalStorage } from "../../hooks"
 import SharedButton from "../Shared/SharedButton"
 import SharedSkeletonLoader from "../Shared/SharedSkeletonLoader"
@@ -162,7 +163,9 @@ export default function WalletAccountBalanceControl(
           width={180}
           customStyles="margin-bottom: 10px;"
         >
-          {currentAccountSigner ? (
+          {currentAccountSigner === ReadOnlyAccountSigner ? (
+            <ReadOnlyNotice />
+          ) : (
             <>
               {hasSavedSeed ? (
                 <div className="send_receive_button_wrap">
@@ -198,8 +201,6 @@ export default function WalletAccountBalanceControl(
                 </div>
               )}
             </>
-          ) : (
-            <ReadOnlyNotice />
           )}
         </SharedSkeletonLoader>
       </div>

--- a/ui/pages/PersonalSign.tsx
+++ b/ui/pages/PersonalSign.tsx
@@ -10,6 +10,7 @@ import {
 } from "@tallyho/tally-background/redux-slices/signing"
 import { SignDataMessageType } from "@tallyho/tally-background/utils/signing"
 import { useHistory } from "react-router-dom"
+import { ReadOnlyAccountSigner } from "@tallyho/tally-background/services/signing"
 import {
   useBackgroundDispatch,
   useBackgroundSelector,
@@ -52,7 +53,7 @@ export default function PersonalSignData(): ReactElement {
   }
 
   const handleConfirm = () => {
-    if (currentAccountSigner === null) return
+    if (currentAccountSigner === ReadOnlyAccountSigner) return
     if (signingDataRequest === undefined) return
 
     dispatch(

--- a/ui/pages/SignData.tsx
+++ b/ui/pages/SignData.tsx
@@ -7,6 +7,7 @@ import {
   selectTypedData,
   signTypedData,
 } from "@tallyho/tally-background/redux-slices/signing"
+import { ReadOnlyAccountSigner } from "@tallyho/tally-background/services/signing"
 import React, { ReactElement, useState } from "react"
 import { useHistory } from "react-router-dom"
 import SignTransactionContainer from "../components/SignTransaction/SignTransactionContainer"
@@ -43,7 +44,10 @@ export default function SignData(): ReactElement {
 
   const handleConfirm = () => {
     if (typedDataRequest !== undefined) {
-      if (currentAccountSigner) {
+      if (
+        currentAccountSigner &&
+        currentAccountSigner !== ReadOnlyAccountSigner
+      ) {
         dispatch(
           signTypedData({
             request: typedDataRequest,

--- a/ui/pages/SignTransaction.tsx
+++ b/ui/pages/SignTransaction.tsx
@@ -11,6 +11,7 @@ import {
   getAccountTotal,
   selectCurrentNetwork,
 } from "@tallyho/tally-background/redux-slices/selectors"
+import { ReadOnlyAccountSigner } from "@tallyho/tally-background/services/signing"
 import {
   useBackgroundDispatch,
   useBackgroundSelector,
@@ -55,7 +56,8 @@ export default function SignTransaction(): ReactElement {
     if (
       isTransactionDataReady &&
       transactionDetails &&
-      accountSigner !== null
+      accountSigner &&
+      accountSigner !== ReadOnlyAccountSigner
     ) {
       dispatch(
         signTransaction({

--- a/ui/pages/SingleAsset.tsx
+++ b/ui/pages/SingleAsset.tsx
@@ -10,6 +10,7 @@ import {
   AnyAsset,
   isSmartContractFungibleAsset,
 } from "@tallyho/tally-background/assets"
+import { ReadOnlyAccountSigner } from "@tallyho/tally-background/services/signing"
 import { useBackgroundSelector } from "../hooks"
 import SharedAssetIcon from "../components/Shared/SharedAssetIcon"
 import SharedButton from "../components/Shared/SharedButton"
@@ -123,7 +124,7 @@ export default function SingleAsset(): ReactElement {
             )}
           </div>
           <div className="right">
-            {currentAccountSigner ? (
+            {currentAccountSigner !== ReadOnlyAccountSigner ? (
               <>
                 <SharedButton
                   type="primary"


### PR DESCRIPTION
Resolves #1799

### What
Fix problems where read-only accounts were allowed to try to sign transactions and other regressions caused by #1724

### Testing

Please test this side by side with our last release to make sure read-only accounts are handled the same way they were before.

![image](https://user-images.githubusercontent.com/20949277/178722179-781cbfba-5fdf-46bd-b9a4-a6f939f0307b.png)
