### PR TITLE
Don't prefix polygon 0x address with `gated`

### DIFF
--- a/background/redux-slices/0x-swap.ts
+++ b/background/redux-slices/0x-swap.ts
@@ -133,7 +133,8 @@ const get0xApiBase = (network: EVMNetwork) => {
   // Use gated features if there is an API key available in the build.
   const prefix =
     typeof process.env.ZEROX_API_KEY !== "undefined" &&
-    process.env.ZEROX_API_KEY.trim() !== ""
+    process.env.ZEROX_API_KEY.trim() !== "" &&
+    network.chainID === ETHEREUM.chainID
       ? "gated."
       : ""
 


### PR DESCRIPTION
Resolves #1896 
### What

Let's use `gated` prefix only on Ethereum mainnet, not on Polygon.

### Test

Test swaps on the build made by Github, not the local one