### PR TITLE
Add page size to Alchemy getNFTs request

### DIFF
--- a/background/lib/alchemy.ts
+++ b/background/lib/alchemy.ts
@@ -328,6 +328,7 @@ export async function getNFTs({
   )
   requestUrl.searchParams.set("owner", address)
   requestUrl.searchParams.set("filters[]", "SPAM")
+  requestUrl.searchParams.set("pageSize", "100")
 
   // TODO validate data with ajv
   const result = await (await fetch(requestUrl.toString())).json()


### PR DESCRIPTION
Resolves #1919
### Why
To prevent Alchemy server errors on really big accounts we need to specify `pageSize` parameter.