### PR TITLE
Change styles for message in the wallet activity list

### DIFF
--- a/ui/components/Shared/SharedButton.tsx
+++ b/ui/components/Shared/SharedButton.tsx
@@ -27,6 +27,7 @@ interface Props {
   showLoadingOnClick: boolean
   isLoading: boolean
   isFormSubmit: boolean
+  style?: React.CSSProperties
 }
 
 interface PropsWithMediumIcon extends Props {
@@ -115,6 +116,7 @@ export default function SharedButton(
     showLoadingOnClick,
     isLoading,
     isFormSubmit,
+    style,
   } = props
 
   const [navigateTo, setNavigateTo] =
@@ -163,6 +165,7 @@ export default function SharedButton(
         { twitter: type === "twitter" }
       )}
       onClick={handleClick}
+      style={style}
     >
       {isShowingLoadingSpinner && (
         <div className="spinner_wrap">

--- a/ui/components/Wallet/WalletActivityList.tsx
+++ b/ui/components/Wallet/WalletActivityList.tsx
@@ -122,7 +122,7 @@ export default function WalletActivityList({
             size="small"
             iconSmall="new-tab"
             onClick={openExplorer}
-            style={{ padding: 0 }}
+            style={{ padding: 0, fontWeight: 400 }}
           >
             {scanWebsite[network.chainID].title}
           </SharedButton>
@@ -133,22 +133,24 @@ export default function WalletActivityList({
             display: flex;
             flex-direction: column;
             align-items: center;
-            color: var(--green-40);
+            color: var(--green-20);
             font-size: 16px;
-            font-weight: 500;
-            line-height: 32px;
+            font-weight: 400;
+            line-height: 24px;
             text-align: center;
           }
           .row {
             display: flex;
             flex-direction: row;
+            align-items: center;
             gap: 8px;
           }
           .hand {
             margin: 10px 0px;
+            font-size: 22px;
           }
           div:last-child {
-            margin-bottom: 25px;
+            margin-bottom: 40px;
           }
         `}</style>
       </span>

--- a/ui/components/Wallet/WalletActivityList.tsx
+++ b/ui/components/Wallet/WalletActivityList.tsx
@@ -120,15 +120,16 @@ export default function WalletActivityList({
           <SharedButton
             type="tertiary"
             size="small"
-            iconMedium="new-tab"
+            iconSmall="new-tab"
             onClick={openExplorer}
+            style={{ padding: 0 }}
           >
             {scanWebsite[network.chainID].title}
           </SharedButton>
         </div>
         <style jsx>{`
           span {
-            width: 316px;
+            width: 100%;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -141,6 +142,7 @@ export default function WalletActivityList({
           .row {
             display: flex;
             flex-direction: row;
+            gap: 8px;
           }
           .hand {
             margin: 10px 0px;


### PR DESCRIPTION
Closes #2074 

This PR fixes styles of "End of activity list" message

**Changes**

- center text
- remove padding for the button
-  reduce the button icon

**UI**

Before

<img width="240" alt="Screenshot 2022-09-05 at 12 16 58" src="https://user-images.githubusercontent.com/23117945/188426412-b4828304-2b06-47c2-9fb6-680973bd3dd8.png">

After
<img width="240" alt="Screenshot 2022-09-05 at 14 29 41" src="https://user-images.githubusercontent.com/23117945/188450002-2ea6a9e6-4c5e-42c4-b6f2-44f78809ba2e.png">

**To Test**

- [ ] Go to the list of activities and check for the message at the end of the list in the middle