### PR TITLE
Dam the Waterfall - Fix Blocknative Cascading Reconnect

### DIFF
--- a/background/lib/gas.ts
+++ b/background/lib/gas.ts
@@ -17,6 +17,8 @@ import { gweiToWei } from "./utils"
 // `process.env` variables in the bundled output
 const BLOCKNATIVE_API_KEY = process.env.BLOCKNATIVE_API_KEY // eslint-disable-line prefer-destructuring
 
+let blocknative: Blocknative
+
 type PolygonFeeDetails = {
   maxPriorityFee: number // gwei
   maxFee: number // gwei
@@ -88,10 +90,12 @@ export default async function getBlockPrices(
     network.chainID === ETHEREUM.chainID
   ) {
     try {
-      const blocknative = Blocknative.connect(
-        BLOCKNATIVE_API_KEY,
-        BlocknativeNetworkIds.ethereum.mainnet
-      )
+      if (!blocknative) {
+        blocknative = Blocknative.connect(
+          BLOCKNATIVE_API_KEY,
+          BlocknativeNetworkIds.ethereum.mainnet
+        )
+      }
       return await blocknative.getBlockPrices()
     } catch (err) {
       logger.error("Error getting block prices from BlockNative", err)

--- a/background/third-party-data/blocknative/index.ts
+++ b/background/third-party-data/blocknative/index.ts
@@ -5,7 +5,7 @@ import { BlockPrices, BlockEstimate } from "../../networks"
 import { EthereumTransactionData } from "./types"
 import { gweiToWei } from "../../lib/utils"
 import { ETHEREUM } from "../../constants/networks"
-import { logger } from "ethers"
+import logger from "../../lib/logger"
 
 const BLOCKNATIVE_API_ROOT = "https://api.blocknative.com"
 

--- a/background/third-party-data/blocknative/index.ts
+++ b/background/third-party-data/blocknative/index.ts
@@ -5,6 +5,7 @@ import { BlockPrices, BlockEstimate } from "../../networks"
 import { EthereumTransactionData } from "./types"
 import { gweiToWei } from "../../lib/utils"
 import { ETHEREUM } from "../../constants/networks"
+import { logger } from "ethers"
 
 const BLOCKNATIVE_API_ROOT = "https://api.blocknative.com"
 
@@ -40,6 +41,20 @@ export default class Blocknative {
     this.blocknative = new BlocknativeSdk({
       dappId: apiKey,
       networkId,
+      onopen() {
+        logger.debug("Connected to blocknative")
+      },
+      onclose() {
+        logger.warn("Blocknative connection closed")
+      },
+      // https://docs.blocknative.com/notify-sdk#ondown-optional
+      // Log why we went down and rely on sdk to automatically reconnect.
+      ondown(closeEvent) {
+        logger.warn("Blocknative connection down", closeEvent)
+      },
+      onreopen() {
+        logger.debug("Reconnected to blocknative")
+      },
     })
 
     this.apiKey = apiKey


### PR DESCRIPTION
Closes #1445


By calling Blocknative.connect inside of `getBlockPrices` - we were opening a websocket connection each time we polled for block prices - which then stayed open for an indefinite amount of time.  Once a critical mass of websocket connections were opened - they would begin to disconnect and then automatically reconnect - causing a loop that used up _significant_ resources.  Switching to a singleton mitigates this issue and still lets us allow on the sdk's reconnect logic in case of connectivity issues.

### To Test
- [ ] Drop a console.log [inside of the blockPrices event handler](https://github.com/tallycash/extension/blob/main/background/main.ts#L701:L701)
- [ ] Drop another log [inside of getBlockPrices](https://github.com/tallycash/extension/blob/blocknative-reconnect/background/lib/gas.ts#L98:L98)
- [ ] Set the [blockPrices handler](https://github.com/tallycash/extension/blob/blocknative-reconnect/background/services/chain/index.ts#L226:L226) period to `0.1`
- [ ] Load up the extension - you should see logs that indicate blockPrices are correctly being retrieved.
- [ ] Disconnect from wifi - you should see errors in the console that indicate blockPrices are not correctly being retrieved
- [ ] Turn wifi back on - you should once again be getting block prices.