### PR TITLE
Add new galaxy url to metamask impersonation list

### DIFF
--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -23,6 +23,7 @@ const impersonateMetamaskWhitelist = [
   "matcha.xyz",
   "bridge.umbria.network",
   "galaxy.eco",
+  "galxe.com",
   "dydx.exchange",
 ]
 


### PR DESCRIPTION
### To Test
- [x] Have Metamask Installed alongside Tally
- [x] Set Tally to Default
- [x] Visit https://galxe.com/
- [x] tally connect prompt should pop up instead of metamask connect prompt