### PR TITLE
Fix fallback logic for unsupported `alchemy_filteredNewFullPendingTransactions`

### DIFF
--- a/background/services/chain/serial-fallback-provider.ts
+++ b/background/services/chain/serial-fallback-provider.ts
@@ -658,7 +658,7 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
       return "subscribed"
     } catch (error) {
       const errorString = String(error)
-      if (errorString.match(/unsupported subscription/i)) {
+      if (errorString.match(/is unsupported on/i)) {
         return "unsupported"
       }
 


### PR DESCRIPTION
### To Test
- [x] Do an in-wallet swap on optimism
- [x] The pending transaction should show up in the activity tab