### PR TITLE
💬Memoize 2/n: use the memoized version of `mergeAssets` in `networkAssetsFromLists` 

### DIFF
--- a/background/lib/token-lists.ts
+++ b/background/lib/token-lists.ts
@@ -168,5 +168,5 @@ export function networkAssetsFromLists(
     tokenListToFungibleAssetsForNetwork(network, tokenListAndReference)
   )
 
-  return mergeAssets(...fungibleAssets)
+  return memoizedMergeAssets(...fungibleAssets)
 }


### PR DESCRIPTION
networkAssetsFromLists is using mergeAssets
and it's called every time getCachedAssets is called

so it also worth memoizing

the effect of this optimization is not that significant
as it was for the `getCachedAssets` but this still
makes this to the top of the list in terms of cpu usage