### PR TITLE
Optimistic Typeguards: Tighten up the EIP1559 tx request type guard

### DIFF
--- a/background/networks.ts
+++ b/background/networks.ts
@@ -376,7 +376,9 @@ export const isEIP1559TransactionRequest = (
     | Partial<PartialTransactionRequestWithFrom>
 ): transactionRequest is EIP1559TransactionRequest =>
   "maxFeePerGas" in transactionRequest &&
-  "maxPriorityFeePerGas" in transactionRequest
+  transactionRequest.maxFeePerGas !== null &&
+  "maxPriorityFeePerGas" in transactionRequest &&
+  transactionRequest.maxPriorityFeePerGas !== null
 
 export const isEIP1559SignedTransaction = (
   signedTransaction: SignedTransaction


### PR DESCRIPTION
Legacy transactions were slipping through, leading to type errors enriching transactions on Optimism.

# To test

- [x] Load a read-only account with tx history on Optimism
- [x] Switch to Optimism
- [x] Wait a while. You should see the wallet activity list populate without the sort of errors seen in #2064

Closes #2064