### PR TITLE
Multiscan: Support Etherscan connections in Tally

### DIFF
--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -151,10 +151,16 @@ export default class ProviderBridgeService extends BaseService<Events> {
       this.emitter.emit("setClaimReferrer", String(referrer))
 
       response.result = null
-    } else if (event.request.method === "eth_chainId") {
-      // we need to send back the chainId independent of dApp permission if we want to be compliant with MM and web3-react
-      // We are calling the `internalEthereumProviderService.routeSafeRPCRequest` directly here, because the point
-      // of this exception is to provide the proper chainId for the dApp, independent from the permissions.
+    } else if (
+      event.request.method === "eth_chainId" ||
+      event.request.method === "net_version"
+    ) {
+      // we need to send back the chainId and net_version (a deprecated
+      // precursor to eth_chainId) independent of dApp permission if we want to
+      // be compliant with MM and web3-react We are calling the
+      // `internalEthereumProviderService.routeSafeRPCRequest` directly here,
+      // because the point of this exception is to provide the proper chainId
+      // for the dApp, independent from the permissions.
       response.result =
         await this.internalEthereumProviderService.routeSafeRPCRequest(
           event.request.method,

--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -29,6 +29,7 @@ const impersonateMetamaskWhitelist = [
   "app.euler.finance",
   "kwenta.io",
   "stargate.finance",
+  "etherscan.io",
 ]
 
 export default class TallyWindowProvider extends EventEmitter {


### PR DESCRIPTION
Will let the picture speak:

<img width="496" alt="Etherscan dApp connection screen" src="https://user-images.githubusercontent.com/8245/192585224-3ca98d29-ab9d-4889-97de-f7a9a38c7664.png">

To do this, we let `net_version` come through before explicit dApp authorization (as we already do with `eth_chainId`, its more contemporary counterpart), and we add Etherscan to the Metamask impersonation list.

Closes #2016, #2290.