### PR TITLE
Greatly increase available swap assets on L2's

### DIFF
--- a/background/redux-slices/assets.ts
+++ b/background/redux-slices/assets.ts
@@ -15,7 +15,7 @@ import { getProvider } from "./utils/contract-utils"
 import { sameNetwork } from "../networks"
 import { ERC20_INTERFACE } from "../lib/erc20"
 import logger from "../lib/logger"
-import { FIAT_CURRENCIES_SYMBOL } from "../constants"
+import { BASE_ASSETS_BY_SYMBOL, FIAT_CURRENCIES_SYMBOL } from "../constants"
 
 type SingleAssetState = AnyAsset & {
   recentPrices: {
@@ -59,7 +59,11 @@ const assetsSlice = createSlice({
                 a.homeNetwork.name === asset.homeNetwork.name &&
                 normalizeEVMAddress(a.contractAddress) ===
                   normalizeEVMAddress(asset.contractAddress)) ||
-              asset.name === a.name
+              // Only match base assets by name - since there may be
+              // many assets that share a name and symbol across L2's
+              (BASE_ASSETS_BY_SYMBOL[a.symbol] &&
+                BASE_ASSETS_BY_SYMBOL[asset.symbol] &&
+                a.name === asset.name)
           )
           // if there aren't duplicates, add the asset
           if (duplicates.length === 0) {


### PR DESCRIPTION
We were deduplicating assets that shared a name but belonged to different networks - now we don't.

### To Test
- [ ] Open the swap screen on Optimism
  - [ ] There should be more than 10 buy assets to choose from
  - [ ] ETH should not be duplicated in the buy asset list
- [ ]  Open the swap screen on Polygon
  - [ ] There should be more assets available to swap than on `main`
  - [ ] MATIC should not be duplicated in the buy asset list