### PR TITLE
Ledger Plus Plus: Enable support for Ledger Nano S Plus

### DIFF
--- a/background/services/ledger/index.ts
+++ b/background/services/ledger/index.ts
@@ -31,6 +31,7 @@ enum LedgerType {
   UNKNOWN,
   LEDGER_NANO_S,
   LEDGER_NANO_X,
+  LEDGER_NANO_S_PLUS,
 }
 
 const LedgerTypeAsString = Object.values(LedgerType)
@@ -44,6 +45,7 @@ export type LedgerAccountSigner = {
 export const LedgerProductDatabase = {
   LEDGER_NANO_S: { productId: 0x1015 },
   LEDGER_NANO_X: { productId: 0x4015 },
+  LEDGER_NANO_S_PLUS: { productId: 0x5015 },
 }
 
 export const isLedgerSupported = typeof navigator.usb === "object"
@@ -110,6 +112,9 @@ async function generateLedgerId(
       break
     case DeviceModelId.nanoX:
       extensionDeviceType = LedgerType.LEDGER_NANO_X
+      break
+    case DeviceModelId.nanoSP:
+      extensionDeviceType = LedgerType.LEDGER_NANO_S_PLUS
       break
     default:
       extensionDeviceType = LedgerType.UNKNOWN


### PR DESCRIPTION
Added the Nano S Plus `productId` so newer hardware wallet users can connect with Tally Ho.

# To test

- [ ] Confirm adding a new Nano S & Nano X still work as usual on Chrome
- [ ] If you have one handy, add a Ledger Nano S Plus as a wallet. Everything should work as with other Ledger devices on Chrome.

Refs #1352, closes #1331

H/t @adrienlacombe-ledger