### PR TITLE
Fix In-wallet selected network affecting gas preview

### DIFF
--- a/background/redux-slices/selectors/transactionConstructionSelectors.ts
+++ b/background/redux-slices/selectors/transactionConstructionSelectors.ts
@@ -10,12 +10,25 @@ import { getAssetsState } from "./accountsSelectors"
 import { selectMainCurrencySymbol } from "./uiSelectors"
 import { selectAssetPricePoint } from "../assets"
 
+export const selectTransactionNetwork = createSelector(
+  (state: { transactionConstruction: TransactionConstruction }) =>
+    state.transactionConstruction.transactionRequest?.network,
+  (network) => network
+)
+
 export const selectDefaultNetworkFeeSettings = createSelector(
   (state: { transactionConstruction: TransactionConstruction }) =>
     state.transactionConstruction,
   (state: { networks: NetworksState }) => state.networks,
   selectCurrentNetwork,
-  (transactionConstruction, networks, currentNetwork): NetworkFeeSettings => {
+  selectTransactionNetwork,
+  (
+    transactionConstruction,
+    networks,
+    selectedNetwork,
+    transactionNetwork
+  ): NetworkFeeSettings => {
+    const currentNetwork = transactionNetwork || selectedNetwork
     const selectedFeesPerGas =
       transactionConstruction.estimatedFeesPerGas?.[currentNetwork.chainID]?.[
         transactionConstruction.feeTypeSelected
@@ -38,8 +51,12 @@ export const selectDefaultNetworkFeeSettings = createSelector(
 export const selectEstimatedFeesPerGas = createSelector(
   (state: { transactionConstruction: TransactionConstruction }) =>
     state.transactionConstruction.estimatedFeesPerGas,
+  selectTransactionNetwork,
   selectCurrentNetwork,
-  (gasData, selectedNetwork) => gasData[selectedNetwork.chainID]
+  (gasData, transactionNetwork, selectedNetwork) =>
+    transactionNetwork
+      ? gasData[transactionNetwork.chainID]
+      : gasData[selectedNetwork.chainID]
 )
 
 export const selectFeeType = createSelector(

--- a/ui/components/NetworkFees/FeeSettingsText.tsx
+++ b/ui/components/NetworkFees/FeeSettingsText.tsx
@@ -98,9 +98,10 @@ export default function FeeSettingsText({
 }: {
   customNetworkSetting?: NetworkFeeSettings
 }): ReactElement {
-  const currentNetwork = useBackgroundSelector(selectCurrentNetwork)
-  const estimatedFeesPerGas = useBackgroundSelector(selectEstimatedFeesPerGas)
   const transactionData = useBackgroundSelector(selectTransactionData)
+  const selectedNetwork = useBackgroundSelector(selectCurrentNetwork)
+  const currentNetwork = transactionData?.network || selectedNetwork
+  const estimatedFeesPerGas = useBackgroundSelector(selectEstimatedFeesPerGas)
   let networkSettings = useBackgroundSelector(selectDefaultNetworkFeeSettings)
   networkSettings = customNetworkSetting ?? networkSettings
   const baseFeePerGas =


### PR DESCRIPTION
This PR fixes a regression where having `Ethereum` selected as the network while transacting on Optimism or Polygon through a dapp showed erroneous gas price previews

<img width="1204" alt="image" src="https://user-images.githubusercontent.com/94649004/189163631-eb7ebd19-911f-49f0-8b9a-27a0136bd74d.png">

### To Test
- [x] Make sure you have the `Ethereum` network selected in wallet
- [x] Setup a optimism swap on Uniswap
- [x] The transaction preview button should show a reasonable estimate (you can check https://l2fees.info/ to see what is reasonable).  

Sometimes l2fees.info is quite slow to update but as long as you're not seeing a dollar cost above $2 then this fix is working as intended.