### PR TITLE
fix for github CI memory issue

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -15,7 +15,7 @@ import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin"
 import WebExtensionArchivePlugin from "./build-utils/web-extension-archive-webpack-plugin"
 import InjectWindowProvider from "./build-utils/inject-window-provider"
 
-const supportedBrowsers = ["brave", "chrome", "edge", "firefox", "opera"]
+const supportedBrowsers = ["chrome"]
 
 // Replicated and adjusted for each target browser and the current build mode.
 const baseConfig: Configuration = {


### PR DESCRIPTION
github actions started to kill the build process
with error message of 137 which signals out of
memory

Couldn't find any way to set it manually without
self-hosting the builder, so I went with a shortcut
of building only for browsers that we are currently
shipping for.

This decreased the memory usage to it's third
8394096640 > 3120578560

to measure on osx: /usr/bin/time -l yarn build