### PR TITLE
⏱ Pending transaction fixes

### DIFF
--- a/background/redux-slices/utils/activity-utils.ts
+++ b/background/redux-slices/utils/activity-utils.ts
@@ -3,6 +3,11 @@ import { ConfirmedEVMTransaction } from "../../networks"
 import { EnrichedEVMTransaction } from "../../services/enrichment"
 import { HexString } from "../../types"
 
+enum TxStatus {
+  FAIL = 0,
+  SUCCESS = 1,
+}
+
 type FieldAdapter = {
   readableName: string
   transformer: (tx: EnrichedEVMTransaction) => string
@@ -73,12 +78,19 @@ function blockHeightTransformer(
   blockHeight: number | null,
   status: number | undefined
 ): string {
-  if (blockHeight !== null && status !== undefined && status !== 1)
+  if (
+    blockHeight !== null &&
+    status !== undefined &&
+    status !== TxStatus.SUCCESS
+  ) {
     return "(failed)"
-
-  if (blockHeight !== null) return blockHeight.toString()
-
-  if (blockHeight === null && status === 0) return "(dropped)"
+  }
+  if (blockHeight !== null) {
+    return blockHeight.toString()
+  }
+  if (blockHeight === null && status === TxStatus.FAIL) {
+    return "(dropped)"
+  }
 
   return "(pending)"
 }

--- a/background/redux-slices/utils/activity-utils.ts
+++ b/background/redux-slices/utils/activity-utils.ts
@@ -69,8 +69,18 @@ function gweiTransformer(value: bigint | null | undefined): string {
   return `${weiToGwei(value) || "0"} Gwei`
 }
 
-function blockHeightTransformer(blockHeight: number | null): string {
-  return blockHeight === null ? "(pending)" : blockHeight.toString()
+function blockHeightTransformer(
+  blockHeight: number | null,
+  status: number | undefined
+): string {
+  if (blockHeight !== null && status !== undefined && status !== 1)
+    return "(failed)"
+
+  if (blockHeight !== null) return blockHeight.toString()
+
+  if (blockHeight === null && status === 0) return "(dropped)"
+
+  return "(pending)"
 }
 
 function toStringTransformer(value: bigint | number): string {
@@ -126,7 +136,11 @@ export function adaptForUI(
 export const keysMap: UIAdaptationMap = {
   blockHeight: {
     readableName: "Block Height",
-    transformer: (tx) => blockHeightTransformer(tx.blockHeight),
+    transformer: (tx) =>
+      blockHeightTransformer(
+        tx.blockHeight,
+        "status" in tx ? tx.status : undefined
+      ),
     detailTransformer: () => "",
   },
   value: {

--- a/ui/components/SignTransaction/SignTransactionContainer.tsx
+++ b/ui/components/SignTransaction/SignTransactionContainer.tsx
@@ -26,6 +26,7 @@ export default function SignTransactionContainer({
   reviewPanel,
   extraPanel,
   confirmButtonLabel,
+  canConfirm,
   handleConfirm,
   handleReject,
   isTransactionSigning,
@@ -38,6 +39,7 @@ export default function SignTransactionContainer({
   reviewPanel: ReactNode
   extraPanel: ReactNode
   confirmButtonLabel: ReactNode
+  canConfirm: boolean
   handleConfirm: () => void
   handleReject: () => void
   isTransactionSigning: boolean
@@ -158,7 +160,9 @@ export default function SignTransactionContainer({
                 onClick={handleConfirm}
                 showLoadingOnClick
                 isDisabled={
-                  isOnDelayToSign || warnings.includes("insufficient-funds")
+                  isOnDelayToSign ||
+                  !canConfirm ||
+                  warnings.includes("insufficient-funds")
                 }
               >
                 {confirmButtonLabel}

--- a/ui/pages/PersonalSign.tsx
+++ b/ui/pages/PersonalSign.tsx
@@ -71,9 +71,12 @@ export default function PersonalSignData(): ReactElement {
     return <></>
   }
 
+  const canConfirm =
+    currentAccountSigner !== ReadOnlyAccountSigner &&
+    signingDataRequest !== undefined
+
   const handleConfirm = () => {
-    if (currentAccountSigner === ReadOnlyAccountSigner) return
-    if (signingDataRequest === undefined) return
+    if (!canConfirm) return
 
     dispatch(
       signData({
@@ -93,6 +96,7 @@ export default function PersonalSignData(): ReactElement {
     <SignTransactionContainer
       signerAccountTotal={signerAccountTotal}
       confirmButtonLabel="Sign"
+      canConfirm={canConfirm}
       handleConfirm={handleConfirm}
       handleReject={handleReject}
       title={TITLE[signingDataRequest.messageType]}

--- a/ui/pages/SignData.tsx
+++ b/ui/pages/SignData.tsx
@@ -63,20 +63,20 @@ export default function SignData(): ReactElement {
 
   if (isLocked) return <></>
 
+  const canConfirm =
+    typedDataRequest !== undefined &&
+    currentAccountSigner &&
+    currentAccountSigner !== ReadOnlyAccountSigner
+
   const handleConfirm = () => {
-    if (typedDataRequest !== undefined) {
-      if (
-        currentAccountSigner &&
-        currentAccountSigner !== ReadOnlyAccountSigner
-      ) {
-        dispatch(
-          signTypedData({
-            request: typedDataRequest,
-            accountSigner: currentAccountSigner,
-          })
-        )
-        setIsTransactionSigning(true)
-      }
+    if (canConfirm) {
+      dispatch(
+        signTypedData({
+          request: typedDataRequest,
+          accountSigner: currentAccountSigner,
+        })
+      )
+      setIsTransactionSigning(true)
     }
 
     // We need to send user to the previous page after signing data is completed
@@ -99,6 +99,7 @@ export default function SignData(): ReactElement {
     <SignTransactionContainer
       signerAccountTotal={signerAccountTotal}
       confirmButtonLabel="Confirm"
+      canConfirm={canConfirm}
       handleConfirm={handleConfirm}
       handleReject={handleReject}
       title={getTitle()}

--- a/ui/pages/SignTransaction.tsx
+++ b/ui/pages/SignTransaction.tsx
@@ -62,16 +62,17 @@ export default function SignTransaction(): ReactElement {
 
   if (isLocked) return <></>
 
+  const canConfirm =
+    isTransactionDataReady &&
+    transactionDetails &&
+    accountSigner &&
+    accountSigner !== ReadOnlyAccountSigner
+
   const handleReject = async () => {
     await dispatch(rejectTransactionSignature())
   }
   const handleConfirm = async () => {
-    if (
-      isTransactionDataReady &&
-      transactionDetails &&
-      accountSigner &&
-      accountSigner !== ReadOnlyAccountSigner
-    ) {
+    if (canConfirm) {
       dispatch(
         signTransaction({
           request: transactionDetails,
@@ -89,6 +90,7 @@ export default function SignTransaction(): ReactElement {
           signerAccountTotal={signerAccountTotal}
           title={title}
           confirmButtonLabel={confirmButtonLabel}
+          canConfirm={canConfirm}
           handleConfirm={handleConfirm}
           handleReject={handleReject}
           detailPanel={infoBlock}


### PR DESCRIPTION
### Dropped tx in activities
Resolves https://github.com/tallycash/extension/issues/1817

Handle blockheight in activities screen the same way as the activity is labeled - `pending`, `dropped`, `failed`. We can add migration so it would fix activities for existing extensions but it is not needed IMO - but open to suggestions 😄 

### Pending Sign button
Resolves https://github.com/tallycash/extension/issues/2051

Fix the problem with pending/loading sign button and transactions that can't be signed.

#### Problem
After user clicks "Sign" button `handleConfirm()`function is called. Each `handleConfirm()` had its rules when the transaction was not yet ready to be signed. In that case, function had no effect but Sign button was already in a "loading" state and as users were waiting for it to finish the action window was often losing focus - and disabling the button.  

#### Solution
Let's add `canConfirm` prop and let's block the Sign button if the transaction is not ready to be signed - for example, it takes a while after gas settings are changed.

### Testing

1. Setup transaction with custom, too low fee settings
2. Sign and check activities - block height should be "dropped"
3. Setup transaction with correct fee settings
4. Click sign, transaction should be successful
5. Check other signing types - Tally pledge, login.xyz, mintkudos...