### PR TITLE
Enrichment Interaction: Annotate "to" address on transactions, not "from"

### DIFF
--- a/background/services/enrichment/transactions.ts
+++ b/background/services/enrichment/transactions.ts
@@ -225,16 +225,11 @@ export default async function resolveTransactionAnnotation(
       // If the tx has no data, it's either a simple ETH send, or it's relying
       // on a contract that's `payable` to execute code
 
-      const [recipient, sender] = await Promise.all([
-        enrichAddressOnNetwork(chainService, nameService, {
-          address: transaction.to,
-          network,
-        }),
-        enrichAddressOnNetwork(chainService, nameService, {
-          address: transaction.from,
-          network,
-        }),
-      ])
+      const recipient = txAnnotation.contractInfo
+      const sender = await enrichAddressOnNetwork(chainService, nameService, {
+        address: transaction.from,
+        network,
+      })
 
       // This is _almost certainly_ not a contract interaction, move on. Note that
       // a simple ETH send to a contract address can still effectively be a

--- a/background/services/enrichment/transactions.ts
+++ b/background/services/enrichment/transactions.ts
@@ -163,11 +163,7 @@ export default async function resolveTransactionAnnotation(
   let txAnnotation: TransactionAnnotation = {
     blockTimestamp: undefined,
     timestamp: Date.now(),
-    type: "contract-interaction",
-    contractInfo: await enrichAddressOnNetwork(chainService, nameService, {
-      address: transaction.from,
-      network,
-    }),
+    type: "contract-deployment",
   }
 
   let block: AnyEVMBlock | undefined
@@ -209,149 +205,164 @@ export default async function resolveTransactionAnnotation(
     }
   }
 
-  // If the tx is missing a recipient, its a contract deployment.
-  if (typeof transaction.to === "undefined") {
+  // If the tx has a recipient, its a contract interaction or another tx type
+  // rather than a deployment.
+  if (typeof transaction.to !== "undefined") {
     txAnnotation = {
       ...txAnnotation,
-      type: "contract-deployment",
-    }
-  } else if (
-    transaction.input === null ||
-    transaction.input === "0x" ||
-    typeof transaction.input === "undefined"
-  ) {
-    // If the tx has no data, it's either a simple ETH send, or it's relying
-    // on a contract that's `payable` to execute code
-
-    const [recipient, sender] = await Promise.all([
-      enrichAddressOnNetwork(chainService, nameService, {
+      type: "contract-interaction",
+      contractInfo: await enrichAddressOnNetwork(chainService, nameService, {
         address: transaction.to,
         network,
       }),
-      enrichAddressOnNetwork(chainService, nameService, {
-        address: transaction.from,
-        network,
-      }),
-    ])
-
-    // This is _almost certainly_ not a contract interaction, move on. Note that
-    // a simple ETH send to a contract address can still effectively be a
-    // contract interaction (because it calls the fallback function on the
-    // contract), but for now we deliberately ignore that scenario when
-    // categorizing activities.
-    // TODO We can do more here by checking how much gas was spent. Anything
-    // over the 21k required to send ETH is a more complex contract interaction
-    if (typeof transaction.value !== "undefined") {
-      // Warn if we're sending ETH to a contract. This is normal if you're
-      // funding a multisig or exchange, but it's good to double check
-      if (recipient.annotation.hasCode) {
-        txAnnotation.warnings ??= []
-        txAnnotation.warnings.push("send-to-contract")
-      }
-
-      txAnnotation = {
-        ...txAnnotation,
-        type: "asset-transfer",
-        sender,
-        recipient,
-        assetAmount: enrichAssetAmountWithDecimalValues(
-          {
-            asset: network.baseAsset,
-            amount: transaction.value,
-          },
-          desiredDecimals
-        ),
-      }
     }
-  } else {
-    const assets = await indexingService.getCachedAssets(network)
 
-    // See if the address matches a fungible asset.
-    const matchingFungibleAsset = assets.find(
-      (asset): asset is SmartContractFungibleAsset =>
-        isSmartContractFungibleAsset(asset) &&
-        sameEVMAddress(asset.contractAddress, transaction.to)
-    )
-
-    const transactionLogoURL = matchingFungibleAsset?.metadata?.logoURL
-
-    const erc20Tx = parseERC20Tx(transaction.input)
-
-    // TODO handle the case where we don't have asset metadata already
     if (
-      matchingFungibleAsset &&
-      erc20Tx &&
-      (erc20Tx.name === "transfer" || erc20Tx.name === "transferFrom")
+      transaction.input === null ||
+      transaction.input === "0x" ||
+      typeof transaction.input === "undefined"
     ) {
-      const [sender, recipient] = await Promise.all([
+      // If the tx has no data, it's either a simple ETH send, or it's relying
+      // on a contract that's `payable` to execute code
+
+      const [recipient, sender] = await Promise.all([
         enrichAddressOnNetwork(chainService, nameService, {
-          address: erc20Tx.args.from ?? transaction.from,
+          address: transaction.to,
           network,
         }),
         enrichAddressOnNetwork(chainService, nameService, {
-          address: erc20Tx.args.to,
+          address: transaction.from,
           network,
         }),
       ])
 
-      // We have an ERC-20 transfer
-      txAnnotation = {
-        ...txAnnotation,
-        type: "asset-transfer",
-        transactionLogoURL,
-        sender,
-        recipient,
-        assetAmount: enrichAssetAmountWithDecimalValues(
-          {
-            asset: matchingFungibleAsset,
-            amount: BigInt(erc20Tx.args.amount),
-          },
-          desiredDecimals
-        ),
-      }
-      // Warn if we're sending the token to its own contract
-      if (sameEVMAddress(erc20Tx.args.to, transaction.to)) {
-        txAnnotation.warnings ??= []
-        txAnnotation.warnings.push("send-to-token")
-      }
-      // Warn if we're sending the token to a contract. This is normal if
-      // you're funding a multisig or exchange, but it's good to double check
-      if (recipient.annotation.hasCode) {
-        txAnnotation.warnings ??= []
-        txAnnotation.warnings.push("send-to-contract")
-      }
-    } else if (matchingFungibleAsset && erc20Tx && erc20Tx.name === "approve") {
-      const spender = await enrichAddressOnNetwork(chainService, nameService, {
-        address: erc20Tx.args.spender,
-        network,
-      })
-      // Warn if we're approving spending to a likely EOA. Note this will also
-      // sweep up CREATE2 contracts that haven't yet been deployed
-      if (!spender.annotation.hasCode) {
-        txAnnotation.warnings ??= []
-        txAnnotation.warnings.push("approve-eoa")
-      }
-      txAnnotation = {
-        ...txAnnotation,
-        type: "asset-approval",
-        transactionLogoURL,
-        spender,
-        assetAmount: enrichAssetAmountWithDecimalValues(
-          {
-            asset: matchingFungibleAsset,
-            amount: BigInt(erc20Tx.args.value),
-          },
-          desiredDecimals
-        ),
+      // This is _almost certainly_ not a contract interaction, move on. Note that
+      // a simple ETH send to a contract address can still effectively be a
+      // contract interaction (because it calls the fallback function on the
+      // contract), but for now we deliberately ignore that scenario when
+      // categorizing activities.
+      // TODO We can do more here by checking how much gas was spent. Anything
+      // over the 21k required to send ETH is a more complex contract interaction
+      if (typeof transaction.value !== "undefined") {
+        // Warn if we're sending ETH to a contract. This is normal if you're
+        // funding a multisig or exchange, but it's good to double check
+        if (recipient.annotation.hasCode) {
+          txAnnotation.warnings ??= []
+          txAnnotation.warnings.push("send-to-contract")
+        }
+
+        txAnnotation = {
+          ...txAnnotation,
+          type: "asset-transfer",
+          sender,
+          recipient,
+          assetAmount: enrichAssetAmountWithDecimalValues(
+            {
+              asset: network.baseAsset,
+              amount: transaction.value,
+            },
+            desiredDecimals
+          ),
+        }
       }
     } else {
-      // Fall back on a standard contract interaction.
-      txAnnotation = {
-        ...txAnnotation,
-        // Include the logo URL if we resolve it even if the interaction is
-        // non-specific; the UI can choose to use it or not, but if we know the
-        // address has an associated logo it's worth passing on.
-        transactionLogoURL,
+      const assets = await indexingService.getCachedAssets(network)
+
+      // See if the address matches a fungible asset.
+      const matchingFungibleAsset = assets.find(
+        (asset): asset is SmartContractFungibleAsset =>
+          isSmartContractFungibleAsset(asset) &&
+          sameEVMAddress(asset.contractAddress, transaction.to)
+      )
+
+      const transactionLogoURL = matchingFungibleAsset?.metadata?.logoURL
+
+      const erc20Tx = parseERC20Tx(transaction.input)
+
+      // TODO handle the case where we don't have asset metadata already
+      if (
+        matchingFungibleAsset &&
+        erc20Tx &&
+        (erc20Tx.name === "transfer" || erc20Tx.name === "transferFrom")
+      ) {
+        const [sender, recipient] = await Promise.all([
+          enrichAddressOnNetwork(chainService, nameService, {
+            address: erc20Tx.args.from ?? transaction.from,
+            network,
+          }),
+          enrichAddressOnNetwork(chainService, nameService, {
+            address: erc20Tx.args.to,
+            network,
+          }),
+        ])
+
+        // We have an ERC-20 transfer
+        txAnnotation = {
+          ...txAnnotation,
+          type: "asset-transfer",
+          transactionLogoURL,
+          sender,
+          recipient,
+          assetAmount: enrichAssetAmountWithDecimalValues(
+            {
+              asset: matchingFungibleAsset,
+              amount: BigInt(erc20Tx.args.amount),
+            },
+            desiredDecimals
+          ),
+        }
+        // Warn if we're sending the token to its own contract
+        if (sameEVMAddress(erc20Tx.args.to, transaction.to)) {
+          txAnnotation.warnings ??= []
+          txAnnotation.warnings.push("send-to-token")
+        }
+        // Warn if we're sending the token to a contract. This is normal if
+        // you're funding a multisig or exchange, but it's good to double check
+        if (recipient.annotation.hasCode) {
+          txAnnotation.warnings ??= []
+          txAnnotation.warnings.push("send-to-contract")
+        }
+      } else if (
+        matchingFungibleAsset &&
+        erc20Tx &&
+        erc20Tx.name === "approve"
+      ) {
+        const spender = await enrichAddressOnNetwork(
+          chainService,
+          nameService,
+          {
+            address: erc20Tx.args.spender,
+            network,
+          }
+        )
+        // Warn if we're approving spending to a likely EOA. Note this will also
+        // sweep up CREATE2 contracts that haven't yet been deployed
+        if (!spender.annotation.hasCode) {
+          txAnnotation.warnings ??= []
+          txAnnotation.warnings.push("approve-eoa")
+        }
+        txAnnotation = {
+          ...txAnnotation,
+          type: "asset-approval",
+          transactionLogoURL,
+          spender,
+          assetAmount: enrichAssetAmountWithDecimalValues(
+            {
+              asset: matchingFungibleAsset,
+              amount: BigInt(erc20Tx.args.value),
+            },
+            desiredDecimals
+          ),
+        }
+      } else {
+        // Fall back on a standard contract interaction.
+        txAnnotation = {
+          ...txAnnotation,
+          // Include the logo URL if we resolve it even if the interaction is
+          // non-specific; the UI can choose to use it or not, but if we know the
+          // address has an associated logo it's worth passing on.
+          transactionLogoURL,
+        }
       }
     }
   }


### PR DESCRIPTION
Pretty sure wallet users know enough about their own wallet 😀

# To Test

- [ ] Try to swap from a wallet with an ENS or UNS name on mainnet
- [ ] In the confirmation page, the "Interacting with" field should be "Ox Router", rather than the wallet's ENS or UNS name

Closes #2131

