### PR TITLE
Fix password preview

### DIFF
--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -153,6 +153,8 @@
     "viewAll": "View all"
   },
   "shared": {
-    "cancelBtn": "Cancel"
+    "cancelBtn": "Cancel",
+    "showPasswordHint": "Show Password",
+    "hidePasswordHint": "Hide Password"
   }
 }

--- a/ui/components/Keyring/KeyringSetPassword.tsx
+++ b/ui/components/Keyring/KeyringSetPassword.tsx
@@ -4,9 +4,9 @@ import { useHistory } from "react-router-dom"
 import { useTranslation } from "react-i18next"
 import { useBackgroundDispatch, useAreKeyringsUnlocked } from "../../hooks"
 import SharedButton from "../Shared/SharedButton"
-import SharedInput from "../Shared/SharedInput"
 import SharedBackButton from "../Shared/SharedBackButton"
 import PasswordStrengthBar from "../Password/PasswordStrengthBar"
+import PasswordInput from "../Shared/PasswordInput"
 
 export default function KeyringSetPassword(): ReactElement {
   const { t } = useTranslation("translation", {
@@ -74,24 +74,20 @@ export default function KeyringSetPassword(): ReactElement {
         }}
       >
         <div className="input_wrap">
-          <SharedInput
-            type="password"
+          <PasswordInput
             label={t("password")}
             onChange={handleInputChange(setPassword)}
             errorMessage={passwordErrorMessage}
-            iconMedium="eye-on"
           />
         </div>
         <div className="strength_bar_wrap">
           {!passwordErrorMessage && <PasswordStrengthBar password={password} />}
         </div>
         <div className="input_wrap repeat_password_wrap">
-          <SharedInput
-            type="password"
+          <PasswordInput
             label={t("repeatPassword")}
             onChange={handleInputChange(setPasswordConfirmation)}
             errorMessage={passwordErrorMessage}
-            iconMedium="eye-on"
           />
         </div>
         <SharedButton

--- a/ui/components/Keyring/KeyringUnlock.tsx
+++ b/ui/components/Keyring/KeyringUnlock.tsx
@@ -10,7 +10,7 @@ import {
   useIsDappPopup,
 } from "../../hooks"
 import SharedButton from "../Shared/SharedButton"
-import SharedInput from "../Shared/SharedInput"
+import PasswordInput from "../Shared/PasswordInput"
 
 export default function KeyringUnlock(): ReactElement {
   const { t } = useTranslation("translation", { keyPrefix: "keyring.unlock" })
@@ -73,8 +73,7 @@ export default function KeyringUnlock(): ReactElement {
       <form onSubmit={dispatchUnlockWallet}>
         <div className="signing_wrap">
           <div className="input_wrap">
-            <SharedInput
-              type="password"
+            <PasswordInput
               label={t("signingPassword")}
               onChange={(value) => {
                 setPassword(value)
@@ -82,7 +81,6 @@ export default function KeyringUnlock(): ReactElement {
                 setErrorMessage("")
               }}
               errorMessage={errorMessage}
-              iconMedium="eye-on"
               focusedLabelBackgroundColor="var(--green-95)"
             />
           </div>

--- a/ui/components/Shared/PasswordInput.tsx
+++ b/ui/components/Shared/PasswordInput.tsx
@@ -1,0 +1,79 @@
+import React, { ComponentProps, ReactElement, useState } from "react"
+import classNames from "classnames"
+import { useTranslation } from "react-i18next"
+import SharedInput from "./SharedInput"
+import { Simplify } from "./types"
+
+type PasswordInputProps = Simplify<
+  { hasPreview?: boolean } & Omit<ComponentProps<typeof SharedInput>, "type">
+>
+
+export default function PasswordInput(props: PasswordInputProps): ReactElement {
+  const { hasPreview = true, ...inputProps } = props
+  const [showPassword, setShowPassword] = useState(false)
+  const passwordInputType = showPassword ? "text" : "password"
+  const { t } = useTranslation("translation", { keyPrefix: "shared" })
+
+  return (
+    <div className="wrapper">
+      <SharedInput
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...inputProps}
+        type={passwordInputType}
+      />
+      {hasPreview && (
+        <button
+          role="switch"
+          type="button"
+          aria-label={
+            !showPassword ? t("showPasswordHint") : t("hidePasswordHint")
+          }
+          aria-checked={showPassword}
+          onClick={() => setShowPassword((visible) => !visible)}
+          className={classNames("icon icon_medium", {
+            active: showPassword,
+          })}
+        />
+      )}
+      <style jsx>
+        {`
+          .wrapper > :global(input) {
+            padding-right: 40px;
+          }
+          .wrapper {
+            position: relative;
+          }
+          .icon {
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            right: 0;
+            margin-right: 16px;
+            height: 16px;
+            width: 16px;
+            mask-image: url("./images/icons/s/eye-on.svg");
+            mask-size: cover;
+            background-position: center;
+            background-color: var(--green-60);
+            background-size: 16px;
+            transition: all 0.12s ease-out;
+            transform: translateY(50%);
+          }
+          .icon.active {
+            background-color: var(--trophy-gold);
+          }
+          .icon_medium {
+            mask-image: url("./images/icons/m/eye-on.svg");
+            mask-size: cover;
+            width: 24px;
+            height: 24px;
+            background-size: 24px;
+          }
+        `}
+      </style>
+    </div>
+  )
+}
+
+const { type: _, ...defaultProps } = SharedInput.defaultProps
+PasswordInput.defaultProps = defaultProps

--- a/ui/components/Shared/SharedInput.tsx
+++ b/ui/components/Shared/SharedInput.tsx
@@ -1,14 +1,6 @@
-import React, {
-  ChangeEvent,
-  ReactElement,
-  useEffect,
-  useReducer,
-  useRef,
-} from "react"
+import React, { ChangeEvent, ReactElement, useEffect, useRef } from "react"
 import classNames from "classnames"
-import { useTranslation } from "react-i18next"
 import { useParsedValidation, useRunOnFirstRender } from "../../hooks"
-import { PropsWithIcon } from "./types"
 
 interface Props<T> {
   id?: string
@@ -32,9 +24,7 @@ interface Props<T> {
   isSmall?: boolean
 }
 
-export function SharedTypedInput<T = string>(
-  props: Props<T> & PropsWithIcon
-): ReactElement {
+export function SharedTypedInput<T = string>(props: Props<T>): ReactElement {
   const {
     id,
     label,
@@ -53,11 +43,8 @@ export function SharedTypedInput<T = string>(
     parseAndValidate,
     isEmpty = false,
     isSmall = false,
-    iconMedium,
-    iconSmall,
   } = props
   const inputRef = useRef<HTMLInputElement | null>(null)
-  const { t } = useTranslation("translation", { keyPrefix: "shared" })
 
   useEffect(() => {
     if (autoFocus) inputRef.current?.focus()
@@ -76,67 +63,37 @@ export function SharedTypedInput<T = string>(
     parseAndValidate
   )
 
-  const [showPassword, toggleShowPassword] = useReducer(
-    (visible) => !visible,
-    false
-  )
-
   useRunOnFirstRender(() => {
     if (currentValue && currentValue.trim() !== inputValue) {
       handleInputChange(currentValue)
     }
   })
 
-  const passwordInputType = showPassword ? "text" : "password"
   return (
     <>
-      <div className="icon_wrapper">
-        <input
-          id={id}
-          type={type === "password" ? passwordInputType : type}
-          placeholder={
-            typeof placeholder === "undefined" || placeholder === ""
-              ? " "
-              : placeholder
-          }
-          value={isEmpty ? "" : inputValue}
-          spellCheck={false}
-          onInput={(event: ChangeEvent<HTMLInputElement>) =>
-            handleInputChange(event.target.value)
-          }
-          onFocus={onFocus}
-          className={classNames({
-            error: !isEmpty && (errorMessage ?? parserError !== undefined),
-            small: isSmall,
-            password: type === "password",
-          })}
-          step={step}
-          ref={inputRef}
-          maxLength={maxLength}
-        />
-        {(iconMedium || iconSmall) &&
-          (type === "password" ? (
-            <button
-              role="switch"
-              type="button"
-              aria-label={
-                !showPassword ? t("showPasswordHint") : t("hidePasswordHint")
-              }
-              aria-checked={showPassword}
-              onClick={toggleShowPassword}
-              className={classNames("icon", {
-                icon_medium: iconMedium,
-                active: showPassword,
-              })}
-            />
-          ) : (
-            <i
-              role="presentation"
-              className={classNames("icon", { icon_medium: iconMedium })}
-            />
-          ))}
-        <label htmlFor={id}>{label}</label>
-      </div>
+      <input
+        id={id}
+        type={type}
+        placeholder={
+          typeof placeholder === "undefined" || placeholder === ""
+            ? " "
+            : placeholder
+        }
+        value={isEmpty ? "" : inputValue}
+        spellCheck={false}
+        onInput={(event: ChangeEvent<HTMLInputElement>) =>
+          handleInputChange(event.target.value)
+        }
+        onFocus={onFocus}
+        className={classNames({
+          error: !isEmpty && (errorMessage ?? parserError !== undefined),
+          small: isSmall,
+        })}
+        step={step}
+        ref={inputRef}
+        maxLength={maxLength}
+      />
+      <label htmlFor={id}>{label}</label>
       {!isEmpty && errorMessage && (
         <div className="validation_message">{errorMessage}</div>
       )}
@@ -155,9 +112,6 @@ export function SharedTypedInput<T = string>(
             border: 2px solid var(--green-60);
             padding: 0px 16px;
             box-sizing: border-box;
-          }
-          input.password {
-            padding-right: 40px;
           }
           input::placeholder {
             color: var(--green-40);
@@ -235,35 +189,6 @@ export function SharedTypedInput<T = string>(
             -webkit-appearance: none;
             margin: 0;
           }
-          .icon_wrapper {
-            position: relative;
-          }
-          .icon {
-            position: absolute;
-            top: 0;
-            bottom: 0;
-            right: 0;
-            margin-right: 16px;
-            height: 16px;
-            width: 16px;
-            mask-image: url("./images/icons/s/${iconSmall}.svg");
-            mask-size: cover;
-            background-position: center;
-            background-color: var(--green-60);
-            background-size: 16px;
-            transition: all 0.12s ease-out;
-            transform: translateY(50%);
-          }
-          .icon.active {
-            background-color: var(--trophy-gold);
-          }
-          .icon_medium {
-            mask-image: url("./images/icons/m/${iconMedium}.svg");
-            mask-size: cover;
-            width: 24px;
-            height: 24px;
-            background-size: 24px;
-          }
         `}
       </style>
     </>
@@ -278,7 +203,7 @@ SharedTypedInput.defaultProps = {
 export default function SharedInput(
   props: Omit<Props<string>, "onChange"> & {
     onChange?: (_: string) => void
-  } & PropsWithIcon
+  }
 ): ReactElement {
   const onChangeWrapper = (newValue: string | undefined) => {
     props.onChange?.(newValue ?? "")

--- a/ui/components/Shared/types.ts
+++ b/ui/components/Shared/types.ts
@@ -67,3 +67,8 @@ export type PropsWithIcon =
   | { iconMedium?: never; iconSmall?: never }
   | PropsWithMediumIcon
   | PropsWithSmallIcon
+
+/**
+ * Simplifies type hints
+ */
+export type Simplify<T> = { [k in keyof T]: T[k] }

--- a/ui/pages/Onboarding/TabbedOnboardingSetPassword.tsx
+++ b/ui/pages/Onboarding/TabbedOnboardingSetPassword.tsx
@@ -15,11 +15,11 @@ import {
 } from "../../hooks"
 import titleStyle from "../../components/Onboarding/titleStyle"
 import SharedButton from "../../components/Shared/SharedButton"
-import SharedInput from "../../components/Shared/SharedInput"
 import SharedBackButton from "../../components/Shared/SharedBackButton"
 import SharedBanner from "../../components/Shared/SharedBanner"
 import SharedToggleButton from "../../components/Shared/SharedToggleButton"
 import PasswordStrengthBar from "../../components/Password/PasswordStrengthBar"
+import PasswordInput from "../../components/Shared/PasswordInput"
 
 export default function KeyringSetPassword({
   nextPage,
@@ -97,8 +97,7 @@ export default function KeyringSetPassword({
         }}
       >
         <div className="input_wrap">
-          <SharedInput
-            type="password"
+          <PasswordInput
             label="Password"
             onChange={handleInputChange(setPassword)}
             errorMessage={passwordErrorMessage}
@@ -108,8 +107,7 @@ export default function KeyringSetPassword({
           {!passwordErrorMessage && <PasswordStrengthBar password={password} />}
         </div>
         <div className="input_wrap repeat_password_wrap">
-          <SharedInput
-            type="password"
+          <PasswordInput
             label="Repeat Password"
             onChange={handleInputChange(setPasswordConfirmation)}
             errorMessage={passwordErrorMessage}


### PR DESCRIPTION
Makes the preview password button work

![_eyecanseenow](https://user-images.githubusercontent.com/28708889/190298493-a102d425-1004-4b18-bd79-8f5ce735862a.gif)


Closes #2187


## To Test:
- [ ] Unlock your wallet, try clicking on the 👁️ . You should be able to see your password (and everyone else too!)
- [ ] Type a very long password, text/mask should not appear behind the toggler icon
- [ ] Check other inputs aren't horribly broken
