### PR TITLE
Block reject button when transaction is not ready

### DIFF
--- a/ui/components/Shared/SharedButton.tsx
+++ b/ui/components/Shared/SharedButton.tsx
@@ -205,6 +205,7 @@ export default function SharedButton(
             line-height: 24px;
             text-align: center;
             padding: 0 17px;
+            transition: background-color 0.2s, color 0.2s;
           }
           .button:hover {
             background-color: var(--gold-80);
@@ -252,7 +253,7 @@ export default function SharedButton(
             margin-left: 10px;
           }
           .secondary {
-            background: unset;
+            background-color: transparent;
             border: 2px solid var(--trophy-gold);
             color: var(--trophy-gold);
             box-sizing: border-box;
@@ -272,6 +273,7 @@ export default function SharedButton(
           }
           .disabled {
             background-color: var(--green-60);
+            border-color: var(--green-60);
             color: var(--green-80);
             pointer-events: none;
           }

--- a/ui/hooks/dom-hooks.ts
+++ b/ui/hooks/dom-hooks.ts
@@ -1,4 +1,4 @@
-import { RefObject, useEffect, useRef, useState } from "react"
+import { RefObject, useEffect, useRef, useState, useCallback } from "react"
 
 export const useOnClickOutside = <T extends HTMLElement = HTMLElement>(
   ref: RefObject<T>,
@@ -78,6 +78,34 @@ export function useDelayContentChange<T>(
   }
 
   return delayedContent
+}
+
+function debounce<T>(setStateFn: (V: T) => void, ms: number) {
+  let timeout: NodeJS.Timer
+
+  return (value: T) => {
+    clearTimeout(timeout)
+
+    timeout = setTimeout(() => {
+      setStateFn(value)
+    }, ms)
+  }
+}
+
+export const useDebounce = <T>(initial: T, wait = 300): [T, (v: T) => void] => {
+  const [state, setState] = useState(initial)
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const debounceCallback = useCallback(
+    debounce((prop: T) => setState(prop), wait),
+    [debounce, wait]
+  )
+
+  const setDebouncedState = (debounced: T) => {
+    debounceCallback(debounced)
+  }
+
+  return [state, setDebouncedState]
 }
 
 export const setLocalStorageItem = (key: string, value: string): void =>


### PR DESCRIPTION
Resolves https://github.com/tallycash/extension/issues/2164
Resolves https://github.com/tallycash/extension/issues/2202
### What
Same as `Sign` button `Reject` button should be blocked when the transaction is not ready to be signed.

This is because sometimes there are pending dispatched actions when the user is rejecting transaction and there is no easy way to cancel them. When they are finally dispatched then the transaction should be already rejected but it is being repopulated with data. Because of this signing screen becomes visible again. 

### Testing
- [ ] setup transaction (send, swap, siwe, with dapp etc)
- [ ] try rejecting transaction
- [ ] try signing transaction
- [ ] try above after gas fee change

Expected: Signing screen shouldn't be visible again after user rejects, after sign there should be no endlessly spinning Sign button

https://user-images.githubusercontent.com/20949277/190655998-46378df8-9cf7-41d1-b1af-d97dec78dbcc.mov

