### PR TITLE
Incorporate L1 Rollup Fees into Optimism Gas Fee Display

### DIFF
--- a/background/constants/networks.ts
+++ b/background/constants/networks.ts
@@ -70,9 +70,13 @@ export const FORK: EVMNetwork = {
   family: "EVM",
 }
 
+export const EIP_1559_COMPLIANT_CHAIN_IDS = new Set(
+  [ETHEREUM, POLYGON].map((network) => network.chainID)
+)
 export const EVM_ROLLUP_CHAIN_IDS = new Set(
   [OPTIMISM].map((network) => network.chainID)
 )
+
 export const NETWORK_BY_CHAIN_ID = {
   [ETHEREUM.chainID]: ETHEREUM,
   [POLYGON.chainID]: POLYGON,

--- a/background/constants/networks.ts
+++ b/background/constants/networks.ts
@@ -70,6 +70,9 @@ export const FORK: EVMNetwork = {
   family: "EVM",
 }
 
+export const EVM_ROLLUP_CHAIN_IDS = new Set(
+  [OPTIMISM].map((network) => network.chainID)
+)
 export const NETWORK_BY_CHAIN_ID = {
   [ETHEREUM.chainID]: ETHEREUM,
   [POLYGON.chainID]: POLYGON,

--- a/background/networks.ts
+++ b/background/networks.ts
@@ -137,6 +137,11 @@ export type LegacyEVMTransaction = EVMTransaction & {
  *
  * Nonce is permitted to be `undefined` as Tally internals can and often do
  * populate the nonce immediately before a request is signed.
+ *
+ * On networks that roll up to ethereum - the rollup fee is directly proportional
+ * to the size (in bytes) of the input of a given transaction.  Networks that do
+ * not roll up will have a rollup fee of 0.
+ *
  */
 export type LegacyEVMTransactionRequest = Pick<
   LegacyEVMTransaction,
@@ -144,6 +149,7 @@ export type LegacyEVMTransactionRequest = Pick<
 > & {
   chainID: LegacyEVMTransaction["network"]["chainID"]
   gasLimit: bigint
+  estimatedRollupFee: bigint
   nonce?: number
 }
 

--- a/background/redux-slices/selectors/transactionConstructionSelectors.ts
+++ b/background/redux-slices/selectors/transactionConstructionSelectors.ts
@@ -27,6 +27,7 @@ export const selectDefaultNetworkFeeSettings = createSelector(
       values: {
         maxFeePerGas: selectedFeesPerGas?.maxFeePerGas ?? 0n,
         maxPriorityFeePerGas: selectedFeesPerGas?.maxPriorityFeePerGas ?? 0n,
+        gasPrice: selectedFeesPerGas?.price ?? 0n,
         baseFeePerGas:
           networks.evm[currentNetwork.chainID].baseFeePerGas ?? undefined, // @TODO: Support multi-network
       },

--- a/background/redux-slices/transaction-construction.ts
+++ b/background/redux-slices/transaction-construction.ts
@@ -1,6 +1,6 @@
 import { createSlice } from "@reduxjs/toolkit"
 import Emittery from "emittery"
-import { FORK } from "../constants"
+import { FORK, OPTIMISM } from "../constants"
 import {
   EXPRESS,
   INSTANT,
@@ -42,6 +42,7 @@ export type NetworkFeeSettings = {
     maxFeePerGas: bigint
     maxPriorityFeePerGas: bigint
     baseFeePerGas?: bigint
+    gasPrice?: bigint
   }
 }
 
@@ -102,6 +103,7 @@ export type GasOption = {
   maxPriorityGwei: string
   maxGwei: string
   dollarValue: string
+  gasPrice?: string
   estimatedFeePerGas: bigint // wei
   baseMaxFeePerGas: bigint // wei
   baseMaxGwei: string
@@ -275,15 +277,29 @@ const transactionSlice = createSlice({
         payload: { estimatedFeesPerGas, network },
       }: { payload: { estimatedFeesPerGas: BlockPrices; network: EVMNetwork } }
     ) => {
-      immerState.estimatedFeesPerGas = {
-        ...(immerState.estimatedFeesPerGas ?? {}),
-        [network.chainID]: {
-          baseFeePerGas: estimatedFeesPerGas.baseFeePerGas,
-          instant: makeBlockEstimate(INSTANT, estimatedFeesPerGas),
-          express: makeBlockEstimate(EXPRESS, estimatedFeesPerGas),
-          regular: makeBlockEstimate(REGULAR, estimatedFeesPerGas),
-        },
+      if (network.chainID === OPTIMISM.chainID) {
+        // @TODO change up how we do block estimates since alchemy only gives us an `instant` estimate for optimism.
+        immerState.estimatedFeesPerGas = {
+          ...(immerState.estimatedFeesPerGas ?? {}),
+          [network.chainID]: {
+            baseFeePerGas: estimatedFeesPerGas.baseFeePerGas,
+            instant: makeBlockEstimate(INSTANT, estimatedFeesPerGas),
+            express: makeBlockEstimate(INSTANT, estimatedFeesPerGas),
+            regular: makeBlockEstimate(INSTANT, estimatedFeesPerGas),
+          },
+        }
+      } else {
+        immerState.estimatedFeesPerGas = {
+          ...(immerState.estimatedFeesPerGas ?? {}),
+          [network.chainID]: {
+            baseFeePerGas: estimatedFeesPerGas.baseFeePerGas,
+            instant: makeBlockEstimate(INSTANT, estimatedFeesPerGas),
+            express: makeBlockEstimate(EXPRESS, estimatedFeesPerGas),
+            regular: makeBlockEstimate(REGULAR, estimatedFeesPerGas),
+          },
+        }
       }
+
       immerState.lastGasEstimatesRefreshed = Date.now()
     },
     setCustomGas: (

--- a/background/services/chain/utils/index.ts
+++ b/background/services/chain/utils/index.ts
@@ -17,9 +17,9 @@ import {
   TransactionRequest,
   isEIP1559SignedTransaction,
   SignedTransaction,
-} from "../../networks"
-import { USE_MAINNET_FORK } from "../../features"
-import { FORK } from "../../constants"
+} from "../../../networks"
+import { USE_MAINNET_FORK } from "../../../features"
+import { FORK } from "../../../constants"
 
 /**
  * Parse a block as returned by a polling provider.

--- a/background/services/chain/utils/optimismGasPriceOracle.tsx
+++ b/background/services/chain/utils/optimismGasPriceOracle.tsx
@@ -1,0 +1,176 @@
+// https://community.optimism.io/docs/developers/build/transaction-fees/#displaying-fees-to-users
+
+export const OPTIMISM_GAS_ORACLE_ADDRESS =
+  "0x420000000000000000000000000000000000000F"
+
+export const OPTIMISM_GAS_ORACLE_ABI = [
+  {
+    inputs: [{ internalType: "address", name: "_owner", type: "address" }],
+    stateMutability: "nonpayable",
+    type: "constructor",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: false, internalType: "uint256", name: "", type: "uint256" },
+    ],
+    name: "DecimalsUpdated",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: false, internalType: "uint256", name: "", type: "uint256" },
+    ],
+    name: "GasPriceUpdated",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: false, internalType: "uint256", name: "", type: "uint256" },
+    ],
+    name: "L1BaseFeeUpdated",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: false, internalType: "uint256", name: "", type: "uint256" },
+    ],
+    name: "OverheadUpdated",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "previousOwner",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "newOwner",
+        type: "address",
+      },
+    ],
+    name: "OwnershipTransferred",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: false, internalType: "uint256", name: "", type: "uint256" },
+    ],
+    name: "ScalarUpdated",
+    type: "event",
+  },
+  {
+    inputs: [],
+    name: "decimals",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "gasPrice",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "bytes", name: "_data", type: "bytes" }],
+    name: "getL1Fee",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "bytes", name: "_data", type: "bytes" }],
+    name: "getL1GasUsed",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "l1BaseFee",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "overhead",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "owner",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "renounceOwnership",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "scalar",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "_decimals", type: "uint256" }],
+    name: "setDecimals",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "_gasPrice", type: "uint256" }],
+    name: "setGasPrice",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "_baseFee", type: "uint256" }],
+    name: "setL1BaseFee",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "_overhead", type: "uint256" }],
+    name: "setOverhead",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "_scalar", type: "uint256" }],
+    name: "setScalar",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "newOwner", type: "address" }],
+    name: "transferOwnership",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+]

--- a/background/services/enrichment/index.ts
+++ b/background/services/enrichment/index.ts
@@ -35,7 +35,7 @@ import {
   getERC20LogsForAddresses,
   isEIP2612TypedData,
 } from "./utils"
-import { ETHEREUM, EVM_ROLLUP_CHAIN_IDS, OPTIMISM } from "../../constants"
+import { ETHEREUM, EVM_ROLLUP_CHAIN_IDS } from "../../constants"
 import { parseLogsForWrappedDepositsAndWithdrawals } from "../../lib/wrappedAsset"
 import { isDefined, isFulfilledPromise } from "../../lib/utils/type-guards"
 

--- a/ui/components/NetworkFees/FeeSettingsText.tsx
+++ b/ui/components/NetworkFees/FeeSettingsText.tsx
@@ -14,6 +14,8 @@ import {
 } from "@tallyho/tally-background/redux-slices/selectors/transactionConstructionSelectors"
 import { selectCurrentNetwork } from "@tallyho/tally-background/redux-slices/selectors"
 import { enrichAssetAmountWithMainCurrencyValues } from "@tallyho/tally-background/redux-slices/utils/asset-utils"
+import { EVM_ROLLUP_CHAIN_IDS } from "@tallyho/tally-background/constants"
+import { isEIP1559TransactionRequest } from "@tallyho/tally-background/networks"
 import {
   PricePoint,
   unitPricePointForPricePoint,
@@ -21,8 +23,6 @@ import {
 } from "@tallyho/tally-background/assets"
 import { useBackgroundSelector } from "../../hooks"
 import FeeSettingsTextDeprecated from "./FeeSettingsTextDeprecated"
-import { EVM_ROLLUP_CHAIN_IDS } from "@tallyho/tally-background/constants"
-import { isEIP1559TransactionRequest } from "@tallyho/tally-background/networks"
 
 const getFeeDollarValue = (
   currencyPrice: PricePoint | undefined,
@@ -84,6 +84,7 @@ export default function FeeSettingsText({
   )
   const gasLimit = networkSettings.gasLimit ?? networkSettings.suggestedGasLimit
   const estimatedSpendPerGas =
+    networkSettings.values.gasPrice ||
     baseFeePerGas + networkSettings.values.maxPriorityFeePerGas
 
   const estimatedGweiAmount =

--- a/ui/components/NetworkFees/NetworkSettingsChooser.tsx
+++ b/ui/components/NetworkFees/NetworkSettingsChooser.tsx
@@ -1,12 +1,15 @@
+import React, { ReactElement, useState } from "react"
 import {
   EstimatedFeesPerGas,
   NetworkFeeSettings,
   setFeeType,
 } from "@tallyho/tally-background/redux-slices/transaction-construction"
 import { selectDefaultNetworkFeeSettings } from "@tallyho/tally-background/redux-slices/selectors/transactionConstructionSelectors"
-import React, { ReactElement, useState } from "react"
+import { EIP_1559_COMPLIANT_CHAIN_IDS } from "@tallyho/tally-background/constants"
+import { selectCurrentNetwork } from "@tallyho/tally-background/redux-slices/selectors"
 import { useBackgroundDispatch, useBackgroundSelector } from "../../hooks"
 import NetworkSettingsSelect from "./NetworkSettingsSelect"
+import NetworkSettingsSelectDeprecated from "./NetworkSettingsSelectDeprecated"
 
 interface NetworkSettingsChooserProps {
   estimatedFeesPerGas: EstimatedFeesPerGas | undefined
@@ -20,6 +23,7 @@ export default function NetworkSettingsChooser({
   const [networkSettings, setNetworkSettings] = useState(
     useBackgroundSelector(selectDefaultNetworkFeeSettings)
   )
+  const currentNetwork = useBackgroundSelector(selectCurrentNetwork)
 
   const dispatch = useBackgroundDispatch()
 
@@ -31,12 +35,21 @@ export default function NetworkSettingsChooser({
   return (
     <>
       <div className="wrapper">
-        <NetworkSettingsSelect
-          estimatedFeesPerGas={estimatedFeesPerGas}
-          networkSettings={networkSettings}
-          onNetworkSettingsChange={setNetworkSettings}
-          onSave={saveNetworkSettings}
-        />
+        {EIP_1559_COMPLIANT_CHAIN_IDS.has(currentNetwork.chainID) ? (
+          <NetworkSettingsSelect
+            estimatedFeesPerGas={estimatedFeesPerGas}
+            networkSettings={networkSettings}
+            onNetworkSettingsChange={setNetworkSettings}
+            onSave={saveNetworkSettings}
+          />
+        ) : (
+          <NetworkSettingsSelectDeprecated
+            estimatedFeesPerGas={estimatedFeesPerGas}
+            networkSettings={networkSettings}
+            onNetworkSettingsChange={setNetworkSettings}
+            onSave={saveNetworkSettings}
+          />
+        )}
       </div>
       <style jsx>
         {`

--- a/ui/components/NetworkFees/NetworkSettingsSelect.tsx
+++ b/ui/components/NetworkFees/NetworkSettingsSelect.tsx
@@ -44,7 +44,7 @@ const gasOptionFromEstimate = (
   mainCurrencyPricePoint: PricePoint | undefined,
   baseFeePerGas: bigint,
   gasLimit: bigint | undefined,
-  { confidence, maxFeePerGas, maxPriorityFeePerGas }: BlockEstimate
+  { confidence, maxFeePerGas, maxPriorityFeePerGas, price }: BlockEstimate
 ): GasOption => {
   const feeOptionData: {
     [confidence: number]: NetworkFeeTypeChosen
@@ -86,6 +86,7 @@ const gasOptionFromEstimate = (
     baseMaxGwei: weiToGwei(BigInt(maxFeePerGas) - BigInt(maxPriorityFeePerGas)),
     maxFeePerGas,
     maxPriorityFeePerGas,
+    gasPrice: price?.toString(),
   }
 }
 

--- a/ui/components/NetworkFees/NetworkSettingsSelectDeprecated.tsx
+++ b/ui/components/NetworkFees/NetworkSettingsSelectDeprecated.tsx
@@ -35,6 +35,7 @@ type GasOption = {
   estimatedFeePerGas: bigint
   maxFeePerGas: bigint
   maxPriorityFeePerGas: bigint
+  gasPrice: bigint
 }
 
 // Map a BlockEstimate from the backend to a GasOption for the UI.
@@ -42,7 +43,7 @@ const gasOptionFromEstimate = (
   mainCurrencyPricePoint: PricePoint | undefined,
   baseFeePerGas: bigint,
   gasLimit: bigint | undefined,
-  { confidence, maxFeePerGas, maxPriorityFeePerGas }: BlockEstimate
+  { confidence, maxFeePerGas, maxPriorityFeePerGas, price }: BlockEstimate
 ): GasOption => {
   const feeOptionData: {
     [confidence: number]: NetworkFeeTypeChosen
@@ -77,6 +78,7 @@ const gasOptionFromEstimate = (
       (baseFeePerGas * ESTIMATED_FEE_MULTIPLIERS[confidence]) / 10n,
     maxFeePerGas,
     maxPriorityFeePerGas,
+    gasPrice: price ?? 0n,
   }
 }
 
@@ -133,6 +135,7 @@ export default function NetworkSettingsSelectDeprecated({
         values: {
           maxFeePerGas: gasOptions[activeFeeIndex].maxFeePerGas,
           maxPriorityFeePerGas: gasOptions[activeFeeIndex].maxPriorityFeePerGas,
+          gasPrice: gasOptions[activeFeeIndex].gasPrice,
         },
         gasLimit: networkSettings.gasLimit,
         suggestedGasLimit: networkSettings.suggestedGasLimit,
@@ -154,6 +157,7 @@ export default function NetworkSettingsSelectDeprecated({
       values: {
         maxFeePerGas: gasOptions[index].maxFeePerGas,
         maxPriorityFeePerGas: gasOptions[index].maxPriorityFeePerGas,
+        gasPrice: gasOptions[activeFeeIndex].gasPrice,
       },
       gasLimit: networkSettings.gasLimit,
       suggestedGasLimit: networkSettings.suggestedGasLimit,

--- a/ui/components/Swap/SwapTransactionSettingsChooser.tsx
+++ b/ui/components/Swap/SwapTransactionSettingsChooser.tsx
@@ -11,11 +11,14 @@ import {
 import { SWAP_FEE } from "@tallyho/tally-background/redux-slices/0x-swap"
 import { CUSTOM_GAS_SELECT } from "@tallyho/tally-background/features"
 import { setSlippageTolerance } from "@tallyho/tally-background/redux-slices/ui"
+import { EIP_1559_COMPLIANT_CHAIN_IDS } from "@tallyho/tally-background/constants"
+import { selectCurrentNetwork } from "@tallyho/tally-background/redux-slices/selectors"
 import SharedSlideUpMenu from "../Shared/SharedSlideUpMenu"
 import { useBackgroundDispatch, useBackgroundSelector } from "../../hooks"
 import NetworkSettingsSelect from "../NetworkFees/NetworkSettingsSelect"
 import FeeSettingsText from "../NetworkFees/FeeSettingsText"
 import SharedSelect, { Option } from "../Shared/SharedSelect"
+import NetworkSettingsSelectDeprecated from "../NetworkFees/NetworkSettingsSelectDeprecated"
 
 export type SwapTransactionSettings = {
   slippageTolerance: number
@@ -42,6 +45,7 @@ export default function SwapTransactionSettingsChooser({
 }: SwapTransactionSettingsProps): ReactElement {
   const { t } = useTranslation()
   const dispatch = useBackgroundDispatch()
+  const currentNetwork = useBackgroundSelector(selectCurrentNetwork)
 
   const estimatedFeesPerGas = useBackgroundSelector(selectEstimatedFeesPerGas)
   const [networkSettings, setNetworkSettings] = useState(
@@ -106,12 +110,21 @@ export default function SwapTransactionSettingsChooser({
                 />
               </div>
               <div className="row row_fee">
-                <NetworkSettingsSelect
-                  estimatedFeesPerGas={estimatedFeesPerGas}
-                  networkSettings={swapTransactionSettings.networkSettings}
-                  onNetworkSettingsChange={setNetworkSettings}
-                  onSave={saveSettings}
-                />
+                {EIP_1559_COMPLIANT_CHAIN_IDS.has(currentNetwork.chainID) ? (
+                  <NetworkSettingsSelect
+                    estimatedFeesPerGas={estimatedFeesPerGas}
+                    networkSettings={swapTransactionSettings.networkSettings}
+                    onNetworkSettingsChange={setNetworkSettings}
+                    onSave={saveSettings}
+                  />
+                ) : (
+                  <NetworkSettingsSelectDeprecated
+                    estimatedFeesPerGas={estimatedFeesPerGas}
+                    networkSettings={swapTransactionSettings.networkSettings}
+                    onNetworkSettingsChange={setNetworkSettings}
+                    onSave={saveSettings}
+                  />
+                )}
               </div>
             </div>
           </SharedSlideUpMenu>

--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -41,6 +41,7 @@ import { selectDefaultNetworkFeeSettings } from "@tallyho/tally-background/redux
 import { selectSlippageTolerance } from "@tallyho/tally-background/redux-slices/ui"
 import { isNetworkBaseAsset } from "@tallyho/tally-background/redux-slices/utils/asset-utils"
 import { ReadOnlyAccountSigner } from "@tallyho/tally-background/services/signing"
+import { EIP_1559_COMPLIANT_CHAIN_IDS } from "@tallyho/tally-background/constants"
 import CorePage from "../components/Core/CorePage"
 import SharedAssetInput from "../components/Shared/SharedAssetInput"
 import SharedButton from "../components/Shared/SharedButton"
@@ -338,7 +339,9 @@ export default function Swap(): ReactElement {
             ? { sellAmount: amount }
             : { buyAmount: amount },
         slippageTolerance: swapTransactionSettings.slippageTolerance,
-        gasPrice: swapTransactionSettings.networkSettings.values.maxFeePerGas,
+        gasPrice: EIP_1559_COMPLIANT_CHAIN_IDS.has(selectedNetwork.chainID)
+          ? swapTransactionSettings.networkSettings.values.maxFeePerGas
+          : swapTransactionSettings.networkSettings.values.gasPrice ?? 0n,
         network: selectedNetwork,
       }
 


### PR DESCRIPTION
<img width="387" alt="image" src="https://user-images.githubusercontent.com/94649004/184732140-97ccbcef-e6de-4796-b719-1a7e39827d49.png">

Some things to note:
- Provider.getGasPrice() only gives us the gas price of a transaction on optimism.
- The bulk of an optimism transaction's cost is taken by the security fee - and deducted automatically by the network.
- The total amount a given account pays for a tx is the L2 tx fee plus the L1 security fee - this is what we want to display for the user.
- Optimism provides a contract that allows us to query the total fee in wei of rolling up a given transaction.
- Displaying the cost in `gwei` will be handled in a future PR - this PR only addresses displaying the $ value.
- We certainly need a redesign of the Fee Settings component because while the tx fee is modifiable by the user the security fee is not.  This means that while a user may set their gas cost to `0.0001` gwei in reality they will be paying much more than that because L1 gas prices are typically much higher than L2 ones.  This seems like information that should definitely be presented to the user.

A small reference: https://help.optimism.io/hc/en-us/articles/4411895794715-Transaction-fees


### To Test
- [ ] Try to send a transaction on optimism - the signing screen button should present a reasonable dollar preview.