### PR TITLE
Patch packages before each dev build

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "start": "run-p devtools \"dev {@}\" --",
     "generate:validators": "ts-node background/generate-validators.ts",
     "build": "webpack --mode=production",
-    "dev": "webpack --mode=development --watch",
+    "dev": "patch-package && webpack --mode=development --watch",
     "devtools": "redux-devtools --hostname=localhost --port=8000",
     "lint": "run-p lint:*",
     "lint-fix": "run-p lint:*:fix",


### PR DESCRIPTION
### What

Apply patches before dev build

### Why

If for some reason webext-redux package is not patched then we experience weird bugs without an easy way to debug them. As this is a recurring issue and we are wasting our time on it,
let's apply patches before dev builds.