### PR TITLE
Introduce an initial CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Any changes to keyring code deserve extra scrutiny
+/background/services/keyring/* @shadowfiend @mhluongo

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,9 @@
-# Any changes to keyring code deserve extra scrutiny
+# Any changes to keyring code deserve extra scrutiny to prevent key
+# exfiltration and general "roll your own crypto" mistakes. Newer
+# contributions to keyring code should be assumed insecure, requiring
+# agreement across the team to merge.
 /background/services/keyring/* @shadowfiend @mhluongo
+# Any changes to dependencies deserve extra scrutiny to help prevent supply
+# chain attacks
+package.json @0xDaedalus @shadowfiend @mhluongo
+yarn.lock @0xDaedalus @shadowfiend @mhluongo


### PR DESCRIPTION
As the code base continues to mature and more users rely on Tally Ho, we also need to scale our security practices.

As a small step, this PR adds myself and @Shadowfiend as required to sign off on all keyring-related code changes, as well as @0xDaedalus to sign off on dependency graph changes.