### PR TITLE
Populate `from` on LegacyTransactions when estimating gas limit

### DIFF
--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -483,6 +483,7 @@ export default class ChainService extends BaseService<Events> {
         transactionRequest
       )
     } catch (error) {
+      logger.error("Error estimating gas limit: ", error)
       // Try to identify unpredictable gas errors to bubble that information
       // out.
       if (error instanceof Error) {

--- a/background/services/chain/utils/index.ts
+++ b/background/services/chain/utils/index.ts
@@ -99,10 +99,11 @@ export function ethersTransactionRequestFromEIP1559TransactionRequest(
 export function ethersTransactionRequestFromLegacyTransactionRequest(
   transaction: LegacyEVMTransactionRequest
 ): EthersTransactionRequest {
-  const { to, input, type, nonce, gasPrice, value, chainID, gasLimit } =
+  const { to, input, type, nonce, gasPrice, value, chainID, gasLimit, from } =
     transaction
 
   return {
+    from,
     to,
     data: input ?? undefined,
     type: type ?? undefined,


### PR DESCRIPTION
Closes https://github.com/tallycash/extension/issues/2204
Closes https://github.com/tallycash/extension/issues/2201

This one was tricky - we need a `from` field when estimating gas limits for a given legacy tx - but `from` is also disallowed when serializing legacy transactions.  Luckily we correctly separate our concerns with `ethersTransactionRequestFromLegacyTransactionRequest` and `ethersTransactionFromSignedTransaction` so the fix was simple to implement - although difficult to pinpoint.

### To Test
- [ ] Follow the steps to recreate #2204 - you should be able to approve and deposit.