### PR TITLE
Multiscan Optimism: Allow wallet_switchEthereumChain calls before authorizing a dApp

### DIFF
--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -176,7 +176,10 @@ export default class ProviderBridgeService extends BaseService<Events> {
         event.request.params,
         origin
       )
-    } else if (event.request.method === "wallet_addEthereumChain") {
+    } else if (
+      event.request.method === "wallet_addEthereumChain" ||
+      event.request.method === "wallet_switchEthereumChain"
+    ) {
       response.result =
         await this.internalEthereumProviderService.routeSafeRPCRequest(
           event.request.method,


### PR DESCRIPTION
This allows certain dApps like Optimism Etherscan to work. It's also in line with our whitelisting wallet_addEthereumChain for access before dApp authorization.

I missed pushing a commit in #2313 and it landed too fast for me to fix it 🙈 