### PR TITLE
Beyond Community Edition: Remove "Community Edition" prefix from bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -51,16 +51,16 @@ body:
       label: Version
       description: What version of the extension are you running?
       options:
-        - Community Edition v0.15.0
-        - Community Edition v0.14.9
-        - Community Edition v0.14.8
-        - Community Edition v0.14.7
-        - Community Edition v0.14.5
-        - Community Edition v0.14.4
-        - Community Edition v0.14.3
-        - Community Edition v0.14.2
-        - Community Edition v0.14.1
-        - Community Edition v0.14.0
+        - v0.15.0
+        - v0.14.9
+        - v0.14.8
+        - v0.14.7
+        - v0.14.5
+        - v0.14.4
+        - v0.14.3
+        - v0.14.2
+        - v0.14.1
+        - v0.14.0
         - Community Edition v0.13.13
         - Community Edition v0.13.12
         - Community Edition v0.13.11

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -20,5 +20,5 @@ echo "$(jq ".version=\"$npm_package_version\"" manifest/manifest.json | yarn -s 
 git add manifest/manifest.json
 
 # Add version to bug template and stage for version bump commit.
-yq e -i '.body[] |= select(has("id")) |= select(.id == "version").attributes.options = ["Community Edition v'$npm_package_version'"] + select(.id == "version").attributes.options' .github/ISSUE_TEMPLATE/BUG.yml
+yq e -i '.body[] |= select(has("id")) |= select(.id == "version").attributes.options = ["v'$npm_package_version'"] + select(.id == "version").attributes.options' .github/ISSUE_TEMPLATE/BUG.yml
 git add .github/ISSUE_TEMPLATE/BUG.yml


### PR DESCRIPTION
We haven't been CE since v0.14.0 😀

# To test

- [x] Run the version bump script and confirm that the new version it adds in `.github/ISSUE_TEMPLATE/BUG.yml` doesn't include the label "Community Edition"