### PR TITLE
Remove `call` code cruft

### DIFF
--- a/background/services/name/resolvers/address-book.ts
+++ b/background/services/name/resolvers/address-book.ts
@@ -19,19 +19,13 @@ export default function addressBookResolverFor(
     },
 
     async lookUpAddressForName(nameOnNetwork: NameOnNetwork) {
-      return preferenceService.lookUpAddressForName.call(
-        preferenceService,
-        nameOnNetwork
-      )
+      return preferenceService.lookUpAddressForName(nameOnNetwork)
     },
     async lookUpAvatar() {
       throw new Error("Avatar resolution not supported in address book.")
     },
     async lookUpNameForAddress(addressOnNetwork: AddressOnNetwork) {
-      return preferenceService.lookUpNameForAddress.call(
-        preferenceService,
-        addressOnNetwork
-      )
+      return preferenceService.lookUpNameForAddress(addressOnNetwork)
     },
   }
 }


### PR DESCRIPTION
No need for a `call` here since changing `lookUpAddressForName` and `lookUpNameForAddress` to functions binds `this` for us.