### PR TITLE
Further reduce background calls

### DIFF
--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -225,7 +225,7 @@ export default class ChainService extends BaseService<Events> {
       blockPrices: {
         runAtStart: false,
         schedule: {
-          periodInMinutes: 0.25, // Every 15 seconds
+          periodInMinutes: MINUTE / 4, // Every 15 seconds
         },
         handler: () => {
           this.pollBlockPrices()
@@ -1220,9 +1220,15 @@ export default class ChainService extends BaseService<Events> {
    */
   private async handleRecentIncomingAssetTransferAlarm(): Promise<void> {
     const accountsToTrack = await this.db.getAccountsToTrack()
-
     await Promise.allSettled(
       accountsToTrack.map((an) => this.loadRecentAssetTransfers(an, true))
+    )
+  }
+
+  private isCurrentlyActiveChainID(chainID: string): boolean {
+    return (
+      Date.now() <
+      this.lastUserActivityOnNetwork[chainID] + NETWORK_POLLING_TIMEOUT
     )
   }
 

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -1056,10 +1056,7 @@ export default class ChainService extends BaseService<Events> {
   }
 
   async pollBlockPricesForNetwork(chainID: string): Promise<void> {
-    if (
-      Date.now() >
-      (this.lastUserActivityOnNetwork[chainID] ?? 0) + NETWORK_POLLING_TIMEOUT
-    ) {
+    if (!this.isCurrentlyActiveChainID(chainID)) {
       return
     }
 


### PR DESCRIPTION
Blocked by https://github.com/tallycash/extension/pull/2301

This PR expands upon the work done in https://github.com/tallycash/extension/pull/2301 to further reduce unnecessary background json-rpc calls.

The behavior implemented here is as follows:
- The extension will stop querying for asset transfers on a given network after 5 minutes of inactivity.
- Every 12 hours - the extension will query asset transfer on _all_ networks regardless if they are active or not.
- When a network that was previously marked as deactivated is reactivated again (either by the user or a dapp requesting on that network) recent asset transfers are immediately queried.

## To Test
- Change the [`NETWORK_POLLING_TIMEOUT`](https://github.com/tallycash/extension/blob/reduce-the-consumption/background/services/chain/index.ts#L90:L90) to 1 minute.
- Drop some logs inside of [`loadRecentAssetTransfer`](https://github.com/tallycash/extension/blob/further-reduce-background-calls/background/services/chain/index.ts#L1120:L1120) so you can monitor when asset transfers are being queried.
- Import a wallet and add it to multiple networks
- [ ] After 1 minute of inactivity - you should no longer see logs indicating that transfers are being queried
- [ ] After opening the extension - you should see logs indicating that transfers of the currently selected network are being queried
- [ ] When connecting to a dapp after a period of inactivity - you should see transfers being queried on the network the dapp is connected to.
- [ ] When switching networks in a dapp to a previously inactive network - you shouldsee transfers being queried on the network the dapp has switched to.