### PR TITLE
Make a text wrapping for messages in the signing page

### DIFF
--- a/ui/components/SignData/EIP191Info.tsx
+++ b/ui/components/SignData/EIP191Info.tsx
@@ -28,7 +28,7 @@ const EIP191Info: React.FC<{
           margin: 16px;
           font-size: 14px;
           width: 100%;
-          line-break: anywhere;
+          overflow-wrap: anywhere;
         }
         .message-title {
           color: var(--green-40);


### PR DESCRIPTION
Closes #1977 

This PR fixes text cutting issue for messages in the signing page where "transaction" is split in the middle. The` line-break` property was removed. The `overflow-wrap` property has been added with value `anywhere`. The value `normal` is used by default for property `word-break`.

**Before:**
![Screenshot 2022-08-24 at 14 14 06](https://user-images.githubusercontent.com/23117945/186437095-045b75ad-57fe-4c82-bff6-95d747e5e197.png)

**After:**
![Screenshot 2022-08-24 at 14 37 39](https://user-images.githubusercontent.com/23117945/186437124-1af1d8f8-fee2-4db7-bf06-804ad4e627eb.png)


**To test**
- [ ] Go to [mintkudos](https://mintkudos.xyz/) and connect wallet. Check how text is displaying in the signing page.