### PR TITLE
App permission details

### DIFF
--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -120,16 +120,12 @@ export default class ProviderBridgeService extends BaseService<Events> {
     }
 
     const { origin } = new URL(url)
+
     const completeTab =
       typeof tab !== "undefined" && typeof tab.id !== "undefined"
-        ? {
-            ...tab,
-            // Firefox sometimes requires an extra query to get favicons,
-            // unclear why but may be related to
-            // https://bugzilla.mozilla.org/show_bug.cgi?id=1417721 .
-            ...(await browser.tabs.get(tab.id)),
-          }
+        ? await browser.tabs.get(tab?.id)
         : tab
+
     const faviconUrl = completeTab?.favIconUrl ?? ""
     const title = completeTab?.title ?? ""
 

--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -32,7 +32,7 @@
     "default_title": "Tally Ho",
     "default_popup": "popup.html"
   },
-  "permissions": ["alarms", "storage", "unlimitedStorage", "activeTab"],
+  "permissions": ["alarms", "storage", "unlimitedStorage", "activeTab", "tabs"],
   "background": {
     "persistent": true,
     "scripts": ["background.js", "background-ui.js"]

--- a/ui/pages/DAppConnect/RequestingDApp.tsx
+++ b/ui/pages/DAppConnect/RequestingDApp.tsx
@@ -1,5 +1,7 @@
 import React, { ReactElement } from "react"
 
+const TITLE_MAX_LENGTH = 55
+
 export default function RequestingDAppBlock(props: {
   title: string
   url: string
@@ -10,8 +12,14 @@ export default function RequestingDAppBlock(props: {
     <div className="request_wrap">
       <div className="dapp_favicon" />
       <div className="info">
-        <div className="dapp_title">{title}</div>
-        <div className="dapp_url">{url}</div>
+        <div className="dapp_title" title={title}>
+          {title.length > TITLE_MAX_LENGTH
+            ? `${title.slice(TITLE_MAX_LENGTH)}...`
+            : title}
+        </div>
+        <div className="dapp_url" title={url}>
+          {url}
+        </div>
       </div>
       <style jsx>{`
         .request_wrap {
@@ -33,13 +41,18 @@ export default function RequestingDAppBlock(props: {
           color: #fff;
           font-size: 16px;
           font-weight: 500;
+          overflow-wrap: anywhere;
         }
         .dapp_url {
           color: var(--green-40);
           font-size: 16px;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
         }
         .info {
           margin-left: 16px;
+          width: calc(100% - 48px - 16px);
         }
       `}</style>
     </div>


### PR DESCRIPTION
Resolves https://github.com/tallycash/extension/issues/2214
### What

Fix the problem with missing dapps favicons and titles.
Fix the problem with overflowing text on connect to dapp page.

### How

To fetch favicon and title properly we have to use `browser.tabs.get(id)`, we can't rely on `browser.runtime.onConnect` because it is not returning website details consistently. If we use `browser.tabs.get` without `tabs` extension permission it won't return any details that we care about ([see docs page](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/Tab), both title and favicon are `undefined` without `tabs` permission).

### Test

- [ ] allow to use extension in incognito mode (problems with title and favicon are happening mostly when you visit given app for the first time, at least for me)
- [ ] connect wallet to multiple dapps, check if dapps connection screen contains correct icon and title (not the URL as a title), check if text is not overflowing

![image](https://user-images.githubusercontent.com/20949277/191262617-5b56450a-4251-48a4-9e3e-5f5fea27005c.png)
