### PR TITLE
More Release Owners: Separate release management from dependency audits

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,7 @@
 /background/services/keyring/* @shadowfiend @mhluongo
 # Any changes to dependencies deserve extra scrutiny to help prevent supply
 # chain attacks
-package.json @0xDaedalus @shadowfiend @mhluongo
-yarn.lock @0xDaedalus @shadowfiend @mhluongo
+package.json @greg-nagy @0xDaedalus @shadowfiend @mhluongo
+yarn.lock @tallycash/extension-dependency-auditors
+# Any changes to code owners deserve extra scrutiny
+.github/CODEOWNERS @shadowfiend @mhluongo


### PR DESCRIPTION
This is closer to my original intent with the `CODEOWNERS` config — keyring code should be hard to change, dependencies should be hard to change, non-dependency releases should be a bit looser.

We should agree on a process for adding people to the @tallycash/extension-dependency-auditors team. The idea here is that anyone who joins it needs to agree that they won't merge without auditing every dependency change... a pretty serious lift / responsibility.