### PR TITLE
Enable Tally users to use Matcha.xyz

### DIFF
--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -20,6 +20,7 @@ import { EventEmitter } from "events"
 //       so let's do this only on the websites that need this feature
 const impersonateMetamaskWhitelist = [
   "opensea.io",
+  "matcha.xyz",
   "bridge.umbria.network",
   "galaxy.eco",
   "dydx.exchange",


### PR DESCRIPTION
matcha.xyz does not play nicely with Tally - so lets add it to our list of websites on which to impersonate metamask.

### To Test
- [ ] Navigate to matcha.xyz.
- [ ] With "Impersonate Metamask" set to off - you should not be able to connect.
- [ ] With "Impersonate Metamask" set to on - you should be able to connect by clicking on the Metamask option.