### PR TITLE
Display uniswap contract name when signing optimism transactions on uniswap

### DIFF
--- a/background/services/preferences/index.ts
+++ b/background/services/preferences/index.ts
@@ -6,7 +6,7 @@ import { Preferences, TokenListPreferences } from "./types"
 import { getOrCreateDB, PreferenceDatabase } from "./db"
 import BaseService from "../base"
 import { normalizeEVMAddress } from "../../lib/utils"
-import { ETHEREUM } from "../../constants"
+import { ETHEREUM, OPTIMISM } from "../../constants"
 import { EVMNetwork, sameNetwork } from "../../networks"
 import { HexString } from "../../types"
 
@@ -30,6 +30,12 @@ const BUILT_IN_CONTRACTS = [
   },
   {
     network: ETHEREUM,
+    // Uniswap v3 Router
+    address: normalizeEVMAddress("0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45"),
+    name: "🦄 Uniswap",
+  },
+  {
+    network: OPTIMISM,
     // Uniswap v3 Router
     address: normalizeEVMAddress("0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45"),
     name: "🦄 Uniswap",


### PR DESCRIPTION
<img width="384" alt="image" src="https://user-images.githubusercontent.com/94649004/189175688-feab96f9-07a8-4e33-92e0-d0228dda6f5e.png">

### To Test
- [ ] Setup an optimism swap on uniswap.
- [ ] The `Send to` field should show `🦄 Uniswap`