### PR TITLE
Revert "Orthogonal Networks: Don't notify dApps when extension account changes"

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -1165,6 +1165,10 @@ export default class Main extends BaseService<never> {
         addressNetwork
       )
       this.store.dispatch(setReferrerStats(referrerStats))
+
+      this.providerBridgeService.notifyContentScriptsAboutAddressChange(
+        addressNetwork.address
+      )
     })
 
     uiSliceEmitter.on(


### PR DESCRIPTION
Reverts tallycash/extension#1961

https://github.com/tallycash/extension/pull/1961#issuecomment-1216858204

> So the situation after this PR: network is still changing for the dapps if the extension changes network but we have lost the change account functionality.