### PR TITLE
Replace .eth.link token lists urls to .eth.limo

### DIFF
--- a/background/services/preferences/db.ts
+++ b/background/services/preferences/db.ts
@@ -158,6 +158,27 @@ export class PreferenceDatabase extends Dexie {
           })
       })
 
+    // Update .eth.link token lists urls to .eth.limo fallback
+    this.version(8)
+      .stores({
+        preferences: "++id",
+      })
+      .upgrade((tx) => {
+        return tx
+          .table("preferences")
+          .toCollection()
+          .modify((storedPreferences: Preferences) => {
+            const updatedURLs = storedPreferences.tokenLists.urls.map((url) =>
+              url.endsWith(".eth.link") ? `${url.slice(0, -9)}.eth.limo` : url
+            )
+            // eslint-disable-next-line no-param-reassign
+            storedPreferences.tokenLists = {
+              ...storedPreferences.tokenLists,
+              urls: updatedURLs,
+            }
+          })
+      })
+
     // This is the old version for populate
     // https://dexie.org/docs/Dexie/Dexie.on.populate-(old-version)
     // The this does not behave according the new docs, but works

--- a/background/services/preferences/defaults.ts
+++ b/background/services/preferences/defaults.ts
@@ -14,8 +14,8 @@ const defaultPreferences: Preferences = {
       "https://gateway.ipfs.io/ipns/tokens.uniswap.org", // the Uniswap default list
       "https://meta.yearn.finance/api/tokens/list", // the Yearn list
       "https://messari.io/tokenlist/messari-verified", // Messari-verified projects
-      "https://wrapped.tokensoft.eth.link", // Wrapped tokens
-      "https://tokenlist.aave.eth.link", // Aave-listed tokens and interest-bearing assets
+      "https://wrapped.tokensoft.eth.limo", // Wrapped tokens
+      "https://tokenlist.aave.eth.limo", // Aave-listed tokens and interest-bearing assets
       "https://raw.githubusercontent.com/compound-finance/token-list/master/compound.tokenlist.json", // Compound-listed tokens and interest-bearing assets
       "https://api-polygon-tokens.polygon.technology/tokenlists/default.tokenlist.json", // Polygon Default Tokens
       "https://static.optimism.io/optimism.tokenlist.json", // Optimism Default Tokens


### PR DESCRIPTION
Updates default and stored token lists URL preferences, the later through a migration

Refs: 
#2039