### PR TITLE
Change z-index for account options menu on the accounts panel

### DIFF
--- a/ui/components/AccountItem/AccountItemOptionsMenu.tsx
+++ b/ui/components/AccountItem/AccountItemOptionsMenu.tsx
@@ -175,6 +175,7 @@ export default function AccountItemOptionsMenu({
             justify-content: space-between;
             width: 212px;
             border-radius: 4px;
+            z-index: 1;
           }
           .option {
             display: flex;


### PR DESCRIPTION
Closes #1957 

This PR fixes layering issue on the accounts panel. Option menu background appears underneath the dots of the row after it. The z-index property has been changed which specifies the stack order of an element. 

**Before:**
![Screenshot 2022-08-24 at 09 05 08](https://user-images.githubusercontent.com/23117945/186353263-6deab6d9-80ab-4638-8b40-fbdfcf86c1b4.png)

**After:**
![Screenshot 2022-08-24 at 09 07 16](https://user-images.githubusercontent.com/23117945/186353458-436b9e83-2888-4ae2-b503-0775d567090a.png)

**To Test** 
- [ ] Go to accounts panel and attempt to open account options when have multiple addresses.
