### PR TITLE
Standardize coingeckoPlatformID

### DIFF
--- a/background/assets.ts
+++ b/background/assets.ts
@@ -53,7 +53,6 @@ export type Asset = {
 export type CoinGeckoAsset = Asset & {
   metadata: Asset["metadata"] & {
     coinGeckoID: string
-    coinGeckoPlatformID?: string
   }
 }
 

--- a/background/constants/currencies.ts
+++ b/background/constants/currencies.ts
@@ -20,7 +20,6 @@ export const ETH: FungibleAsset & CoinGeckoAsset & NetworkBaseAsset = {
   coinType: coinTypesByAssetSymbol.ETH,
   metadata: {
     coinGeckoID: "ethereum",
-    coinGeckoPlatformID: "ethereum",
     tokenLists: [],
     websiteURL: "https://ethereum.org",
   },
@@ -33,7 +32,6 @@ export const MATIC: FungibleAsset & CoinGeckoAsset & NetworkBaseAsset = {
   coinType: coinTypesByAssetSymbol.MATIC,
   metadata: {
     coinGeckoID: "matic-network",
-    coinGeckoPlatformID: "polygon-pos",
     tokenLists: [],
     websiteURL: "https://polygon.technology/",
   },
@@ -46,7 +44,6 @@ export const BTC: FungibleAsset & CoinGeckoAsset & NetworkBaseAsset = {
   coinType: coinTypesByAssetSymbol.BTC,
   metadata: {
     coinGeckoID: "bitcoin",
-    coinGeckoPlatformID: "bitcoin",
     tokenLists: [],
     websiteURL: "https://bitcoin.org",
   },

--- a/background/constants/networks.ts
+++ b/background/constants/networks.ts
@@ -6,6 +6,7 @@ export const ETHEREUM: EVMNetwork = {
   baseAsset: ETH,
   chainID: "1",
   family: "EVM",
+  coingeckoPlatformID: "ethereum",
 }
 
 export const POLYGON: EVMNetwork = {
@@ -13,6 +14,7 @@ export const POLYGON: EVMNetwork = {
   baseAsset: MATIC,
   chainID: "137",
   family: "EVM",
+  coingeckoPlatformID: "polygon-pos",
 }
 
 export const ARBITRUM_ONE: EVMNetwork = {
@@ -36,6 +38,7 @@ export const ROPSTEN: EVMNetwork = {
   baseAsset: ETH,
   chainID: "3",
   family: "EVM",
+  coingeckoPlatformID: "ethereum",
 }
 
 export const RINKEBY: EVMNetwork = {
@@ -43,6 +46,7 @@ export const RINKEBY: EVMNetwork = {
   baseAsset: ETH,
   chainID: "4",
   family: "EVM",
+  coingeckoPlatformID: "ethereum",
 }
 
 export const GOERLI: EVMNetwork = {
@@ -50,6 +54,7 @@ export const GOERLI: EVMNetwork = {
   baseAsset: ETH,
   chainID: "5",
   family: "EVM",
+  coingeckoPlatformID: "ethereum",
 }
 
 export const KOVAN: EVMNetwork = {
@@ -57,12 +62,14 @@ export const KOVAN: EVMNetwork = {
   baseAsset: ETH,
   chainID: "42",
   family: "EVM",
+  coingeckoPlatformID: "ethereum",
 }
 
 export const BITCOIN: Network = {
   name: "Bitcoin",
   baseAsset: BTC,
   family: "BTC",
+  coingeckoPlatformID: "bitcoin",
 }
 
 export const FORK: EVMNetwork = {

--- a/background/lib/prices.ts
+++ b/background/lib/prices.ts
@@ -118,10 +118,7 @@ export async function getTokenPrices(
 
   // TODO cover failed schema validation
   const addys = tokenAddresses.join(",")
-  const url = `${COINGECKO_API_ROOT}/simple/token_price/${
-    network.coingeckoPlatformID ??
-    network.baseAsset.metadata.coinGeckoPlatformID
-  }?vs_currencies=${fiatSymbol}&include_last_updated_at=true&contract_addresses=${addys}`
+  const url = `${COINGECKO_API_ROOT}/simple/token_price/${network.coingeckoPlatformID}?vs_currencies=${fiatSymbol}&include_last_updated_at=true&contract_addresses=${addys}`
 
   try {
     const json = await fetchJson(url)

--- a/background/networks.ts
+++ b/background/networks.ts
@@ -32,7 +32,7 @@ export type Network = {
   baseAsset: NetworkBaseAsset & CoinGeckoAsset
   family: NetworkFamily
   chainID?: string
-  coingeckoPlatformID?: string
+  coingeckoPlatformID: string
 }
 
 /**

--- a/background/tests/keyring-integration.test.ts
+++ b/background/tests/keyring-integration.test.ts
@@ -51,7 +51,13 @@ const validTransactionRequests: {
     maxPriorityFeePerGas: 0n,
     gasLimit: 0n,
     chainID: "0",
-    network: { name: "none", chainID: "0", baseAsset: ETH, family: "EVM" },
+    network: {
+      name: "none",
+      chainID: "0",
+      baseAsset: ETH,
+      family: "EVM",
+      coingeckoPlatformID: "ethereum",
+    },
   },
 }
 


### PR DESCRIPTION
remove coingeckoPlatformID from `CoinGeckoAsset` and add it to `Network` instead.