### PR TITLE
Fix error on NFT preview slideup with no image

### DIFF
--- a/ui/components/NFTs/NFTsSlideUpPreviewContent.tsx
+++ b/ui/components/NFTs/NFTsSlideUpPreviewContent.tsx
@@ -35,7 +35,7 @@ export default function NFTsSlideUpPreviewContent({
     network: { chainID },
     contract: { address: contractAddress },
   } = nft
-  const src = media[0].url ?? ""
+  const src = media[0]?.url ?? ""
 
   return (
     <>


### PR DESCRIPTION
### Testing

1. Find NFT with no preview image
2. Click on the NFT

Bug: Unexpected Error
Expected: Opens slideup with selected NFT

![image](https://user-images.githubusercontent.com/20949277/185391681-1f37da20-84ea-4d80-a648-f9a967db9a16.png)
