### PR TITLE
Support partial subannotation population in the case where one annotation fails.

### DIFF
--- a/background/services/enrichment/transactions.ts
+++ b/background/services/enrichment/transactions.ts
@@ -86,7 +86,7 @@ async function annotationsFromLogs(
   )
 
   const subannotations = (
-    await Promise.all(
+    await Promise.allSettled(
       tokenTransferLogs.map(
         async ({
           contractAddress,
@@ -136,7 +136,10 @@ async function annotationsFromLogs(
         }
       )
     )
-  ).filter(isDefined)
+  )
+    .filter(isFulfilledPromise)
+    .map(({ value }) => value)
+    .filter(isDefined)
 
   return subannotations
 }

--- a/background/services/enrichment/transactions.ts
+++ b/background/services/enrichment/transactions.ts
@@ -62,7 +62,7 @@ async function annotationsFromLogs(
     )
 
   // Look up transfer log names, then flatten to an address -> name map.
-  const annotationsByAddress = Object.fromEntries(
+  const addressEnrichmentsByAddress = Object.fromEntries(
     (
       await Promise.allSettled(
         relevantAddresses.map(
@@ -104,13 +104,15 @@ async function annotationsFromLogs(
 
           // Try to find a resolved annotation for the recipient and sender and otherwise fetch them
           const recipient =
-            annotationsByAddress[normalizeEVMAddress(recipientAddress)] ??
+            addressEnrichmentsByAddress[
+              normalizeEVMAddress(recipientAddress)
+            ] ??
             (await enrichAddressOnNetwork(chainService, nameService, {
               address: recipientAddress,
               network,
             }))
           const sender =
-            annotationsByAddress[normalizeEVMAddress(senderAddress)] ??
+            addressEnrichmentsByAddress[normalizeEVMAddress(senderAddress)] ??
             (await enrichAddressOnNetwork(chainService, nameService, {
               address: senderAddress,
               network,

--- a/background/services/enrichment/transactions.ts
+++ b/background/services/enrichment/transactions.ts
@@ -56,13 +56,10 @@ async function annotationsFromLogs(
     tokenTransferLogs,
     accountAddresses
   )
-  const relevantAddresses = [
-    ...new Set(
-      getDistinctRecipentAddressesFromERC20Logs(relevantTransferLogs).map(
-        normalizeEVMAddress
-      )
-    ),
-  ]
+  const relevantAddresses =
+    getDistinctRecipentAddressesFromERC20Logs(relevantTransferLogs).map(
+      normalizeEVMAddress
+    )
 
   // Look up transfer log names, then flatten to an address -> name map.
   const annotationsByAddress = Object.fromEntries(

--- a/background/services/enrichment/utils.ts
+++ b/background/services/enrichment/utils.ts
@@ -87,13 +87,11 @@ export const getERC20LogsForAddresses = (
   logs: ERC20TransferLog[],
   addresses: string[]
 ): ERC20TransferLog[] => {
-  const relevantAddresses = Object.fromEntries(
-    addresses.map((address) => [address, true])
-  )
+  const relevantAddresses = new Set(addresses)
 
   return logs.filter(
     (log) =>
-      relevantAddresses[normalizeEVMAddress(log.recipientAddress)] ||
-      relevantAddresses[normalizeEVMAddress(log.senderAddress)]
+      relevantAddresses.has(normalizeEVMAddress(log.recipientAddress)) ||
+      relevantAddresses.has(normalizeEVMAddress(log.senderAddress))
   )
 }


### PR DESCRIPTION
This fixes a potential problem where failing to enrich one subannotation from a `Transfer` log prevents all subannotations from populating.