### PR TITLE
Update texts for SwitchWalletPage

### DIFF
--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -266,7 +266,8 @@
     },
     "selectToken": "Select token",
     "backButtonText": "Back",
-    "saveBtn": "Save"
+    "saveBtn": "Save",
+    "closeWindow": "Close window"
   },
   "signing": {
     "signatureRequired": "Your signature is required",
@@ -357,5 +358,13 @@
     "sendButton": "Continue",
     "receiveAddress": "Receive address",
     "sendToContractWarning": "This is a contract address, sending assets could result in loss of funds."
+  },
+  "dAppConnect": {
+    "switchWallet":{
+      "title": "Tally Ho not Default",
+      "descFirstPart": "We disabled Tally as default wallet for you. You can always enable it back from Settings",
+      "descSecondPart": "at any time.",
+      "toggleTitle": "Use Tally Ho as default wallet"
+    }
   }
 }

--- a/ui/pages/DAppConnect/SwitchWalletPage.tsx
+++ b/ui/pages/DAppConnect/SwitchWalletPage.tsx
@@ -1,7 +1,9 @@
 import { setNewDefaultWalletValue } from "@tallyho/tally-background/redux-slices/ui"
 import React, { ReactElement, useCallback, useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { useDispatch } from "react-redux"
 import SharedButton from "../../components/Shared/SharedButton"
+import SharedIcon from "../../components/Shared/SharedIcon"
 import SharedToggleButton from "../../components/Shared/SharedToggleButton"
 
 export default function SwitchWalletPage({
@@ -9,6 +11,10 @@ export default function SwitchWalletPage({
 }: {
   close: () => Promise<void>
 }): ReactElement {
+  const { t } = useTranslation("translation", {
+    keyPrefix: "dAppConnect.switchWallet",
+  })
+  const { t: tShared } = useTranslation("translation", { keyPrefix: "shared" })
   const dispatch = useDispatch()
   const [toggleState, setToggleState] = useState(false)
 
@@ -27,13 +33,20 @@ export default function SwitchWalletPage({
   return (
     <div className="page">
       <section className="standard_width">
-        <h1 className="serif_header">Tally Ho not Default</h1>
+        <h1 className="serif_header"> {t("title")}</h1>
         <p>
-          We disabled Tally as default wallet for you. You can always enable it
-          back from Menu ☰ at any time.
+          {t("descFirstPart")}
+          <span className="icon_wrap">
+            <SharedIcon
+              icon="icons/s/settings.svg"
+              width={16}
+              color="var(--green-40)"
+            />
+          </span>
+          {t("descSecondPart")}
         </p>
         <div className="toggle_default">
-          <span>Use Tally Ho as default wallet</span>
+          <span>{t("toggleTitle")}</span>
           <SharedToggleButton
             onChange={(value) => toggleDefaultWallet(value)}
             value={toggleState}
@@ -41,7 +54,7 @@ export default function SwitchWalletPage({
         </div>
         <div className="button_wrap">
           <SharedButton type="primary" size="large" onClick={close}>
-            Close window
+            {tShared("closeWindow")}
           </SharedButton>
         </div>
       </section>
@@ -71,8 +84,10 @@ export default function SwitchWalletPage({
           font-size: 16px;
           line-height: 24px;
           font-weight: 500;
-          width: 335px;
+          width: 100%;
           margin: 0 0 37px;
+          padding: 0 8px;
+          box-sizing: border-box;
         }
         .toggle_default {
           background: var(--hunter-green);
@@ -89,6 +104,9 @@ export default function SwitchWalletPage({
         .button_wrap {
           display: flex;
           justify-content: center;
+        }
+        .icon_wrap {
+          vertical-align: middle;
         }
       `}</style>
     </div>


### PR DESCRIPTION
Closes #2255 

This PR updates Switch Wallet Page.

**Changes**
- add texts to translations
- change "Menu" to "Setting"
- add settings icon to description

**UI**

Before
<img width="240" alt="Screenshot 2022-09-26 at 11 05 24" src="https://user-images.githubusercontent.com/23117945/192257980-ce3a3205-3881-4abb-a6f0-696b271782a6.png">

After
<img width="240" alt="Screenshot 2022-09-26 at 12 41 28" src="https://user-images.githubusercontent.com/23117945/192257994-8d6c6712-0fa5-4233-8371-f55b7603fd88.png">

**To test**
- [ ] go to Switch Wallet Page and check texts
