### PR TITLE
Make default account names more random

### DIFF
--- a/background/redux-slices/accounts.ts
+++ b/background/redux-slices/accounts.ts
@@ -120,13 +120,15 @@ function newAccountData(
             (existingAccountsCount % availableDefaultNames.length)
         )
     )
-  const defaultAccountName =
-    sameAccountOnDifferentChain?.defaultName ??
-    availableDefaultNames[defaultNameIndex]
 
-  // Move used default names to the start so they can be skipped above.
-  availableDefaultNames.splice(defaultNameIndex, 1)
-  availableDefaultNames.unshift(defaultAccountName)
+  let defaultAccountName = sameAccountOnDifferentChain?.defaultName
+
+  if (typeof defaultAccountName === "undefined") {
+    defaultAccountName = availableDefaultNames[defaultNameIndex]
+    // Move used default names to the start so they can be skipped above.
+    availableDefaultNames.splice(defaultNameIndex, 1)
+    availableDefaultNames.unshift(defaultAccountName)
+  }
 
   const defaultAccountAvatar = `./images/avatars/${defaultAccountName.toLowerCase()}@2x.png`
 


### PR DESCRIPTION
Resolves #2075

### What
Avoid adding two accounts with the same default name and avatar in the row.
### Testing
Add multiple accounts and check if no two addresses in a row have the same name and avatar