### PR TITLE
Orthogonal Networks: Don't notify dApps when extension account changes

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -1165,10 +1165,6 @@ export default class Main extends BaseService<never> {
         addressNetwork
       )
       this.store.dispatch(setReferrerStats(referrerStats))
-
-      this.providerBridgeService.notifyContentScriptsAboutAddressChange(
-        addressNetwork.address
-      )
     })
 
     uiSliceEmitter.on(


### PR DESCRIPTION
Switching networks in the extension shouldn't impact different dApp connections.

# To Test

- [x] Visit app.uniswap.org and connect to Tally Ho
- [x] Change Tally Ho to Polygon, and make sure Uniswap hasn't switched networks
- [x] Change Tally Ho back to Ethereum, then change Uniswap to Polygon. Ensure the extension is still set to mainnet

Closes #1846