### PR TITLE
⚠Warn before sending funds to a known ERC-20 contract

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -77,6 +77,7 @@ import {
   rejectTransactionSignature,
   transactionSigned,
   clearCustomGas,
+  setETHAddressType,
 } from "./redux-slices/transaction-construction"
 import { selectDefaultNetworkFeeSettings } from "./redux-slices/selectors/transactionConstructionSelectors"
 import { allAliases } from "./redux-slices/utils"
@@ -627,6 +628,16 @@ export default class Main extends BaseService<never> {
             })
           )
         }
+      }
+    )
+
+    transactionConstructionSliceEmitter.on(
+      "lookupETHAddressType",
+      async (address: string) => {
+        const isContractAddress =
+          await this.enrichmentService.checkIsEthereumContractAddress(address)
+
+        this.store.dispatch(setETHAddressType([address, isContractAddress]))
       }
     )
 

--- a/background/redux-slices/migrations/index.ts
+++ b/background/redux-slices/migrations/index.ts
@@ -11,12 +11,13 @@ import to11 from "./to-11"
 import to12 from "./to-12"
 import to13 from "./to-13"
 import to14 from "./to-14"
+import to15 from "./to-15"
 
 /**
  * The version of persisted Redux state the extension is expecting. Any previous
  * state without this version, or with a lower version, ought to be migrated.
  */
-export const REDUX_STATE_VERSION = 14
+export const REDUX_STATE_VERSION = 15
 
 /**
  * Common type for all migration functions.
@@ -40,6 +41,7 @@ const allMigrations: { [targetVersion: string]: Migration } = {
   12: to12,
   13: to13,
   14: to14,
+  15: to15,
 }
 
 /**

--- a/background/redux-slices/migrations/to-15.ts
+++ b/background/redux-slices/migrations/to-15.ts
@@ -1,0 +1,42 @@
+type OldState = {
+  transactionConstruction: {
+    status: unknown
+    transactionRequest?: unknown
+    signedTransaction?: unknown
+    broadcastOnSign?: boolean
+    transactionLikelyFails?: boolean
+    estimatedFeesPerGas: unknown
+    customFeesPerGas?: unknown
+    lastGasEstimatesRefreshed: number
+    feeTypeSelected: unknown
+  }
+  [otherSlice: string]: unknown
+}
+
+type NewState = {
+  transactionConstruction: {
+    status: unknown
+    transactionRequest?: unknown
+    signedTransaction?: unknown
+    broadcastOnSign?: boolean
+    transactionLikelyFails?: boolean
+    ETHAddressLookupCache: Record<string, boolean>
+    estimatedFeesPerGas: unknown
+    customFeesPerGas?: unknown
+    lastGasEstimatesRefreshed: number
+    feeTypeSelected: unknown
+  }
+  [otherSlice: string]: unknown
+}
+
+export default (prevState: Record<string, unknown>): NewState => {
+  const { transactionConstruction, ...newState } = prevState as OldState
+
+  return {
+    ...newState,
+    transactionConstruction: {
+      ...transactionConstruction,
+      ETHAddressLookupCache: {},
+    },
+  }
+}

--- a/background/redux-slices/selectors/transactionConstructionSelectors.ts
+++ b/background/redux-slices/selectors/transactionConstructionSelectors.ts
@@ -54,6 +54,12 @@ export const selectBaseAsset = createSelector(
   (baseAsset) => baseAsset
 )
 
+export const selectETHAddressLookupCache = createSelector(
+  (state: { transactionConstruction: TransactionConstruction }) =>
+    state.transactionConstruction.ETHAddressLookupCache,
+  (cache) => cache
+)
+
 export const selectTransactionMainCurrencyPricePoint = createSelector(
   selectBaseAsset, // Base asset for transaction
   getAssetsState,

--- a/background/services/enrichment/index.ts
+++ b/background/services/enrichment/index.ts
@@ -19,6 +19,7 @@ import { enrichEIP2612SignTypedDataRequest, isEIP2612TypedData } from "./utils"
 import { ETHEREUM } from "../../constants"
 
 import resolveTransactionAnnotation from "./transactions"
+import { enrichAddressOnNetwork } from "./addresses"
 
 export * from "./types"
 
@@ -29,6 +30,7 @@ interface Events extends ServiceLifecycleEvents {
   }
   enrichedEVMTransactionSignatureRequest: EnrichedEVMTransactionSignatureRequest
   enrichedSignTypedDataRequest: EnrichedSignTypedDataRequest
+  enrichedETHAddressTypeLookup: boolean
 }
 
 /**
@@ -89,6 +91,16 @@ export default class EnrichmentService extends BaseService<Events> {
         })
       }
     )
+  }
+
+  async checkIsEthereumContractAddress(address: string): Promise<boolean> {
+    const addressDetails = await enrichAddressOnNetwork(
+      this.chainService,
+      this.nameService,
+      { address, network: ETHEREUM }
+    )
+
+    return addressDetails.annotation.hasCode
   }
 
   async enrichTransactionSignature(

--- a/background/services/enrichment/index.ts
+++ b/background/services/enrichment/index.ts
@@ -1,3 +1,4 @@
+import { isAddress } from "ethers/lib/utils"
 import { normalizeHexAddress } from "@tallyho/hd-keyring"
 import { AnyEVMTransaction, EVMNetwork } from "../../networks"
 import { SmartContractFungibleAsset } from "../../assets"
@@ -94,6 +95,8 @@ export default class EnrichmentService extends BaseService<Events> {
   }
 
   async checkIsEthereumContractAddress(address: string): Promise<boolean> {
+    if (!isAddress(address)) return false
+
     const addressDetails = await enrichAddressOnNetwork(
       this.chainService,
       this.nameService,

--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -29,7 +29,8 @@
     "assetAmount": "Asset / Amount",
     "sendTo": "Send To:",
     "sendButton": "Continue",
-    "receiveAddress": "Receive address"
+    "receiveAddress": "Receive address",
+    "sendToContractWarning": "This is a token address, sending assets will result in loss of funds."
   },
   "swap": {
     "title": "Swap Assets",

--- a/ui/pages/Send.tsx
+++ b/ui/pages/Send.tsx
@@ -249,10 +249,7 @@ export default function Send(): ReactElement {
                   color="var(--hunter-green)"
                 />
               </div>
-              <p>
-                This is a token address, sending assets will result in loss of
-                funds.
-              </p>
+              <p>{t("wallet.sendToContractWarning")}</p>
             </div>
           )}
           <div className="send_footer standard_width_padded">


### PR DESCRIPTION
Displays a warning when user inputs a contract address as the destination in the Send Tab

![warning](https://user-images.githubusercontent.com/28708889/183350972-38ac0cae-d557-4526-9943-e82042fa3fbd.gif)

Refs #261
Duplicate of #1901 

## To Test

- [X] Input a contract address like `0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48` (USDC), after loading a warning should appear and the send button should remain disabled.
- [X] Input a normal address, no warning should appear and the send button should work normally again.
- [X] Changing the destination address back to a contract address that previously triggered the warning should not send new requests to the provider until the Send tab is closed.