### PR TITLE
Drastically reduce unnecessary enrichment of ERC-20 Transfers.

### DIFF
--- a/background/services/enrichment/transactions.ts
+++ b/background/services/enrichment/transactions.ts
@@ -58,16 +58,9 @@ async function annotationsFromLogs(
   )
   const relevantAddresses = [
     ...new Set(
-      getDistinctRecipentAddressesFromERC20Logs(relevantTransferLogs)
-        .concat(
-          tokenTransferLogs.flatMap<string>(
-            ({ senderAddress, recipientAddress }) => [
-              senderAddress,
-              recipientAddress,
-            ]
-          )
-        )
-        .map(normalizeEVMAddress)
+      getDistinctRecipentAddressesFromERC20Logs(relevantTransferLogs).map(
+        normalizeEVMAddress
+      )
     ),
   ]
 

--- a/background/services/enrichment/transactions.ts
+++ b/background/services/enrichment/transactions.ts
@@ -85,42 +85,58 @@ async function annotationsFromLogs(
       .filter(([, annotation]) => isDefined(annotation))
   )
 
-  const subannotations = tokenTransferLogs.flatMap<TransactionAnnotation>(
-    ({ contractAddress, amount, senderAddress, recipientAddress }) => {
-      // See if the address matches a fungible asset.
-      const matchingFungibleAsset = assets.find(
-        (asset): asset is SmartContractFungibleAsset =>
-          isSmartContractFungibleAsset(asset) &&
-          sameEVMAddress(asset.contractAddress, contractAddress)
+  const subannotations = (
+    await Promise.all(
+      tokenTransferLogs.map(
+        async ({
+          contractAddress,
+          amount,
+          senderAddress,
+          recipientAddress,
+        }) => {
+          // See if the address matches a fungible asset.
+          const matchingFungibleAsset = assets.find(
+            (asset): asset is SmartContractFungibleAsset =>
+              isSmartContractFungibleAsset(asset) &&
+              sameEVMAddress(asset.contractAddress, contractAddress)
+          )
+
+          if (!matchingFungibleAsset) {
+            return undefined
+          }
+
+          // Try to find a resolved annotation for the recipient and sender and otherwise fetch them
+          const recipient =
+            annotationsByAddress[normalizeEVMAddress(recipientAddress)] ??
+            (await enrichAddressOnNetwork(chainService, nameService, {
+              address: recipientAddress,
+              network,
+            }))
+          const sender =
+            annotationsByAddress[normalizeEVMAddress(senderAddress)] ??
+            (await enrichAddressOnNetwork(chainService, nameService, {
+              address: senderAddress,
+              network,
+            }))
+
+          return {
+            type: "asset-transfer" as const,
+            assetAmount: enrichAssetAmountWithDecimalValues(
+              {
+                asset: matchingFungibleAsset,
+                amount,
+              },
+              desiredDecimals
+            ),
+            sender,
+            recipient,
+            timestamp: resolvedTime,
+            blockTimestamp: block?.timestamp,
+          }
+        }
       )
-
-      if (!matchingFungibleAsset) {
-        return []
-      }
-
-      // Try to find a resolved annotation for the recipient and sender
-      const recipient =
-        annotationsByAddress[normalizeEVMAddress(recipientAddress)]
-      const sender = annotationsByAddress[normalizeEVMAddress(senderAddress)]
-
-      return [
-        {
-          type: "asset-transfer",
-          assetAmount: enrichAssetAmountWithDecimalValues(
-            {
-              asset: matchingFungibleAsset,
-              amount,
-            },
-            desiredDecimals
-          ),
-          sender,
-          recipient,
-          timestamp: resolvedTime,
-          blockTimestamp: block?.timestamp,
-        },
-      ]
-    }
-  )
+    )
+  ).filter(isDefined)
 
   return subannotations
 }


### PR DESCRIPTION
Closes #2063 

This PR addresses an issue where transactions producing multiple ERC-20 `Transfer` events were significantly impacting the performance of the extension.

In extreme cases - transactions such as [this one](https://etherscan.io/tx/0x3c712768212cc75eec5329c6d08ed4a4edc679ee5c4553c6433c7b16259816fb) containing thousands of ERC-20 `Transfer's` would cause the extension to attempt to enrich each address involved in the transfer - slowing the extension to a standstill.  This PR aims to keep the desired behavior of enriching addresses involved in ERC-20 `Transfer` events while only enriching the events that are relevant to the accounts loaded into the extension.

### To Test
- [x] load up `mhluongo.eth` into the extension
- [x] open up the background logs
- [ ] go eat a delicious sandwich
- [x] Check the console in 10-15 minutes - you should not see an enormous amount of `429` errors related to querying unstoppabledomains.  Some errors may still be present because of network conditions and whatnot - but nothing like what we see in https://github.com/tallycash/extension/issues/2063
- [x] ERC-20 transactions should properly enrich with ENS/UNS names in wallet activity tab.