### PR TITLE
Add all new accounts to all networks

### DIFF
--- a/background/redux-slices/accounts.ts
+++ b/background/redux-slices/accounts.ts
@@ -371,8 +371,8 @@ export const resolveNameOnNetwork = createBackgroundAsyncThunk(
  * the promise returned from this action's dispatch will be fulfilled by a void
  * value.
  */
-export const addAddressNetwork = createBackgroundAsyncThunk(
-  "account/addAccount",
+export const addAddressToNetwork = createBackgroundAsyncThunk(
+  "account/addAddressToNetwork",
   async (addressNetwork: AddressOnNetwork, { dispatch, extra: { main } }) => {
     const normalizedAddressNetwork = {
       address: normalizeEVMAddress(addressNetwork.address),
@@ -380,7 +380,14 @@ export const addAddressNetwork = createBackgroundAsyncThunk(
     }
 
     dispatch(loadAccount(normalizedAddressNetwork))
-    await main.addAccount(normalizedAddressNetwork)
+    await main.addAccountToTrack(normalizedAddressNetwork)
+  }
+)
+
+export const addAddressToAllNetworks = createBackgroundAsyncThunk(
+  "account/addAddressToAllNetworks",
+  async (address: string, { extra: { main } }) => {
+    await main.addAccountToAllNetworks(address)
   }
 )
 

--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -3,7 +3,7 @@ import Emittery from "emittery"
 import { AddressOnNetwork } from "../accounts"
 import { ETHEREUM } from "../constants"
 import { EVMNetwork } from "../networks"
-import { AccountState, addAddressNetwork } from "./accounts"
+import { AccountState, addAddressToNetwork } from "./accounts"
 import { createBackgroundAsyncThunk } from "./utils"
 
 const defaultSettings = {
@@ -172,7 +172,7 @@ export const setSelectedNetwork = createBackgroundAsyncThunk(
     if (
       !account.accountsData.evm[network.chainID]?.[ui.selectedAccount.address]
     ) {
-      dispatch(addAddressNetwork({ ...ui.selectedAccount, network }))
+      dispatch(addAddressToNetwork({ ...ui.selectedAccount, network }))
     }
   }
 )

--- a/ui/pages/Onboarding/OnboardingViewOnlyWallet.tsx
+++ b/ui/pages/Onboarding/OnboardingViewOnlyWallet.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useCallback, useState } from "react"
 import { Redirect } from "react-router-dom"
-import { addAddressNetwork } from "@tallyho/tally-background/redux-slices/accounts"
+import { addAddressToAllNetworks } from "@tallyho/tally-background/redux-slices/accounts"
 import { setNewSelectedAccount } from "@tallyho/tally-background/redux-slices/ui"
 import { HexString } from "@tallyho/tally-background/types"
 import { AddressOnNetwork } from "@tallyho/tally-background/accounts"
@@ -38,7 +38,7 @@ export default function OnboardingViewOnlyWallet(): ReactElement {
       return
     }
 
-    await dispatch(addAddressNetwork(addressOnNetwork))
+    await dispatch(addAddressToAllNetworks(addressOnNetwork.address))
     dispatch(setNewSelectedAccount(addressOnNetwork))
     setRedirect(true)
   }, [dispatch, addressOnNetwork])


### PR DESCRIPTION
Resolves #1864

### What
- Add all types of accounts to all supported networks at once.
- Refactor add account methods to avoid code duplication.
### Testing
- add multiple accounts of all types - import, read only, Ledger - to the wallet and make sure they are visible on the accounts list no matter what chain is selected

![image](https://user-images.githubusercontent.com/20949277/187729083-82d5c5d8-d5b2-42c7-92a3-e9b303c029c6.png)
