### PR TITLE
Enable Background tracking of Goerli.

### DIFF
--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -30,7 +30,6 @@ import {
 } from "../../constants"
 import {
   SUPPORT_ARBITRUM,
-  SUPPORT_GOERLI,
   SUPPORT_OPTIMISM,
   USE_MAINNET_FORK,
 } from "../../features"
@@ -232,7 +231,7 @@ export default class ChainService extends BaseService<Events> {
     this.supportedNetworks = [
       ETHEREUM,
       POLYGON,
-      ...(SUPPORT_GOERLI ? [GOERLI] : []),
+      GOERLI,
       ...(SUPPORT_ARBITRUM ? [ARBITRUM_ONE] : []),
       ...(SUPPORT_OPTIMISM ? [OPTIMISM] : []),
     ]
@@ -730,7 +729,14 @@ export default class ChainService extends BaseService<Events> {
 
   async getNetworksToTrack(): Promise<EVMNetwork[]> {
     const chainIDs = await this.db.getChainIDsToTrack()
-    return [...chainIDs].map((chainID) => {
+    if (chainIDs.size === 0) {
+      // Temporarily add Goerli to default networks to track.  The
+      // SUPPORT_GOERLI still gates actual use of Goerli.
+      return [ETHEREUM, GOERLI]
+    }
+    // Temporarily add Goerli to default networks to track.  The
+    // SUPPORT_GOERLI still gates actual use of Goerli.
+    return [...chainIDs, GOERLI.chainID].map((chainID) => {
       const network = NETWORK_BY_CHAIN_ID[chainID]
       return network
     })


### PR DESCRIPTION
Enables tracking of the Goerli network in the background.


### To Test
- [x] Load up a new extension or update an existing installation.
- [x] You should see a websocket connection to `eth-goerli.ws.alchemyapi.io` with messages going out over it.