### PR TITLE
Remove erroneous Trezor derivation path

### DIFF
--- a/ui/components/Onboarding/OnboardingDerivationPathSelect.tsx
+++ b/ui/components/Onboarding/OnboardingDerivationPathSelect.tsx
@@ -18,15 +18,11 @@ const initialDerivationPaths: Option[] = [
   },
   {
     value: "m/44'/60'/0'/0",
-    label: "Ethereum",
+    label: "BIP 44 (Trezor, MetaMask)",
   },
   {
     value: "m/44'/1'/0'/0",
     label: "Ethereum Testnet",
-  },
-  {
-    value: "m/44'/61'/0'/0",
-    label: "Trezor",
   },
   {
     value: "m/44'/60'/0'",


### PR DESCRIPTION
The path we were using works with MEW's derivation notation, but was
erroring on a Ledger because... *drumroll*... it's for ETC.

https://blog.trezor.io/trezor-integration-with-myetherwallet-3e217a652e08
https://www.reddit.com/r/TREZOR/comments/81qffg/comment/dv4exam/

Closes #1943