### PR TITLE
Avoid adding transaction hashes for known asset transfers to the queue of transactions to retrieve.

### DIFF
--- a/background/services/chain/db.ts
+++ b/background/services/chain/db.ts
@@ -174,6 +174,10 @@ export class ChainDatabase extends Dexie {
     )
   }
 
+  async getAllSavedTransactions(): Promise<AnyEVMTransaction[]> {
+    return this.chainTransactions.toArray()
+  }
+
   /**
    * Looks up and returns all pending transactions for the given network.
    */

--- a/background/services/chain/db.ts
+++ b/background/services/chain/db.ts
@@ -1,4 +1,4 @@
-import Dexie from "dexie"
+import Dexie, { IndexableTypeArray } from "dexie"
 
 import { UNIXTime } from "../../types"
 import { AccountBalance, AddressOnNetwork } from "../../accounts"
@@ -174,8 +174,8 @@ export class ChainDatabase extends Dexie {
     )
   }
 
-  async getAllSavedTransactions(): Promise<AnyEVMTransaction[]> {
-    return this.chainTransactions.toArray()
+  async getAllSavedTransactionHashes(): Promise<IndexableTypeArray> {
+    return this.chainTransactions.orderBy("hash").keys()
   }
 
   /**

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -16,7 +16,6 @@ import {
   EIP1559TransactionRequest,
   EVMNetwork,
   BlockPrices,
-  sameNetwork,
   TransactionRequest,
   TransactionRequestWithNonce,
   SignedTransaction,
@@ -1049,8 +1048,6 @@ export default class ChainService extends BaseService<Events> {
     const savedTransactionHashes = new Set(
       await this.db.getAllSavedTransactionHashes()
     )
-
-    console.log({ savedTransactionHashes })
     /// send all new tx hashes into a queue to retrieve + cache
     assetTransfers.forEach((a) => {
       if (!savedTransactionHashes.has(a.txHash)) {

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -1054,7 +1054,7 @@ export default class ChainService extends BaseService<Events> {
         (tx) => `${tx.hash}-${tx.network.chainID}`
       )
     )
-    /// send all found tx hashes into a queue to retrieve + cache
+    /// send all new tx hashes into a queue to retrieve + cache
     assetTransfers.forEach((a) => {
       const cacheKey = `${a.txHash}-${addressOnNetwork.network.chainID}`
       if (!savedTransactionCacheKeys.has(cacheKey)) {


### PR DESCRIPTION
Now that we've moved to an approach of querying a given accounts most recent 1k asset transfers every 90 seconds - we need to ensure that we are not retrieving the same transactions unnecessarily.

Prior to this change - the "transactionsToRetrieve" queue would fill up every 90 seconds even after some transactions were correctly processed via "handleQueuedTransactionAlarm".  The performance hit from that was especially large on accounts with a large asset transfer history due to how we handle determining if a given transaction hash is already in the queue inside of "queueTransactionHashToRetrieve".

### To Test
- [ ] drop the following log [inside of the chain service constructor](https://github.com/tallycash/extension/blob/unnecessary-tx-enrichment/background/services/chain/index.ts#L229)
```
setInterval(() => console.log("Transactions in queue: ", this.transactionsToRetrieve.length), 10_000)
```
- [ ] Load a new account into the wallet and open the logs for the background page.
- [ ] You should see the size of this.transactionsToRetrieve decrease by 5 every minute.