### PR TITLE
Pass unprefixed hex to Ledger for message signing

### DIFF
--- a/background/services/ledger/index.ts
+++ b/background/services/ledger/index.ts
@@ -527,7 +527,8 @@ export default class LedgerService extends BaseService<Events> {
 
     const signature = await eth.signPersonalMessage(
       accountData.path,
-      hexDataToSign
+      // Ledger requires unprefixed hex, so make sure that's what we pass.
+      hexDataToSign.replace(/^0x/, "")
     )
 
     const signatureHex = joinSignature({


### PR DESCRIPTION
This was introduced in siwe-while-you-sign, and is due to a subtlety of
Buffer.from().toString("hex"), which was swapped out with passing hex data
directly here. Buffer.toString("hex") does not include the 0x prefix,
whereas our hex data does. The Ledger library can't handle that and
blows up.

Fixes #1971.

## Testing

- [x] See test steps in #1971. Make sure both Ledger and internal keyring continue to work correctly.
- [x] Also try to Sign In With Ethereum at https://login.xyz/ . Again, make sure both Ledger and internal keyring continue to work correctly.