### PR TITLE
Reduce ram/cpu usage for eslint

### DIFF
--- a/.tsconfig-eslint.json
+++ b/.tsconfig-eslint.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
   "include": [".eslintrc.js", "**/*.js", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "dist", "**/validate/*.js", "**/local-chain/**"]
 }


### PR DESCRIPTION
After testing the extension on Firefox, I found my eslint server crashing constantly due to being out of memory. A couple of tests afterwards revealed the problem to be in the exclude directives used by `.tsconfig-eslint.json`. 

As shown in the screenshot below, both my RAM usage and CPU time went down by a lot (~70%/~50%) when linting after adding output directories to the excluded paths in `.tsconfig-eslint.json`.

![#justjavascriptthings](https://user-images.githubusercontent.com/28708889/190886677-9b768c85-902f-49f2-a902-29a3ed1f2f7c.jpg)

Left side has same settings as PR
Middle does not exclude `validate` and `local-chain` folders
Right side only excludes `dist/firefox`
