### PR TITLE
Make Single Asset Etherscan link Network Aware

### DIFF
--- a/ui/pages/SingleAsset.tsx
+++ b/ui/pages/SingleAsset.tsx
@@ -4,6 +4,7 @@ import {
   selectCurrentAccountActivitiesWithTimestamps,
   selectCurrentAccountBalances,
   selectCurrentAccountSigner,
+  selectCurrentNetwork,
 } from "@tallyho/tally-background/redux-slices/selectors"
 import { normalizeEVMAddress } from "@tallyho/tally-background/lib/utils"
 import {
@@ -17,6 +18,7 @@ import SharedButton from "../components/Shared/SharedButton"
 import WalletActivityList from "../components/Wallet/WalletActivityList"
 import SharedBackButton from "../components/Shared/SharedBackButton"
 import SharedTooltip from "../components/Shared/SharedTooltip"
+import { scanWebsite } from "../utils/constants"
 
 export default function SingleAsset(): ReactElement {
   const location = useLocation<AnyAsset>()
@@ -28,6 +30,7 @@ export default function SingleAsset(): ReactElement {
       : undefined
 
   const currentAccountSigner = useBackgroundSelector(selectCurrentAccountSigner)
+  const currentNetwork = useBackgroundSelector(selectCurrentNetwork)
 
   const filteredActivities = useBackgroundSelector((state) =>
     (selectCurrentAccountActivitiesWithTimestamps(state) ?? []).filter(
@@ -102,7 +105,9 @@ export default function SingleAsset(): ReactElement {
                   IconComponent={() => (
                     <a
                       className="new_tab_link"
-                      href={`https://etherscan.io/token/${contractAddress}`}
+                      href={`${
+                        scanWebsite[currentNetwork.chainID].url
+                      }/token/${contractAddress}`}
                       target="_blank"
                       rel="noreferrer"
                     >
@@ -110,7 +115,7 @@ export default function SingleAsset(): ReactElement {
                     </a>
                   )}
                 >
-                  View asset on Etherscan
+                  View asset on {scanWebsite[currentNetwork.chainID].title}
                 </SharedTooltip>
               ) : (
                 <></>


### PR DESCRIPTION
<img width="374" alt="image" src="https://user-images.githubusercontent.com/94649004/188702223-15d5528f-71fd-4054-b3d2-d5dd055ff388.png">


### To Test
- [x] Select an asset on Optimism - click the etherscan link - it should link to optimistic.etherscan.io
- [x] Select an asset on Polygon - click the polygonscan link - it should like to polygonscan.com