### PR TITLE
Display current network's base asset earlier in assets list

### DIFF
--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -138,6 +138,18 @@ const computeCombinedAssetAmountsData = (
         return 1
       }
 
+      // Always display the current network's base asset first
+      const networkBaseAsset = currentNetwork.baseAsset
+
+      const leftIsNetworkBaseAsset =
+        networkBaseAsset.symbol === asset1.asset.symbol
+      const rightIsNetworkBaseAsset =
+        networkBaseAsset.symbol === asset2.asset.symbol
+
+      if (leftIsNetworkBaseAsset !== rightIsNetworkBaseAsset) {
+        return leftIsNetworkBaseAsset ? -1 : 1
+      }
+
       const leftIsBaseAsset = asset1.asset.symbol in BASE_ASSETS_BY_SYMBOL
       const rightIsBaseAsset = asset2.asset.symbol in BASE_ASSETS_BY_SYMBOL
 


### PR DESCRIPTION
Closes #2084 

![image](https://user-images.githubusercontent.com/28708889/188248851-b42f780e-f2f5-4158-86bb-0b09b3401c3c.png)


### To Test
- [x] Load an account with both ETH and MATIC (e.g. `0xb23da923a507761cd1561b32cc6a0cc47b345fbc`)
- [x] When using the Ethereum network ETH should be displayed at the top of the list, the same goes for MATIC when the current network is Polygon