### PR TITLE
👛 You Must Have a Wallet to Have a Default Wallet: Don't set Tally Ho as the default wallet before onboarding

### DIFF
--- a/background/services/preferences/defaults.ts
+++ b/background/services/preferences/defaults.ts
@@ -23,7 +23,7 @@ const defaultPreferences: Preferences = {
     ],
   },
   currency: USD,
-  defaultWallet: true,
+  defaultWallet: false,
   selectedAccount: {
     address: "",
     network: ETHEREUM,

--- a/background/services/preferences/tests/index.integration.test.ts
+++ b/background/services/preferences/tests/index.integration.test.ts
@@ -28,10 +28,10 @@ describe("Preference Service Integration", () => {
 
   describe("setDefaultWalletValue", () => {
     it("should correctly toggle defaultWallet in indexedDB", async () => {
-      // Should default to true
-      expect(await preferenceService.getDefaultWallet()).toEqual(true)
-      await preferenceService.setDefaultWalletValue(false)
+      // Should default to false
       expect(await preferenceService.getDefaultWallet()).toEqual(false)
+      await preferenceService.setDefaultWalletValue(true)
+      expect(await preferenceService.getDefaultWallet()).toEqual(true)
     })
   })
 })


### PR DESCRIPTION
Turn off the "set Tally Ho as default wallet" preference default. This avoids the error where users try to use the wallet before onboarding, and are greeted with a frustrated green screen message.

We have product alignment for this new behavior to avoid churn / uninstalls. There's an ongoing discussion about where to go from here in #2085 that I suggest all who are interested check out.

# To test

- [ ] Download & install [MetaMask](https://metamask.io) 
- [ ] Complete MetaMask onboarding
- [ ] Install Tally Ho, but don't onboard
- [ ] Visit [CowSwap](https://cowswap.exchange/#/swap?chain=mainnet) and connect to MetaMask. Tally Ho shouldn't pop up
- [ ] Onboard with Tally Ho, importing or creating a new wallet. Flip the "use as default wallet" setting to "on"
- [ ] Visit [CowSwap](https://cowswap.exchange/#/swap?chain=mainnet) and connect. "Injected" should be shown instead of MetaMask

Closes #2026