### PR TITLE
⏰ Remove historical pricepoint from assets

### DIFF
--- a/background/constants/currencies.ts
+++ b/background/constants/currencies.ts
@@ -9,19 +9,7 @@ export const USD: FiatCurrency = {
   decimals: 10,
 }
 
-export const EUR: FiatCurrency = {
-  name: "euro",
-  symbol: "EUR",
-  decimals: 10,
-}
-
-export const CNY: FiatCurrency = {
-  name: "renminbi",
-  symbol: "CNY",
-  decimals: 10,
-}
-
-export const FIAT_CURRENCIES = [USD, EUR, CNY]
+export const FIAT_CURRENCIES = [USD]
 
 export const ETH: FungibleAsset & CoinGeckoAsset & NetworkBaseAsset = {
   name: "Ether",

--- a/background/redux-slices/migrations/index.ts
+++ b/background/redux-slices/migrations/index.ts
@@ -10,12 +10,13 @@ import to10 from "./to-10"
 import to11 from "./to-11"
 import to12 from "./to-12"
 import to13 from "./to-13"
+import to14 from "./to-14"
 
 /**
  * The version of persisted Redux state the extension is expecting. Any previous
  * state without this version, or with a lower version, ought to be migrated.
  */
-export const REDUX_STATE_VERSION = 13
+export const REDUX_STATE_VERSION = 14
 
 /**
  * Common type for all migration functions.
@@ -38,6 +39,7 @@ const allMigrations: { [targetVersion: string]: Migration } = {
   11: to11,
   12: to12,
   13: to13,
+  14: to14,
 }
 
 /**

--- a/background/redux-slices/migrations/to-14.ts
+++ b/background/redux-slices/migrations/to-14.ts
@@ -1,0 +1,15 @@
+// This migration ensures the assets collection is cleared due to a change in
+// assets slice shape; the assets list should be repopulated during startup by
+// the IndexingService.
+
+export default (
+  prevState: Record<string, unknown>
+): Record<string, unknown> => {
+  const { assets, ...newState } = prevState
+
+  // Clear assets collection; these should be immediately repopulated by the
+  // IndexingService in startService.
+  newState.assets = []
+
+  return newState
+}

--- a/background/tests/earn/assets.mock.ts
+++ b/background/tests/earn/assets.mock.ts
@@ -8,26 +8,6 @@ const assets: AssetsState = [
     decimals: 18,
     homeNetwork: ETHEREUM,
     contractAddress: "0x0",
-    prices: [
-      {
-        pair: [
-          {
-            contractAddress: "0x0",
-            decimals: 18,
-            homeNetwork: ETHEREUM,
-            name: "Wrapped Ether",
-            symbol: "WETH",
-          },
-          {
-            name: "United States Dollar",
-            symbol: "USD",
-            decimals: 10,
-          },
-        ],
-        amounts: [1000000000000000000n, 30955400000000n],
-        time: 1650536441,
-      },
-    ],
     recentPrices: {
       USD: {
         pair: [
@@ -55,26 +35,6 @@ const assets: AssetsState = [
     decimals: 18,
     homeNetwork: ETHEREUM,
     contractAddress: "0x0",
-    prices: [
-      {
-        pair: [
-          {
-            name: "Uniswap",
-            symbol: "UNI",
-            decimals: 18,
-            contractAddress: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
-            homeNetwork: ETHEREUM,
-          },
-          {
-            name: "United States Dollar",
-            symbol: "USD",
-            decimals: 10,
-          },
-        ],
-        amounts: [1000000000000000000n, 93600000000n],
-        time: 1650536467,
-      },
-    ],
     recentPrices: {
       USD: {
         pair: [

--- a/background/tests/prices.test.ts
+++ b/background/tests/prices.test.ts
@@ -178,14 +178,10 @@ describe("lib/prices.ts", () => {
       const fetchJsonResponse = {
         ethereum: {
           usd: 3836.53,
-          eur: 3297.36,
-          cny: 24487,
           last_updated_at: 1634672101,
         },
         bitcoin: {
           usd: 63909,
-          eur: 54928,
-          cny: 407908,
           last_updated_at: 1634672139,
         },
       }
@@ -200,31 +196,11 @@ describe("lib/prices.ts", () => {
           time: dateNow,
         },
         {
-          amounts: [549280000000000n, 100000000n],
-          pair: [{ decimals: 10, name: "euro", symbol: "EUR" }, BTC],
-          time: dateNow,
-        },
-        {
-          amounts: [4079080000000000n, 100000000n],
-          pair: [{ decimals: 10, name: "renminbi", symbol: "CNY" }, BTC],
-          time: dateNow,
-        },
-        {
           amounts: [38365300000000n, 1000000000000000000n],
           pair: [
             { decimals: 10, name: "United States Dollar", symbol: "USD" },
             ETH,
           ],
-          time: dateNow,
-        },
-        {
-          amounts: [32973600000000n, 1000000000000000000n],
-          pair: [{ decimals: 10, name: "euro", symbol: "EUR" }, ETH],
-          time: dateNow,
-        },
-        {
-          amounts: [244870000000000n, 1000000000000000000n],
-          pair: [{ decimals: 10, name: "renminbi", symbol: "CNY" }, ETH],
           time: dateNow,
         },
       ]


### PR DESCRIPTION
## What 

Remove the historical price data from the redux store. We are not using it for anything and it's saved into indexedDB, so we can query for it later when we need it. 

## Test 

⚠️ These testing steps focus on this PR and #1875 together as a measure to improve our CPU usage. They are kind of separate from dev perspective, but part of the same problem — big redux store.

- create a clean install 
- test store size change
  - verify store size with the script below 
  - import `enroll...`
  - check overview tab and wallet > assets tab that it shows usd values
  - wait 5 minutes
  - verify store size again 
  - wait 10 minutes
  - verify store size again 
  - wait 10 minutes
  - verify store size again 
- test cpu usage with final store size (after completing the above steps)
  - with chrome task manager
    - [open chrome task manager](https://www.howtogeek.com/437681/how-to-use-chromes-built-in-task-manager/) 
    - select tally + wait for network activity to happen
      - ![CleanShot 2022-08-05 at 10 49 03](https://user-images.githubusercontent.com/7690112/183018870-1bb39a23-1d69-4608-b06e-fbc6e0e4f970.png)
      - check to see if cpu goes above 50 for a longer period 
  - through activity monitor
    - open activity monitor > select cpu > order desc by % CPU
    - check the CPU load on activity monitor
      - ![CleanShot 2022-08-05 at 10 57 32](https://user-images.githubusercontent.com/7690112/183019943-98e6e14f-f05d-44b7-b180-f793421d1b45.png)
      - there shouldn't be any significant periodical spikes 

### Expected outputs

After install BEFORE import
```
2022-08-05T06:41:16.328Z state size [kb]: 412.28125
redux size:6 	assets size [kb]: 352.8994140625
redux size:6 	activities size [kb]: 0.001953125
```
5 minutes after import 
```
2022-08-05T06:46:59.041Z state size [kb]: 568.9052734375
redux size:6 	assets size [kb]: 369.888671875
redux size:6 	activities size [kb]: 73.56640625
redux size:9 		0x208e94d5661a73360d9387d3ca169e5c130090cd size [kb]: 73.5205078125
```

15 minutes after import 
```
2022-08-05T06:57:12.915Z state size [kb]: 690.251953125
redux size:6 	assets size [kb]: 371.8349609375
redux size:6 	activities size [kb]: 192.7841796875
redux size:9 		0x208e94d5661a73360d9387d3ca169e5c130090cd size [kb]: 192.73828125
```

25 minutes after import 
```
2022-08-05T07:07:19.011Z state size [kb]: 770.0927734375
redux size:6 	assets size [kb]: 371.8349609375
redux size:6 	activities size [kb]: 272.6240234375
redux size:9 		0x208e94d5661a73360d9387d3ca169e5c130090cd size [kb]: 272.578125
```

## Script

```
chrome.storage.local.get(["state"], ({state: stateString}) => {
    const state = JSON.parse(stateString)
    console.log(`${new Date(Date.now()).toISOString()} state size [kb]: ${stateString.length/1024}`)
    Object.keys(state).filter(k => k === "assets" || k === "activities").map(sliceKey => {
        const slice = state[sliceKey]
        console.log(`\t${sliceKey} size [kb]: ${JSON.stringify(slice).length/1024}`)
        if (!Array.isArray(slice)) {
            Object.keys(slice).map(key => {
                console.log(`\t\t${key} size [kb]: ${JSON.stringify(slice[key]).length/1024}`)
            })
        }
    })
})
```