### PR TITLE
Add timeout to UNS Requests

### DIFF
--- a/background/services/name/resolvers/uns.ts
+++ b/background/services/name/resolvers/uns.ts
@@ -6,9 +6,31 @@ import {
   OPTIMISM,
   POLYGON,
 } from "../../../constants"
+import logger from "../../../lib/logger"
 import { isDefined } from "../../../lib/utils/type-guards"
 import { sameNetwork } from "../../../networks"
 import { NameResolver } from "../name-resolver"
+
+const makeFetchWithTimeout = (timeoutMs: number) => {
+  return async function fetchWithTimeout(
+    requestInfo: RequestInfo,
+    options?: RequestInit | undefined
+  ) {
+    const controller = new AbortController()
+    const id = setTimeout(() => {
+      logger.warn("Request to ", requestInfo, " timed out")
+      return controller.abort()
+    }, timeoutMs)
+    const response = await fetch(requestInfo, {
+      ...options,
+      signal: controller.signal,
+    })
+    clearTimeout(id)
+    return response
+  }
+}
+
+const fetchWithTimeout = makeFetchWithTimeout(3_000)
 
 const UNS_SUPPORTED_NETWORKS = [
   ETHEREUM,
@@ -22,7 +44,7 @@ const UNS_SUPPORTED_NETWORKS = [
  * Lookup a UNS domain name and fetch the owners address
  */
 const lookupUNSDomain = async (domain: string) => {
-  const response = await fetch(
+  const response = await fetchWithTimeout(
     `https://unstoppabledomains.g.alchemy.com/domains/${domain}`,
     {
       method: "GET",
@@ -40,7 +62,7 @@ const lookupUNSDomain = async (domain: string) => {
  * Reverse lookup an address and fetch it's corresponding UNS domain name
  */
 const reverseLookupAddress = async (address: string) => {
-  const response = await fetch(
+  const response = await fetchWithTimeout(
     `https://unstoppabledomains.g.alchemy.com/domains/?owners=${address}&sortBy=id&sortDirection=ASC`,
     {
       method: "GET",


### PR DESCRIPTION
This should alleviate the sometimes painfully slow loading of transaction confirmation screens.

### - To Test
- [ ] Attempt to sign a transaction
- [ ] The TX popup screen should either popup within 3 seconds or should popup after 3 seconds with a message in the console about the UNS request timing out.