### PR TITLE
Don't show "Tally Ho as default" page onboarding

### DIFF
--- a/ui/pages/Onboarding/OnboardingInfoIntro.tsx
+++ b/ui/pages/Onboarding/OnboardingInfoIntro.tsx
@@ -30,17 +30,6 @@ const steps = HIDE_TOKEN_FEATURES
         body: `That means Tally Ho is owned by our users. And all profits go straight to the community.`,
         buttonCopy: "Continue",
       },
-      {
-        image: {
-          width: 267,
-          height: 236.6,
-          fileName: "illustration_onboarding_default",
-          extraStyles: `margin-top: 21px;`,
-        },
-        title: "Tally Ho set as default",
-        body: `Tally Ho will open any time you connect to a dapp — even if you select MetaMask. You can disable this anytime from Settings.`,
-        buttonCopy: "Get started",
-      },
     ]
   : [
       {

--- a/ui/pages/Onboarding/Tabbed/Intro.tsx
+++ b/ui/pages/Onboarding/Tabbed/Intro.tsx
@@ -28,17 +28,6 @@ const steps = HIDE_TOKEN_FEATURES
         body: `That means Tally Ho is owned by our users. And all profits go straight to the community.`,
         buttonCopy: "Continue",
       },
-      {
-        image: {
-          width: 267,
-          height: 236.6,
-          fileName: "illustration_onboarding_default",
-          extraStyles: `margin-top: 21px;`,
-        },
-        title: "Tally Ho set as default",
-        body: `Tally Ho will open any time you connect to a dapp — even if you select MetaMask. You can disable this anytime from Settings.`,
-        buttonCopy: "Get started",
-      },
     ]
   : [
       {


### PR DESCRIPTION
We no longer flip the option on by default.

Closes #2257

# To Test

- [ ] Onboard with `SUPPORT_TABBED_ONBOARD=false`. You shouldn't see an intro page about Tally being set as default
- [ ] Onboard with `SUPPORT_TABBED_ONBOARD=true`. You shouldn't see an intro page about Tally being set as default