### PR TITLE
update nvm install to use curl and not brew because brew is unsupported

### DIFF
--- a/scripts/macos-setup.sh
+++ b/scripts/macos-setup.sh
@@ -12,7 +12,7 @@ brew list pre-commit &>/dev/null || brew install pre-commit
 pre-commit install --install-hooks
 
 echo "Installing nvm..."
-brew list nvm &>/dev/null || brew install nvm
+command -v nvm &>/dev/null || curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/nvm.sh | bash
 
 echo "Setting up nvm, yarn, and dependencies..."
 nvm use

--- a/scripts/macos-setup.sh
+++ b/scripts/macos-setup.sh
@@ -12,7 +12,7 @@ brew list pre-commit &>/dev/null || brew install pre-commit
 pre-commit install --install-hooks
 
 echo "Installing nvm..."
-command -v nvm &>/dev/null || curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/nvm.sh | bash
+command -v nvm &>/dev/null || curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash
 
 echo "Setting up nvm, yarn, and dependencies..."
 nvm use


### PR DESCRIPTION
Updating the mac os install script to use curl as per docs: 

https://github.com/nvm-sh/nvm#installing-and-updating

> Homebrew installation is not supported. If you have issues with homebrew-installed nvm, please brew uninstall it, and install it using the instructions below, before filing an issue.
