### PR TITLE
Only poll for gas prices when a network is active

### DIFF
--- a/background/lib/gas.ts
+++ b/background/lib/gas.ts
@@ -129,33 +129,6 @@ export default async function getBlockPrices(
   const gasPrice = feeData?.gasPrice?.toBigInt() || 0n
 
   if (baseFeePerGas) {
-    console.log({
-      network,
-      blockNumber: currentBlock.number,
-      baseFeePerGas,
-      estimatedTransactionCount: null,
-      estimatedPrices: [
-        {
-          confidence: 99,
-          maxPriorityFeePerGas: 2_500_000_000n,
-          maxFeePerGas: baseFeePerGas * 2n + 2_500_000_000n,
-          price: gasPrice, // this estimate isn't great
-        },
-        {
-          confidence: 95,
-          maxPriorityFeePerGas: 1_500_000_000n,
-          maxFeePerGas: (baseFeePerGas * 15n) / 10n + 1_500_000_000n,
-          price: (gasPrice * 9n) / 10n,
-        },
-        {
-          confidence: 70,
-          maxPriorityFeePerGas: 1_100_000_000n,
-          maxFeePerGas: (baseFeePerGas * 13n) / 10n + 1_100_000_000n,
-          price: (gasPrice * 8n) / 10n,
-        },
-      ],
-      dataSource: "local",
-    })
     return {
       network,
       blockNumber: currentBlock.number,
@@ -199,21 +172,6 @@ export default async function getBlockPrices(
   const maxFeePerGas = feeData?.maxFeePerGas?.toBigInt() || 0n
   const maxPriorityFeePerGas = feeData?.maxPriorityFeePerGas?.toBigInt() || 0n
 
-  console.log({
-    network,
-    blockNumber: currentBlock.number,
-    baseFeePerGas: (maxFeePerGas - maxPriorityFeePerGas) / 2n,
-    estimatedTransactionCount: null,
-    estimatedPrices: [
-      {
-        confidence: 99,
-        maxPriorityFeePerGas,
-        maxFeePerGas,
-        price: gasPrice,
-      },
-    ],
-    dataSource: "local",
-  })
   return {
     network,
     blockNumber: currentBlock.number,

--- a/background/lib/gas.ts
+++ b/background/lib/gas.ts
@@ -129,6 +129,33 @@ export default async function getBlockPrices(
   const gasPrice = feeData?.gasPrice?.toBigInt() || 0n
 
   if (baseFeePerGas) {
+    console.log({
+      network,
+      blockNumber: currentBlock.number,
+      baseFeePerGas,
+      estimatedTransactionCount: null,
+      estimatedPrices: [
+        {
+          confidence: 99,
+          maxPriorityFeePerGas: 2_500_000_000n,
+          maxFeePerGas: baseFeePerGas * 2n + 2_500_000_000n,
+          price: gasPrice, // this estimate isn't great
+        },
+        {
+          confidence: 95,
+          maxPriorityFeePerGas: 1_500_000_000n,
+          maxFeePerGas: (baseFeePerGas * 15n) / 10n + 1_500_000_000n,
+          price: (gasPrice * 9n) / 10n,
+        },
+        {
+          confidence: 70,
+          maxPriorityFeePerGas: 1_100_000_000n,
+          maxFeePerGas: (baseFeePerGas * 13n) / 10n + 1_100_000_000n,
+          price: (gasPrice * 8n) / 10n,
+        },
+      ],
+      dataSource: "local",
+    })
     return {
       network,
       blockNumber: currentBlock.number,
@@ -172,6 +199,21 @@ export default async function getBlockPrices(
   const maxFeePerGas = feeData?.maxFeePerGas?.toBigInt() || 0n
   const maxPriorityFeePerGas = feeData?.maxPriorityFeePerGas?.toBigInt() || 0n
 
+  console.log({
+    network,
+    blockNumber: currentBlock.number,
+    baseFeePerGas: (maxFeePerGas - maxPriorityFeePerGas) / 2n,
+    estimatedTransactionCount: null,
+    estimatedPrices: [
+      {
+        confidence: 99,
+        maxPriorityFeePerGas,
+        maxFeePerGas,
+        price: gasPrice,
+      },
+    ],
+    dataSource: "local",
+  })
   return {
     network,
     blockNumber: currentBlock.number,

--- a/background/main.ts
+++ b/background/main.ts
@@ -1082,7 +1082,6 @@ export default class Main extends BaseService<never> {
     )
 
     uiSliceEmitter.on("newSelectedNetwork", (network) => {
-      this.chainService.markNetworkActivity(network.chainID)
       this.internalEthereumProviderService.routeSafeRPCRequest(
         "wallet_switchEthereumChain",
         [{ chainId: network.chainID }],

--- a/background/main.ts
+++ b/background/main.ts
@@ -1075,6 +1075,7 @@ export default class Main extends BaseService<never> {
     )
 
     uiSliceEmitter.on("newSelectedNetwork", (network) => {
+      this.chainService.markNetworkActivity(network.chainID)
       this.internalEthereumProviderService.routeSafeRPCRequest(
         "wallet_switchEthereumChain",
         [{ chainId: network.chainID }],
@@ -1096,6 +1097,14 @@ export default class Main extends BaseService<never> {
       "initializeAllowedPages",
       async (allowedPages: PermissionMap) => {
         this.store.dispatch(initializePermissions(allowedPages))
+      }
+    )
+
+    this.providerBridgeService.emitter.on(
+      "permissionQueriedForChain",
+      async (chainID: string) => {
+        this.chainService.markNetworkActivity(chainID)
+        this.chainService.pollBlockPricesForNetwork(chainID)
       }
     )
 

--- a/background/main.ts
+++ b/background/main.ts
@@ -1110,7 +1110,6 @@ export default class Main extends BaseService<never> {
       "permissionQueriedForChain",
       async (chainID: string) => {
         this.chainService.markNetworkActivity(chainID)
-        this.chainService.pollBlockPricesForNetwork(chainID)
       }
     )
 

--- a/background/main.ts
+++ b/background/main.ts
@@ -733,6 +733,10 @@ export default class Main extends BaseService<never> {
         )
       )
     })
+
+    uiSliceEmitter.on("userActivityEncountered", (addressOnNetwork) => {
+      this.chainService.markNetworkActivity(addressOnNetwork.network.chainID)
+    })
   }
 
   async connectNameService(): Promise<void> {

--- a/background/main.ts
+++ b/background/main.ts
@@ -1034,6 +1034,9 @@ export default class Main extends BaseService<never> {
         resolver: (result: string | PromiseLike<string>) => void
         rejecter: () => void
       }) => {
+        this.chainService.pollBlockPricesForNetwork(
+          payload.account.network.chainID
+        )
         this.store.dispatch(signDataRequest(payload))
 
         const clear = () => {

--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -39,6 +39,7 @@ export type Events = {
   newDefaultWalletValue: boolean
   refreshBackgroundPage: null
   newSelectedAccount: AddressOnNetwork
+  userActivityEncountered: AddressOnNetwork
   newSelectedNetwork: EVMNetwork
 }
 
@@ -172,6 +173,13 @@ export const setNewSelectedAccount = createBackgroundAsyncThunk(
     await emitter.emit("newSelectedAccount", addressNetwork)
     // Once the default value has persisted, propagate to the store.
     dispatch(uiSlice.actions.setSelectedAccount(addressNetwork))
+  }
+)
+
+export const userActivityEncountered = createBackgroundAsyncThunk(
+  "ui/userActivityEncountered",
+  async (addressNetwork: AddressOnNetwork) => {
+    await emitter.emit("userActivityEncountered", addressNetwork)
   }
 )
 

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -378,6 +378,7 @@ export default class ChainService extends BaseService<Events> {
       logger.warn(
         `${activeNetwork.name} already active - no need to activate it`
       )
+      this.markNetworkActivity(activeNetwork.chainID)
       return activeNetwork
     }
 
@@ -408,6 +409,7 @@ export default class ChainService extends BaseService<Events> {
       })
     }
 
+    this.markNetworkActivity(networkToActivate.chainID)
     return networkToActivate
   }
 

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -1031,6 +1031,10 @@ export default class ChainService extends BaseService<Events> {
     }
   }
 
+  markNetworkActivity(chainID: string): void {
+    this.lastUserActivityOnNetwork[chainID] = Date.now()
+  }
+
   /*
    * Periodically fetch block prices and emit an event whenever new data is received
    * Write block prices to IndexedDB so we have them for later

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -140,6 +140,10 @@ export default class ChainService extends BaseService<Events> {
     provider: SerialFallbackProvider
   }[]
 
+  private lastUserActivityOnNetwork: {
+    [chainID: string]: UNIXTime
+  } = {}
+
   /**
    * For each chain id, track an address's last seen nonce. The tracked nonce
    * should generally not be allocated to a new transaction, nor should any

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -1025,14 +1025,13 @@ export default class ChainService extends BaseService<Events> {
   }
 
   async markNetworkActivity(chainID: string): Promise<void> {
-    if (
-      Date.now() - NETWORK_POLLING_TIMEOUT >
-      this.lastUserActivityOnNetwork[chainID]
-    ) {
+    const now = Date.now()
+    const deactivatesAt = this.lastUserActivityOnNetwork[chainID]
+    this.lastUserActivityOnNetwork[chainID] = now
+    if (now - NETWORK_POLLING_TIMEOUT > deactivatesAt) {
       // Reactivating a potentially deactivated network
       this.pollBlockPricesForNetwork(chainID)
     }
-    this.lastUserActivityOnNetwork[chainID] = Date.now()
   }
 
   /*

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -225,8 +225,7 @@ export default class ChainService extends BaseService<Events> {
       blockPrices: {
         runAtStart: false,
         schedule: {
-          periodInMinutes:
-            Number(process.env.GAS_PRICE_POLLING_FREQUENCY ?? "120") / 60,
+          periodInMinutes: 0.5, // Every 30 seconds
         },
         handler: () => {
           this.pollBlockPrices()

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -1059,7 +1059,9 @@ export default class ChainService extends BaseService<Events> {
     )
 
     if (!subscription) {
-      logger.warn(`Can't fetch block prices for unsupported chainID ${chainID}`)
+      logger.warn(
+        `Can't fetch block prices for unsubscribed chainID ${chainID}`
+      )
       return
     }
 

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -225,7 +225,7 @@ export default class ChainService extends BaseService<Events> {
       blockPrices: {
         runAtStart: false,
         schedule: {
-          periodInMinutes: 0.25, // Every 30 seconds
+          periodInMinutes: 0.25, // Every 15 seconds
         },
         handler: () => {
           this.pollBlockPrices()

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -232,14 +232,6 @@ export default class ChainService extends BaseService<Events> {
           this.pollBlockPrices()
         },
       },
-      latestBlocks: {
-        schedule: {
-          periodInMinutes: 0.25, // every 15 seconds
-        },
-        handler: () => {
-          this.getLatestBlocks()
-        },
-      },
     })
 
     this.supportedNetworks = [
@@ -1096,17 +1088,6 @@ export default class ChainService extends BaseService<Events> {
     this.emitter.emit("block", block)
     // TODO if it matches a known blockheight and the difficulty is higher,
     // emit a reorg event
-  }
-
-  /*
-   * Poll for latest blocks on all networks
-   */
-  private async getLatestBlocks(): Promise<void> {
-    await Promise.allSettled(
-      this.subscribedNetworks.map(async ({ network, provider }) => {
-        this.pollLatestBlock(network, provider)
-      })
-    )
   }
 
   async send(

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -225,7 +225,7 @@ export default class ChainService extends BaseService<Events> {
       blockPrices: {
         runAtStart: false,
         schedule: {
-          periodInMinutes: 0.5, // Every 30 seconds
+          periodInMinutes: 0.25, // Every 30 seconds
         },
         handler: () => {
           this.pollBlockPrices()

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -1031,7 +1031,14 @@ export default class ChainService extends BaseService<Events> {
     }
   }
 
-  markNetworkActivity(chainID: string): void {
+  async markNetworkActivity(chainID: string): Promise<void> {
+    if (
+      Date.now() - NETWORK_POLLING_TIMEOUT >
+      this.lastUserActivityOnNetwork[chainID]
+    ) {
+      // Reactivating a potentially deactivated network
+      this.pollBlockPricesForNetwork(chainID)
+    }
     this.lastUserActivityOnNetwork[chainID] = Date.now()
   }
 

--- a/background/services/internal-ethereum-provider/index.ts
+++ b/background/services/internal-ethereum-provider/index.ts
@@ -362,7 +362,11 @@ export default class InternalEthereumProviderService extends BaseService<Events>
     }
 
     try {
-      return await this.chainService.activateNetworkOrThrow(chainID)
+      const activatedNetwork = await this.chainService.activateNetworkOrThrow(
+        chainID
+      )
+      this.chainService.markNetworkActivity(chainID)
+      return activatedNetwork
     } catch (e) {
       logger.warn(e)
       return undefined

--- a/background/services/internal-ethereum-provider/index.ts
+++ b/background/services/internal-ethereum-provider/index.ts
@@ -357,6 +357,7 @@ export default class InternalEthereumProviderService extends BaseService<Events>
       (network) => toHexChainID(network.chainID) === toHexChainID(chainID)
     )
     if (activeNetwork) {
+      this.chainService.markNetworkActivity(activeNetwork.chainID)
       return activeNetwork
     }
 

--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -32,6 +32,7 @@ type Events = ServiceLifecycleEvents & {
   requestPermission: PermissionRequest
   initializeAllowedPages: PermissionMap
   setClaimReferrer: string
+  permissionQueriedForChain: string
 }
 
 /**
@@ -339,6 +340,9 @@ export default class ProviderBridgeService extends BaseService<Events> {
     origin: string,
     chainID: string
   ): Promise<PermissionRequest | undefined> {
+    // This is analagous to "User opened a dapp on chain X"
+    this.emitter.emit("permissionQueriedForChain", chainID)
+
     const { address: selectedAddress } =
       await this.preferenceService.getSelectedAccount()
     const currentAddress = selectedAddress

--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -340,7 +340,7 @@ export default class ProviderBridgeService extends BaseService<Events> {
     origin: string,
     chainID: string
   ): Promise<PermissionRequest | undefined> {
-    // This is analagous to "User opened a dapp on chain X"
+    // This is analogous to "User opened a dapp on chain X"
     this.emitter.emit("permissionQueriedForChain", chainID)
 
     const { address: selectedAddress } =

--- a/background/tests/factories.ts
+++ b/background/tests/factories.ts
@@ -1,7 +1,11 @@
 import { keccak256 } from "ethers/lib/utils"
 import { AccountBalance, AddressOnNetwork } from "../accounts"
 import { ETH, ETHEREUM, OPTIMISM } from "../constants"
-import { AnyEVMTransaction, LegacyEVMTransactionRequest } from "../networks"
+import {
+  AnyEVMTransaction,
+  BlockPrices,
+  LegacyEVMTransactionRequest,
+} from "../networks"
 import {
   ChainService,
   KeyringService,
@@ -144,6 +148,25 @@ export const createAddressOnNetwork = (
   overrides: Partial<AddressOnNetwork> = {}
 ): AddressOnNetwork => ({
   address: "0x208e94d5661a73360d9387d3ca169e5c130090cd",
+  network: ETHEREUM,
+  ...overrides,
+})
+
+export const createBlockPrices = (
+  overrides: Partial<BlockPrices> = {}
+): BlockPrices => ({
+  baseFeePerGas: 0n,
+  blockNumber: 25639147,
+  dataSource: "local",
+  estimatedPrices: [
+    {
+      confidence: 99,
+      maxFeePerGas: 0n,
+      maxPriorityFeePerGas: 0n,
+      price: 1001550n,
+    },
+  ],
+  estimatedTransactionCount: null,
   network: ETHEREUM,
   ...overrides,
 })

--- a/ui/pages/Popup.tsx
+++ b/ui/pages/Popup.tsx
@@ -90,11 +90,13 @@ function useConnectPopupMonitor() {
 export function Main(): ReactElement {
   const dispatch = useBackgroundDispatch()
 
-  // Emit an event when the popup page is first loaded.
   const currentAccount = useBackgroundSelector(selectCurrentAddressNetwork)
+  // Emit an event when the popup page is first loaded.
   useEffect(() => {
     dispatch(userActivityEncountered(currentAccount))
-  })
+    // We explicitly do not want to reload on dependency change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const isDappPopup = useIsDappPopup()
   const [shouldDisplayDecoy, setShouldDisplayDecoy] = useState(false)

--- a/ui/pages/Popup.tsx
+++ b/ui/pages/Popup.tsx
@@ -6,6 +6,7 @@ import classNames from "classnames"
 import {
   setRouteHistoryEntries,
   Location,
+  userActivityEncountered,
 } from "@tallyho/tally-background/redux-slices/ui"
 
 import { Store } from "webext-redux"
@@ -17,6 +18,7 @@ import { USE_UPDATED_SIGNING_UI } from "@tallyho/tally-background/features"
 import { popupMonitorPortName } from "@tallyho/tally-background/main"
 import {
   selectCurrentAccountSigner,
+  selectCurrentAddressNetwork,
   selectKeyringStatus,
 } from "@tallyho/tally-background/redux-slices/selectors"
 import { selectIsTransactionPendingSignature } from "@tallyho/tally-background/redux-slices/selectors/transactionConstructionSelectors"
@@ -87,6 +89,12 @@ function useConnectPopupMonitor() {
 
 export function Main(): ReactElement {
   const dispatch = useBackgroundDispatch()
+
+  // Emit an event when the popup page is first loaded.
+  const currentAccount = useBackgroundSelector(selectCurrentAddressNetwork)
+  useEffect(() => {
+    dispatch(userActivityEncountered(currentAccount))
+  })
 
   const isDappPopup = useIsDappPopup()
   const [shouldDisplayDecoy, setShouldDisplayDecoy] = useState(false)


### PR DESCRIPTION
This PR introduces functionality which limits the extension from polling for gas prices when the extension is not active - and lays the groundwork for doing the same with base asset balances, erc20 lookups, and just about any other chain lookup we want to throttle.

## What is going on here.

The central change that this PR introduces is a [central piece of state](https://github.com/tallycash/extension/blob/reduce-the-consumption/background/services/chain/index.ts#L146:L148) inside of chain service which tracks the last time a network was "active".  The current events that trigger a refresh of "active" time are:
-  User has opened or navigated to any page in the extension (currently selected network activity)
-  A dapp has requested to permission to connect to the wallet (dapp's connected network activity)
-  A dapp has requested to switch to a given network (network that is requested to switch to activity)

When any of these events is triggered - one of the following two things happens:
-  If a network was active within [the last 5 minutes](https://github.com/tallycash/extension/blob/reduce-the-consumption/background/services/chain/index.ts#L90:L91) the  "last active time" is refreshed to the current time.
- If a network was not active within the last 5 minutes - blockPrices are immediately requested, and the "last active time" is refreshed to the current time.

Once a network is "active" - gas prices are queried and updated in the background every 15 seconds (per our standard browser alarm pattern) until there has been 5 minutes of no activity on that network.

## What is not going on here

Asset transfer refresh schedule and query frequency is not affected.
Asset balance refresh schedule and query frequency is not affected.
Token price refresh schedule and query frequency is not affected.

## Implementation Notes
- Since this PR does not reduce the frequency of the browser alarms querying for gas prices - we still maintain background-script activity that should prevent the background service worker from being turned off due to inactivity once we switch to manifest v3.
- If we like this pattern - we can extend it to asset transfer and asset balance polling as well - although that will likely require more UX testing that this PR since those queries touch data that we want immediately presentable upon application open.

## To Test
- Change the [`NETWORK_POLLING_TIMEOUT`](https://github.com/tallycash/extension/blob/reduce-the-consumption/background/services/chain/index.ts#L90:L90) to 1 minute.
- Drop some logs inside of [`pollBlockPricesForNetwork`](https://github.com/tallycash/extension/blob/reduce-the-consumption/background/services/chain/index.ts#L1049:L1049) after the first `if` so you can monitor when a network's block prices are being polled.
- Import a wallet and add it to multiple networks
- [ ] After 1 minute of inactivity - you should no longer see logs indicating that block prices are being polled
- [ ] After opening the extension - you should see logs indicating that block prices of the currently selected network are being polled
- [ ] After connecting to a dapp - you should see block prices of the network the dapp is connected to being polled
- [ ] After switching networks in a dapp - you should see block prices of the network you've switched to being polled
- [ ] When signing a transaction - you should see gas prices populating and updating with values similar to what you'd see on https://l2fees.info/