### PR TITLE
Remove dApp permissions with account

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -85,6 +85,7 @@ import {
   requestPermission,
   emitter as providerBridgeSliceEmitter,
   initializePermissions,
+  revokePermissionsForAddress,
 } from "./redux-slices/dapp"
 import logger from "./lib/logger"
 import {
@@ -493,6 +494,9 @@ export default class Main extends BaseService<never> {
   ): Promise<void> {
     this.store.dispatch(deleteAccount(address))
     this.store.dispatch(deleteNFts(address))
+    // remove dApp premissions
+    this.store.dispatch(revokePermissionsForAddress(address))
+    await this.providerBridgeService.revokePermissionsForAddress(address)
     // TODO Adjust to handle specific network.
     await this.signingService.removeAccount(address, signerType)
   }

--- a/background/redux-slices/dapp.ts
+++ b/background/redux-slices/dapp.ts
@@ -92,6 +92,19 @@ const dappSlice = createSlice({
 
       return state
     },
+    revokePermissionsForAddress: (
+      immerState,
+      { payload: address }: { payload: string }
+    ) => {
+      ;[ETHEREUM, POLYGON, OPTIMISM, GOERLI].forEach((network) => {
+        if (immerState.allowed.evm[network.chainID]?.[address]) {
+          const { [address]: _, ...withoutAddressToRemove } =
+            immerState.allowed.evm[network.chainID]
+
+          immerState.allowed.evm[network.chainID] = withoutAddressToRemove
+        }
+      })
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -148,6 +161,10 @@ const dappSlice = createSlice({
   },
 })
 
-export const { requestPermission, initializePermissions } = dappSlice.actions
+export const {
+  requestPermission,
+  initializePermissions,
+  revokePermissionsForAddress,
+} = dappSlice.actions
 
 export default dappSlice.reducer

--- a/background/redux-slices/dapp.ts
+++ b/background/redux-slices/dapp.ts
@@ -96,12 +96,12 @@ const dappSlice = createSlice({
       immerState,
       { payload: address }: { payload: string }
     ) => {
-      ;[ETHEREUM, POLYGON, OPTIMISM, GOERLI].forEach((network) => {
-        if (immerState.allowed.evm[network.chainID]?.[address]) {
+      Object.keys(immerState.allowed.evm).forEach((chainID) => {
+        if (immerState.allowed.evm[chainID]?.[address]) {
           const { [address]: _, ...withoutAddressToRemove } =
-            immerState.allowed.evm[network.chainID]
+            immerState.allowed.evm[chainID]
 
-          immerState.allowed.evm[network.chainID] = withoutAddressToRemove
+          immerState.allowed.evm[chainID] = withoutAddressToRemove
         }
       })
     },
@@ -141,19 +141,13 @@ const dappSlice = createSlice({
         ) => {
           const updatedPermissionRequests = { ...immerState.permissionRequests }
           delete updatedPermissionRequests[permission.origin]
-          ;[ETHEREUM, POLYGON, OPTIMISM, GOERLI].forEach((network) => {
-            if (
-              immerState.allowed.evm[network.chainID]?.[
-                permission.accountAddress
-              ]
-            ) {
+
+          Object.keys(immerState.allowed.evm).forEach((chainID) => {
+            if (immerState.allowed.evm[chainID]?.[permission.accountAddress]) {
               const { [permission.origin]: _, ...withoutOriginToRemove } =
-                immerState.allowed.evm[network.chainID][
-                  permission.accountAddress
-                ]
-              immerState.allowed.evm[network.chainID][
-                permission.accountAddress
-              ] = withoutOriginToRemove
+                immerState.allowed.evm[chainID][permission.accountAddress]
+              immerState.allowed.evm[chainID][permission.accountAddress] =
+                withoutOriginToRemove
             }
           })
         }

--- a/background/services/provider-bridge/db.ts
+++ b/background/services/provider-bridge/db.ts
@@ -135,6 +135,10 @@ export class ProviderBridgeServiceDatabase extends Dexie {
       .delete()
   }
 
+  async deletePermissionByAddress(accountAddress: string): Promise<number> {
+    return this.dAppPermissions.where({ accountAddress }).delete()
+  }
+
   async checkPermission(
     origin: string,
     accountAddress: string,

--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -339,6 +339,11 @@ export default class ProviderBridgeService extends BaseService<Events> {
     this.notifyContentScriptsAboutAddressChange()
   }
 
+  async revokePermissionsForAddress(revokeAddress: string): Promise<void> {
+    await this.db.deletePermissionByAddress(revokeAddress)
+    this.notifyContentScriptsAboutAddressChange()
+  }
+
   async checkPermission(
     origin: string,
     chainID: string


### PR DESCRIPTION
Resolves #1978

### What
When user removes address we should remove its dApp permissions too from db and redux store

### Testing
1. Add a couple of accounts to the wallet
2. Open background script devtools so you can observe how dAppPermissions database is changing 
<img width="1112" alt="image" src="https://user-images.githubusercontent.com/20949277/187916317-bcdf538d-4113-4e82-b847-45c7dfe86577.png">

3. Connect to any dapp - confirm in the UI it is connected on both dapp and wallet side, refresh db and check new connection is saved there
4. Remove address that is connected to the dapp
5. Confirm it is correctly disconnected from dapp and wallet, UI and db
6. Add that address again - it shouldn't be connected to that dapp
7. Confirm dapps connections feature is working as before in general (connect, switch accounts, disconnect, sign tx)