### PR TITLE
Cursory View of History: Don't check outgoing asset transfers unless necessary

### DIFF
--- a/background/lib/alchemy.ts
+++ b/background/lib/alchemy.ts
@@ -120,7 +120,7 @@ export async function getAssetTransfers(
           }
         : addressOnNetwork.network.baseAsset
       return {
-        network, // TODO make this friendly across other networks
+        network,
         assetAmount: {
           asset,
           amount: BigInt(transfer.rawContract.value),

--- a/background/services/chain/asset-data-helper.ts
+++ b/background/services/chain/asset-data-helper.ts
@@ -141,7 +141,8 @@ export default class AssetDataHelper {
   async getAssetTransfers(
     addressOnNetwork: AddressOnNetwork,
     startBlock: number,
-    endBlock?: number
+    endBlock?: number,
+    incomingOnly = false
   ): Promise<AssetTransfer[]> {
     const provider = this.providerTracker.providerForNetwork(
       addressOnNetwork.network
@@ -155,22 +156,27 @@ export default class AssetDataHelper {
         provider.currentProvider instanceof AlchemyWebSocketProvider ||
         provider.currentProvider instanceof AlchemyProvider
       ) {
-        return (await Promise.all([
+        const promises = [
           getAlchemyAssetTransfers(
             provider.currentProvider,
             addressOnNetwork,
             "incoming",
             startBlock,
-            endBlock,
+            endBlock
           ),
-          getAlchemyAssetTransfers(
-            provider.currentProvider,
-            addressOnNetwork,
-            "outgoing",
-            startBlock,
-            endBlock,
+        ]
+        if (!incomingOnly) {
+          promises.push(
+            getAlchemyAssetTransfers(
+              provider.currentProvider,
+              addressOnNetwork,
+              "outgoing",
+              startBlock,
+              endBlock
+            )
           )
-        ])).flat()
+        }
+        return (await Promise.all(promises)).flat()
       }
     } catch (error) {
       logger.warn(

--- a/background/services/chain/asset-data-helper.ts
+++ b/background/services/chain/asset-data-helper.ts
@@ -155,12 +155,22 @@ export default class AssetDataHelper {
         provider.currentProvider instanceof AlchemyWebSocketProvider ||
         provider.currentProvider instanceof AlchemyProvider
       ) {
-        return await getAlchemyAssetTransfers(
-          provider.currentProvider,
-          addressOnNetwork,
-          startBlock,
-          endBlock
-        )
+        return (await Promise.all([
+          getAlchemyAssetTransfers(
+            provider.currentProvider,
+            addressOnNetwork,
+            "incoming",
+            startBlock,
+            endBlock,
+          ),
+          getAlchemyAssetTransfers(
+            provider.currentProvider,
+            addressOnNetwork,
+            "outgoing",
+            startBlock,
+            endBlock,
+          )
+        ])).flat()
       }
     } catch (error) {
       logger.warn(

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -936,8 +936,7 @@ export default class ChainService extends BaseService<Events> {
    * **************** */
 
   /**
-   * Load recent asset transfers from an account on a particular network. Backs
-   * off exponentially (in block range, not in time) on failure.
+   * Load recent asset transfers from an account on a particular network.
    *
    * @param addressNetwork the address and network whose asset transfers we need
    * @param incomingOnly if true, only fetch asset transfers received by this
@@ -950,7 +949,7 @@ export default class ChainService extends BaseService<Events> {
     const blockHeight =
       (await this.getBlockHeight(addressNetwork.network)) -
       BLOCKS_TO_SKIP_FOR_TRANSACTION_HISTORY
-    let fromBlock = blockHeight - BLOCKS_FOR_TRANSACTION_HISTORY
+    const fromBlock = blockHeight - BLOCKS_FOR_TRANSACTION_HISTORY
     try {
       return await this.loadAssetTransfers(
         addressNetwork,
@@ -966,36 +965,6 @@ export default class ChainService extends BaseService<Events> {
       )
     }
 
-    // TODO replace the home-spun backoff with a util function
-    fromBlock = blockHeight - Math.floor(BLOCKS_FOR_TRANSACTION_HISTORY / 2)
-    try {
-      return await this.loadAssetTransfers(
-        addressNetwork,
-        BigInt(fromBlock),
-        BigInt(blockHeight)
-      )
-    } catch (err) {
-      logger.error(
-        "Second failure loading recent assets, retrying with shorter block range",
-        addressNetwork,
-        err
-      )
-    }
-
-    fromBlock = blockHeight - Math.floor(BLOCKS_FOR_TRANSACTION_HISTORY / 4)
-    try {
-      return await this.loadAssetTransfers(
-        addressNetwork,
-        BigInt(fromBlock),
-        BigInt(blockHeight)
-      )
-    } catch (err) {
-      logger.error(
-        "Final failure loading recent assets for account",
-        addressNetwork,
-        err
-      )
-    }
     return Promise.resolve()
   }
 

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -703,12 +703,6 @@ export default class ChainService extends BaseService<Events> {
         e
       )
     })
-    this.loadRecentAssetTransfers(addressNetwork).catch((e) => {
-      logger.error(
-        "chainService/addAccountToTrack: Error loading recent asset transfers",
-        e
-      )
-    })
     this.loadHistoricAssetTransfers(addressNetwork).catch((e) => {
       logger.error(
         "chainService/addAccountToTrack: Error loading historic asset transfers",

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -940,9 +940,12 @@ export default class ChainService extends BaseService<Events> {
    * off exponentially (in block range, not in time) on failure.
    *
    * @param addressNetwork the address and network whose asset transfers we need
+   * @param incomingOnly if true, only fetch asset transfers received by this
+   *        address
    */
   private async loadRecentAssetTransfers(
-    addressNetwork: AddressOnNetwork
+    addressNetwork: AddressOnNetwork,
+    incomingOnly = false
   ): Promise<void> {
     const blockHeight =
       (await this.getBlockHeight(addressNetwork.network)) -
@@ -952,7 +955,8 @@ export default class ChainService extends BaseService<Events> {
       return await this.loadAssetTransfers(
         addressNetwork,
         BigInt(fromBlock),
-        BigInt(blockHeight)
+        BigInt(blockHeight),
+        incomingOnly
       )
     } catch (err) {
       logger.error(
@@ -1023,7 +1027,8 @@ export default class ChainService extends BaseService<Events> {
   private async loadAssetTransfers(
     addressOnNetwork: AddressOnNetwork,
     startBlock: bigint,
-    endBlock: bigint
+    endBlock: bigint,
+    incomingOnly = false
   ): Promise<void> {
     if (
       addressOnNetwork.network.chainID !== ETHEREUM.chainID &&
@@ -1042,7 +1047,8 @@ export default class ChainService extends BaseService<Events> {
     const assetTransfers = await this.assetData.getAssetTransfers(
       addressOnNetwork,
       Number(startBlock),
-      Number(endBlock)
+      Number(endBlock),
+      incomingOnly,
     )
 
     await this.db.recordAccountAssetTransferLookup(


### PR DESCRIPTION
Alchemy only supports checking against a "to" or "from" address when calling `getAssetTransfers`... meaning we are often making two API calls per account tracking.

This PR skips checking outgoing asset transfers when possible in `ChainService`. It should reduce `getAssetTransfer` calls by around 45% every 15 minutes (after the initial history load).

# To test

- [ ] Drop a `console.log` in `background/lib/alchemy.ts#getAssetTransfers`. Thanks to this being a call over a websocket, I didn't see an obvious way to instrument in dev tools.
- [ ] Add a read-only account
- [ ] Set a 15 minute timer on your phone :grin: 
- [ ] At the end of the period, count the number of `getAssetTransfer` calls. In my testing against `main`, I saw 40 calls in 15 minutes... and on this branch, 20 calls in 15 minutes. Note that some of that reduction is from the last PR, and my numbers are so high because I have 4 networks turned on (versus two).

Closes #2059