### PR TITLE
Move default wallet up to top of Settings

### DIFF
--- a/ui/pages/Settings.tsx
+++ b/ui/pages/Settings.tsx
@@ -161,8 +161,8 @@ export default function Settings(): ReactElement {
   }
 
   const generalList = [
-    hideSmallAssetBalance,
     setAsDefault,
+    hideSmallAssetBalance,
     ...(SUPPORT_MULTIPLE_LANGUAGES ? [languages] : []),
     ...(SUPPORT_GOERLI ? [enableTestNetworks] : []),
     dAppsSettings,


### PR DESCRIPTION
Closes #2294 

This PR is moving "default wallet" up to top of "Settings.

**UI**

Before
<img width="240" alt="Screenshot 2022-09-26 at 10 51 48" src="https://user-images.githubusercontent.com/23117945/192235130-bd6f00cb-782e-4034-b7dd-87bde95470b2.png">

After
<img width="240" alt="Screenshot 2022-09-26 at 10 52 0" src="https://user-images.githubusercontent.com/23117945/192235142-dc53dc76-787d-4002-808f-2a9506012cfb.png">

**To test**
- [ ] go to the Setting page anch check that ,,default wallet''  is at the top 
