### PR TITLE
🔧 Signing and networks improvements

### DIFF
--- a/ui/components/SignData/SignDataInfo.tsx
+++ b/ui/components/SignData/SignDataInfo.tsx
@@ -23,6 +23,8 @@ const SignDataInfo: React.FC<{
         }
         .content {
           color: var(--green-20);
+          word-break: break-word;
+          margin-left: 3px;
         }
       `}</style>
     </>

--- a/ui/components/SignTransaction/SignTransactionNetworkAccountInfoTopBar.tsx
+++ b/ui/components/SignTransaction/SignTransactionNetworkAccountInfoTopBar.tsx
@@ -9,13 +9,15 @@ type Props = {
 export default function SignTransactionNetworkAccountInfoTopBar({
   accountTotal,
 }: Props): ReactElement {
-  const { shortenedAddress, name, avatarURL } = accountTotal
+  const { shortenedAddress, name, avatarURL, network } = accountTotal
 
   return (
     <div className="top_bar_wrap standard_width">
       <div className="row_part">
-        <div className="network_icon" />
-        <span className="network_name">Arbitrum</span>
+        <div className="network_icon_wrap">
+          <div className="network_icon" />
+        </div>
+        <span className="network_name">{network.name}</span>
       </div>
       <div className="row_part">
         <SharedCurrentAccountInformation
@@ -38,8 +40,6 @@ export default function SignTransactionNetworkAccountInfoTopBar({
             font-size: 16px;
             font-weight: 500;
             line-height: 24px;
-            margin-left: 5px;
-            opacity: 0;
           }
           .account_name {
             color: #fff;
@@ -62,11 +62,23 @@ export default function SignTransactionNetworkAccountInfoTopBar({
             background-size: cover;
           }
           .network_icon {
-            background: url("./images/arbitrum_icon_small@2x.png");
+            background: url("./images/networks/${network.name
+              .replaceAll(" ", "")
+              .toLowerCase()}-square@2x.png");
             background-size: cover;
-            width: 15px;
             height: 16px;
-            opacity: 0;
+            width: 16px;
+            border-radius: 4px;
+          }
+          .network_icon_wrap {
+            width: 24px;
+            height: 24px;
+            border-radius: 4px;
+            background-color: var(--green-80);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin-right: 5px;
           }
         `}
       </style>

--- a/ui/pages/DAppConnect/RequestingDApp.tsx
+++ b/ui/pages/DAppConnect/RequestingDApp.tsx
@@ -27,6 +27,7 @@ export default function RequestingDAppBlock(props: {
           width: 48px;
           height: 48px;
           border-radius: 12px;
+          flex-shrink: 0;
         }
         .dapp_title {
           color: #fff;

--- a/ui/pages/PersonalSign.tsx
+++ b/ui/pages/PersonalSign.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement, useState } from "react"
 import {
   getAccountTotal,
   selectCurrentAccountSigner,
+  selectCurrentNetwork,
 } from "@tallyho/tally-background/redux-slices/selectors"
 import {
   rejectDataSignature,
@@ -28,14 +29,17 @@ const TITLE: Record<SignDataMessageType, string> = {
 
 export default function PersonalSignData(): ReactElement {
   const dispatch = useBackgroundDispatch()
-
+  const currentNetwork = useBackgroundSelector(selectCurrentNetwork)
   const signingDataRequest = useBackgroundSelector(selectSigningData)
 
   const history = useHistory()
 
   const signerAccountTotal = useBackgroundSelector((state) => {
     if (typeof signingDataRequest !== "undefined") {
-      return getAccountTotal(state, signingDataRequest.account)
+      return getAccountTotal(state, {
+        address: signingDataRequest.account.address,
+        network: currentNetwork,
+      })
     }
     return undefined
   })

--- a/ui/pages/SignData.tsx
+++ b/ui/pages/SignData.tsx
@@ -2,6 +2,7 @@ import { USE_UPDATED_SIGNING_UI } from "@tallyho/tally-background/features"
 import {
   getAccountTotal,
   selectCurrentAccountSigner,
+  selectCurrentNetwork,
 } from "@tallyho/tally-background/redux-slices/selectors"
 import {
   rejectDataSignature,
@@ -27,12 +28,16 @@ export enum SignDataType {
 export default function SignData(): ReactElement {
   const dispatch = useBackgroundDispatch()
   const typedDataRequest = useBackgroundSelector(selectTypedData)
+  const currentNetwork = useBackgroundSelector(selectCurrentNetwork)
 
   const history = useHistory()
 
   const signerAccountTotal = useBackgroundSelector((state) => {
     if (typeof typedDataRequest !== "undefined") {
-      return getAccountTotal(state, typedDataRequest.account)
+      return getAccountTotal(state, {
+        address: typedDataRequest.account.address,
+        network: currentNetwork,
+      })
     }
     return undefined
   })


### PR DESCRIPTION
Resolves #1895
Relates to #1794

### What

* show the current network on the signing screen - that way we can see what network is selected in a wallet during signing
* fix the problem with data sign and a personal sign that was expecting the wallet to be on the same network as dapp, while [transaction sign was accepting it being on a different network](https://github.com/tallycash/extension/blob/show-network-on-signing-page/ui/pages/SignTransaction.tsx#L37-L43) - ideally wallet should match the network that dapp is expecting but let's unify our implementation first
* fix styles problems on the signing screens