### PR TITLE
Default to main route if wallet is stuck on unknown route

### DIFF
--- a/ui/pages/Popup.tsx
+++ b/ui/pages/Popup.tsx
@@ -137,10 +137,11 @@ export function Main(): ReactElement {
               needsKeyringUnlock
             )
 
-            const normalizedPathname =
-              transformedLocation.pathname !== "/wallet"
-                ? transformedLocation.pathname
-                : "/"
+            const normalizedPathname = pagePreferences[
+              transformedLocation.pathname
+            ]
+              ? transformedLocation.pathname
+              : "/"
 
             // `initialEntries` needs to be a reversed version of route history
             // entities. Without avoiding the initial load, entries will keep reversing.


### PR DESCRIPTION
### What

We have changed routes names before - if a user hasn't used the wallet for a while and it updates to a newer version then it can be stuck on a location that has been removed. Let's default to the main route if the wallet is in an unknown location.