### PR TITLE
Avoid looking up historical transfers for newly created accounts.

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -223,7 +223,8 @@ export default class Main extends BaseService<never> {
 
   static create: ServiceCreatorFunction<never, Main, []> = async () => {
     const preferenceService = PreferenceService.create()
-    const chainService = ChainService.create(preferenceService)
+    const keyringService = KeyringService.create()
+    const chainService = ChainService.create(preferenceService, keyringService)
     const indexingService = IndexingService.create(
       preferenceService,
       chainService
@@ -234,7 +235,6 @@ export default class Main extends BaseService<never> {
       indexingService,
       nameService
     )
-    const keyringService = KeyringService.create()
     const internalEthereumProviderService =
       InternalEthereumProviderService.create(chainService, preferenceService)
     const providerBridgeService = ProviderBridgeService.create(

--- a/background/services/keyring/index.ts
+++ b/background/services/keyring/index.ts
@@ -348,6 +348,10 @@ export default class KeyringService extends BaseService<Events> {
     return newKeyring.id
   }
 
+  /**
+   * Return the source of a given address' keyring if it exists.  If an
+   * address does not have a keyring associated with it - returns null.
+   */
   async getKeyringSourceForAddress(
     address: string
   ): Promise<"import" | "internal" | null> {

--- a/background/services/keyring/index.ts
+++ b/background/services/keyring/index.ts
@@ -348,6 +348,18 @@ export default class KeyringService extends BaseService<Events> {
     return newKeyring.id
   }
 
+  async getKeyringSourceForAddress(
+    address: string
+  ): Promise<"import" | "internal" | null> {
+    try {
+      const keyring = await this.#findKeyring(address)
+      return this.#keyringMetadata[keyring.id].source
+    } catch (e) {
+      // Address is not associated with a keyring
+      return null
+    }
+  }
+
   /**
    * Return an array of keyring representations that can safely be stored and
    * used outside the extension.

--- a/background/tests/factories.ts
+++ b/background/tests/factories.ts
@@ -10,24 +10,26 @@ export const createPreferenceService = async (): Promise<PreferenceService> => {
   return PreferenceService.create()
 }
 
+export const createKeyringService = async (): Promise<KeyringService> => {
+  return KeyringService.create()
+}
+
 type CreateChainServiceOverrides = {
   preferenceService?: Promise<PreferenceService>
+  keyringService?: Promise<KeyringService>
 }
 
 export const createChainService = async (
   overrides: CreateChainServiceOverrides = {}
 ): Promise<ChainService> => {
   return ChainService.create(
-    overrides.preferenceService ?? createPreferenceService()
+    overrides.preferenceService ?? createPreferenceService(),
+    overrides.keyringService ?? createKeyringService()
   )
 }
 
 export const createLedgerService = async (): Promise<LedgerService> => {
   return LedgerService.create()
-}
-
-export const createKeyringService = async (): Promise<KeyringService> => {
-  return KeyringService.create()
 }
 
 type CreateSigningServiceOverrides = {


### PR DESCRIPTION
Closes #2042 

This change should free up some alchemy bandwidth if and when we get an influx of new users similar to last week.

### To Test
- [ ] Load up a fresh extension.
- [ ] Open devtools - go to network tab - press cmd + r - click on one of the websocket connections to alchemy - go to the `Messages` tab.
- [ ] Create a new account.
- [ ] You should not see any `alchemy_getAssetTransfers` messages go out over the connection when creating the account.
- [ ] ~90 seconds after creating the account - you should see an `alchemy_getAssetTransfer` message go out over the connection.