### PR TITLE
Fix "0x Router" not displaying in Activity List for Tally Swaps

### DIFF
--- a/background/utils/view-model-transformer.ts
+++ b/background/utils/view-model-transformer.ts
@@ -24,6 +24,7 @@ export const transactionPropertiesForUI = [
   "annotation.blockTimestamp",
   "annotation.type",
   "annotation.source",
+  "annotation.contractInfo.annotation.nameOnNetwork.name",
   "annotation.recipient.address",
   "annotation.recipient.network",
   "annotation.recipient.annotation",


### PR DESCRIPTION
### To Test
- [ ] Make an in-wallet swap
- [ ] Activity list should display `To: 0x Router` for the corresponding transaction

<img width="371" alt="image" src="https://user-images.githubusercontent.com/94649004/190525336-4f322a78-92a1-4f2e-8188-ff74d3621c91.png">
