### PR TITLE
Fix swap screen sometimes crashing when switching networks for the first time.

### DIFF
--- a/background/redux-slices/selectors/transactionConstructionSelectors.ts
+++ b/background/redux-slices/selectors/transactionConstructionSelectors.ts
@@ -42,7 +42,7 @@ export const selectDefaultNetworkFeeSettings = createSelector(
         maxPriorityFeePerGas: selectedFeesPerGas?.maxPriorityFeePerGas ?? 0n,
         gasPrice: selectedFeesPerGas?.price ?? 0n,
         baseFeePerGas:
-          networks.evm[currentNetwork.chainID].baseFeePerGas ?? undefined, // @TODO: Support multi-network
+          networks.evm[currentNetwork.chainID]?.baseFeePerGas ?? undefined,
       },
     }
   }


### PR DESCRIPTION
This PR addresses a bug that arises due to a race condition or poor connection quality - so it is a bit hard to reproduce.

It looks like when switching to a new network for the first time we are sometimes trying to access `networks.evm[currentNetwork.chainID]` before `networks.evm[currentNetwork.chainID]` has been populated.  

It is quite inconsistent and difficult to recreate - but these are the general steps:

- [ ] Throttle chrome speed to slow 3g
- [ ] Load in a new account
- [ ] Switch to the swap screen while on the Ethereum Network
- [ ] Switch to Polygon / Optimism while viewing the swap screen
- [ ] If you see an "Unexpected Error" screen - you will see a `cannot read baseGasFee of undefined` error in the console pointing to the line in this PR.

I can reproduce this about 1 out of 20 times but the change is quite straightforward and has minimal risk of doing anything harmful - so hoping we can merge.