### PR TITLE
Change NFTs styles when it is already loaded

### DIFF
--- a/ui/components/NFTs/NFTsImage.tsx
+++ b/ui/components/NFTs/NFTsImage.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames"
-import React, { ReactElement } from "react"
+import React, { ReactElement, useState } from "react"
 
 export default function NFTsImage({
   width,
@@ -14,15 +14,19 @@ export default function NFTsImage({
   src: string
   fit?: string
 }): ReactElement {
+  const [isLoading, setIsLoading] = useState(true)
   return (
     <>
       <img
         loading="lazy"
+        onLoad={() => setIsLoading(false)}
+        className={classNames({
+          loading: isLoading,
+        })}
         alt={alt}
         src={src}
         width={width}
         height={height}
-        className={classNames("loading")}
         onError={({ currentTarget }) => {
           // eslint-disable-next-line no-param-reassign
           currentTarget.onerror = null // prevents looping


### PR DESCRIPTION
Closes #2081 

This PR stops blinking loader animation after NFTs are loaded.

**UI**

Before

<img width="240" alt="Screenshot 2022-09-05 at 12 16 58" src="https://user-images.githubusercontent.com/23117945/188441138-5d4fc24b-8006-413b-acaf-f5c07e23cd16.png">

After

<img width="240" alt="Screenshot 2022-09-05 at 12 08 12" src="https://user-images.githubusercontent.com/23117945/188441103-b258285b-f616-4df9-88b1-fb8289e3b3d6.png">

**To Test**

- [ ] Checkout account with NFTs with transparent backgrounds - for example Unstoppable Domains Animals collection. When the NFT image is loaded, the blinking loader animation will stop