### PR TITLE
📒Create a memoized version of the mergeAssets

### DIFF
--- a/background/lib/token-lists.ts
+++ b/background/lib/token-lists.ts
@@ -1,5 +1,6 @@
 import { TokenList } from "@uniswap/token-lists"
 
+import { memoize } from "lodash"
 import {
   FungibleAsset,
   SmartContractFungibleAsset,
@@ -144,6 +145,10 @@ export function mergeAssets<T extends FungibleAsset>(
       (b.metadata?.tokenLists?.length || 0)
   )
 }
+
+export const memoizedMergeAssets = memoize(mergeAssets, (...assetLists) => {
+  return assetLists.reduce((acc, curr) => acc + curr.length, 0)
+})
 
 /*
  * Return all tokens in the provided lists, de-duplicated and structured in our

--- a/background/lib/token-lists.ts
+++ b/background/lib/token-lists.ts
@@ -146,6 +146,11 @@ export function mergeAssets<T extends FungibleAsset>(
   )
 }
 
+// The result of the `mergeAssets` is a pure function in the sense that the output depends
+// only on the function argument, which makes it a good candidate for memoization.
+// As for cache key generation we are using the total number of assets that were provided.
+// This is not 100% accurate, but given that we are dealing with token lists it seems to be
+// a safe bet. The chances are slim that 1 asset is added and 1 is removed in 1 minute.
 export const memoizedMergeAssets = memoize(mergeAssets, (...assetLists) => {
   return assetLists.reduce((acc, curr) => acc + curr.length, 0)
 })

--- a/background/package.json
+++ b/background/package.json
@@ -54,6 +54,7 @@
     "node-fetch": "^2.6.1",
     "siwe": "^1.1.0",
     "util": "^0.12.4",
+    "lodash": "^4.17.21",
     "webextension-polyfill": "^0.8.0"
   },
   "devDependencies": {

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -15,7 +15,7 @@ import { BASE_ASSETS, FIAT_CURRENCIES, USD } from "../../constants"
 import { getPrices, getTokenPrices } from "../../lib/prices"
 import {
   fetchAndValidateTokenList,
-  mergeAssets,
+  memoizedMergeAssets,
   networkAssetsFromLists,
 } from "../../lib/token-lists"
 import PreferenceService from "../preferences"
@@ -194,7 +194,7 @@ export default class IndexingService extends BaseService<Events> {
       await this.preferenceService.getTokenListPreferences()
     const tokenLists = await this.db.getLatestTokenLists(tokenListPrefs.urls)
 
-    return mergeAssets<FungibleAsset>(
+    return memoizedMergeAssets<FungibleAsset>(
       [network.baseAsset],
       customAssets,
       networkAssetsFromLists(network, tokenLists)


### PR DESCRIPTION
this function call is extremply expensive cpu wise
and it's also a pure function in the practical sense
so we can optimize by running it only if the input
list changes

we use a shortcut for calculating the cache key
for similarity definition. We are not checking for
all the contract addresses to be the same, but
we use the number of all the elements in the list
as an indicator that the incoming lists are the same
This is a reasonable compromise, given we are dealing
with token lists here.