### PR TITLE
Fix missing activities for read only accounts

### DIFF
--- a/ui/hooks/validation-hooks.ts
+++ b/ui/hooks/validation-hooks.ts
@@ -1,5 +1,8 @@
 import { AddressOnNetwork } from "@tallyho/tally-background/accounts"
-import { isProbablyEVMAddress } from "@tallyho/tally-background/lib/utils"
+import {
+  isProbablyEVMAddress,
+  normalizeEVMAddress,
+} from "@tallyho/tally-background/lib/utils"
 import { resolveNameOnNetwork } from "@tallyho/tally-background/redux-slices/accounts"
 import { selectCurrentAccount } from "@tallyho/tally-background/redux-slices/selectors"
 import { HexString } from "@tallyho/tally-background/types"
@@ -157,7 +160,7 @@ export const useAddressOrNameValidation: AsyncValidationHook<
       if (trimmed === "") {
         onValidChange(undefined)
       } else if (isProbablyEVMAddress(trimmed)) {
-        onValidChange({ address: trimmed })
+        onValidChange({ address: normalizeEVMAddress(trimmed) })
       } else {
         setIsValidating(true)
         validatingValue.current = trimmed


### PR DESCRIPTION
This fixes an issue with imported accounts, where activities never load since the UI slice's selected account stores a dirty address that never gets matched to it's normalized version in the activities slice.

## To test
1. Import this address `0x00976385980F6a03606C29EB97627691d7e3CAA6` or any non normalized address 
2. Activities should show up now