### PR TITLE
📖 Conservative View of History: Rely on a single `getAssetTransfers` to pull wallet history in the happy case 

### DIFF
--- a/background/lib/alchemy.ts
+++ b/background/lib/alchemy.ts
@@ -39,13 +39,17 @@ export async function getAssetTransfers(
   provider: AlchemyProvider | AlchemyWebSocketProvider,
   addressOnNetwork: AddressOnNetwork,
   fromBlock: number,
-  toBlock?: number
+  toBlock?: number,
+  order: "asc" | "desc" = "desc",
+  maxCount = 1000
 ): Promise<AssetTransfer[]> {
   const { address: account, network } = addressOnNetwork
 
   const params = {
     fromBlock: utils.hexValue(fromBlock),
     toBlock: toBlock === undefined ? "latest" : utils.hexValue(toBlock),
+    maxCount: utils.hexValue(maxCount),
+    order,
     // excludeZeroValue: false,
   }
 

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -589,7 +589,6 @@ export default class ChainService extends BaseService<Events> {
     // the address has a pending transaction floating around with a nonce that
     // is not an increase by one over previous transactions, this approach will
     // allocate more nonces that won't mine.
-    // TODO Deal with multi-network.
     this.evmChainLastSeenNoncesByNormalizedAddress[chainID][normalizedAddress] =
       Math.max(existingNonce, chainNonce)
 

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -194,15 +194,15 @@ export default class ChainService extends BaseService<Events> {
           this.handleQueuedTransactionAlarm()
         },
       },
-      // historicAssetTransfers: {
-      //   schedule: {
-      //     periodInMinutes: 1,
-      //   },
-      //   handler: () => {
-      //     this.handleHistoricAssetTransferAlarm()
-      //   },
-      //   runAtStart: false,
-      // },
+      historicAssetTransfers: {
+        schedule: {
+          periodInMinutes: 1,
+        },
+        handler: () => {
+          this.handleHistoricAssetTransferAlarm()
+        },
+        runAtStart: false,
+      },
       recentAssetTransfers: {
         schedule: {
           periodInMinutes: 1.5,

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -192,7 +192,7 @@ export default class ChainService extends BaseService<Events> {
       },
       historicAssetTransfers: {
         schedule: {
-          periodInMinutes: 1,
+          periodInMinutes: 60,
         },
         handler: () => {
           this.handleHistoricAssetTransferAlarm()
@@ -698,6 +698,12 @@ export default class ChainService extends BaseService<Events> {
     this.loadRecentAssetTransfers(addressNetwork).catch((e) => {
       logger.error(
         "chainService/addAccountToTrack: Error loading recent asset transfers",
+        e
+      )
+    })
+    this.loadHistoricAssetTransfers(addressNetwork).catch((e) => {
+      logger.error(
+        "chainService/addAccountToTrack: Error loading historic asset transfers",
         e
       )
     })

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -89,10 +89,6 @@ const BLOCKS_FOR_TRANSACTION_HISTORY = 128000
 // OpenEthereum with tracing to catch up to where we are.
 const BLOCKS_TO_SKIP_FOR_TRANSACTION_HISTORY = 20
 
-// The number of asset transfer lookups that will be done per account to rebuild
-// historic activity.
-const HISTORIC_ASSET_TRANSFER_LOOKUPS_PER_ACCOUNT = 10
-
 // The number of milliseconds after a request to look up a transaction was
 // first seen to continue looking in case the transaction fails to be found
 // for either internal (request failure) or external (transaction dropped from
@@ -1002,27 +998,12 @@ export default class ChainService extends BaseService<Events> {
   private async loadHistoricAssetTransfers(
     addressNetwork: AddressOnNetwork
   ): Promise<void> {
-    const oldest = await this.db.getOldestAccountAssetTransferLookup(
-      addressNetwork
-    )
-    const newest = await this.db.getNewestAccountAssetTransferLookup(
-      addressNetwork
-    )
+    const oldest =
+      (await this.db.getOldestAccountAssetTransferLookup(addressNetwork)) ??
+      BigInt(await this.getBlockHeight(addressNetwork.network))
 
-    if (newest !== null && oldest !== null) {
-      const range = newest - oldest
-      if (
-        range <
-        BLOCKS_FOR_TRANSACTION_HISTORY *
-          HISTORIC_ASSET_TRANSFER_LOOKUPS_PER_ACCOUNT
-      ) {
-        // if we haven't hit 10x the single-call limit, pull another.
-        await this.loadAssetTransfers(
-          addressNetwork,
-          oldest - BigInt(BLOCKS_FOR_TRANSACTION_HISTORY),
-          oldest
-        )
-      }
+    if (oldest !== 0n) {
+      await this.loadAssetTransfers(addressNetwork, 0n, oldest)
     }
   }
 

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -1039,12 +1039,11 @@ export default class ChainService extends BaseService<Events> {
     startBlock: bigint,
     endBlock: bigint
   ): Promise<void> {
-    // TODO this will require custom code for Arbitrum and Optimism support
-    // as neither have Alchemy's assetTransfers endpoint
     if (
       addressOnNetwork.network.chainID !== ETHEREUM.chainID &&
       addressOnNetwork.network.chainID !== POLYGON.chainID &&
       addressOnNetwork.network.chainID !== OPTIMISM.chainID &&
+      addressOnNetwork.network.chainID !== ARBITRUM_ONE.chainID &&
       addressOnNetwork.network.chainID !== GOERLI.chainID
     ) {
       logger.error(


### PR DESCRIPTION
Remove the sliding window transfer lookup construct in `ChainService`, instead immediately looking up history when an account is tracked.

While the block height concept isn't absolutely removed for now, in practice in the happy path we should have a single call for a new account's transfer history.

Explicitly out of scope for this PR, though I'd like to address some of these issues in follow-ups
* Intelligent retries/backoffs for the original history pull. The current behavior is a single dumb hourly retry, but doesn't change parameters.
* Removing the dumb hammer-retry logic getting more recent asset transfers.
* Even though I call this a "single call" for history lookups, it's actually 2 — one for incoming and another for outgoing transactions. I'd like to get it down to 1 for new wallets. #2042
* ... and, one day, pulling history based on nonce and chain bisection. Alchemy misses a ton of juicy stuff today, and my hope for this wallet is still to replace EtherScan for the vast majority of use cases... and that means a more consistent history than this or the previous behavior can give us.

# To test

- [x] From a fresh install, load a read-only account with history
- [x] Ensure that over the next 5-10 minutes, the wallet activity list is populated.
- [x] Make sure there aren't any unexpected errors in the background page console

Closes #2031, alternative to #2031