### PR TITLE
Prevent chain service from subscribing to networks twice.

### DIFF
--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -268,13 +268,6 @@ export default class ChainService extends BaseService<Events> {
     const activeNetworks = await this.getActiveNetworks()
 
     // get the latest blocks and subscribe for all active networks
-    // TODO revisit whether we actually want to subscribe to new heads
-    // if a user isn't tracking a relevant addressOnNetwork
-    activeNetworks.forEach(async (network) => {
-      this.subscribeToNetworkEvents(network).catch((e) => {
-        logger.error("Error getting block number or new head", e)
-      })
-    })
 
     Promise.allSettled(
       accounts
@@ -1024,6 +1017,7 @@ export default class ChainService extends BaseService<Events> {
    * Write block prices to IndexedDB so we have them for later
    */
   async pollBlockPrices(): Promise<void> {
+    console.log("polling", this.subscribedNetworks)
     await Promise.allSettled(
       this.subscribedNetworks.map(async ({ network, provider }) => {
         const blockPrices = await getBlockPrices(network, provider)

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -1017,7 +1017,6 @@ export default class ChainService extends BaseService<Events> {
    * Write block prices to IndexedDB so we have them for later
    */
   async pollBlockPrices(): Promise<void> {
-    console.log("polling", this.subscribedNetworks)
     await Promise.allSettled(
       this.subscribedNetworks.map(async ({ network, provider }) => {
         const blockPrices = await getBlockPrices(network, provider)

--- a/background/services/chain/tests/index.integration.test.ts
+++ b/background/services/chain/tests/index.integration.test.ts
@@ -37,14 +37,8 @@ describe("ChainService", () => {
     it("should not add duplicate networks on startup", async () => {
       // Startup is simulated in the `beforeEach`
       expect(
-        chainService.supportedNetworks.filter(
-          (network) => network.chainID === ETHEREUM.chainID
-        )
-      ).toHaveLength(1)
-
-      expect(
-        chainService.supportedNetworks.filter(
-          (network) => network.chainID === POLYGON.chainID
+        chainService.subscribedNetworks.filter(
+          ({ network }) => network.chainID === ETHEREUM.chainID
         )
       ).toHaveLength(1)
     })

--- a/background/services/chain/tests/index.integration.test.ts
+++ b/background/services/chain/tests/index.integration.test.ts
@@ -1,6 +1,6 @@
 import sinon from "sinon"
 import ChainService from ".."
-import { OPTIMISM } from "../../../constants"
+import { ETHEREUM, OPTIMISM, POLYGON } from "../../../constants"
 import {
   AnyEVMTransaction,
   TransactionRequest,
@@ -32,6 +32,24 @@ describe("ChainService", () => {
     chainService = await createChainService()
     await chainService.startService()
   })
+
+  describe("internalStartService", () => {
+    it("should not add duplicate networks on startup", async () => {
+      // Startup is simulated in the `beforeEach`
+      expect(
+        chainService.supportedNetworks.filter(
+          (network) => network.chainID === ETHEREUM.chainID
+        )
+      ).toHaveLength(1)
+
+      expect(
+        chainService.supportedNetworks.filter(
+          (network) => network.chainID === POLYGON.chainID
+        )
+      ).toHaveLength(1)
+    })
+  })
+
   it("handlePendingTransactions should update nonce tracking, subscribe to transaction confirmations, and persist the transaction to indexedDB", async () => {
     const chainServiceExternalized =
       chainService as unknown as ChainServiceExternalized

--- a/background/services/chain/tests/index.integration.test.ts
+++ b/background/services/chain/tests/index.integration.test.ts
@@ -1,6 +1,6 @@
 import sinon from "sinon"
 import ChainService from ".."
-import { ETHEREUM, OPTIMISM, POLYGON } from "../../../constants"
+import { ETHEREUM, OPTIMISM } from "../../../constants"
 import {
   AnyEVMTransaction,
   TransactionRequest,


### PR DESCRIPTION
This should also help decrease our json-rpc usage.

### To Test
- [x] Drop a setInterval inside of chain service that logs `this.subscribedNetworks `
- [x] Ensure that the `this.subscribedNetworks ` array does not have any duplicates.