### PR TITLE
Ensure that thrown errors are instantiated with "new"

### DIFF
--- a/background/services/chain/utils.ts
+++ b/background/services/chain/utils.ts
@@ -266,10 +266,10 @@ export function transactionFromEthersTransaction(
   network: EVMNetwork
 ): AnyEVMTransaction {
   if (tx.hash === undefined) {
-    throw Error("Malformed transaction")
+    throw new Error("Malformed transaction")
   }
   if (tx.type !== 0 && tx.type !== 1 && tx.type !== 2) {
-    throw Error(`Unknown transaction type ${tx.type}`)
+    throw new Error(`Unknown transaction type ${tx.type}`)
   }
 
   const newTx = {

--- a/background/services/ledger/index.ts
+++ b/background/services/ledger/index.ts
@@ -389,7 +389,7 @@ export default class LedgerService extends BaseService<Events> {
           tx.type !== 2 &&
           tx.type !== null
         ) {
-          throw Error(`Unknown transaction type ${tx.type}`)
+          throw new Error(`Unknown transaction type ${tx.type}`)
         }
 
         const signedTx = {


### PR DESCRIPTION
Cleanup some errors that were being thrown without the `new` keyword.