### PR TITLE
Monster Paths: Allow for paths that don't have page entries

### DIFF
--- a/ui/pages/Popup.tsx
+++ b/ui/pages/Popup.tsx
@@ -149,7 +149,7 @@ export function Main(): ReactElement {
             // the user or explicitly added. That said, we can still certainly "POP" via
             // history.goBack(). This case is not yet accounted for.
             if (
-              pagePreferences[normalizedPathname].persistOnClose &&
+              pagePreferences[normalizedPathname]?.persistOnClose === true &&
               routeProps.history.action === "PUSH"
             ) {
               // @ts-expect-error TODO: fix the typing


### PR DESCRIPTION
persistOnClose lookup assumes the normalized path will always have a
page entry, but there's nothing about the normalization process that
guarantees this. Allow for undefineds to deal with this problem.