### PR TITLE
👻 Banish Ghosts: fix `to-16.ts` migration, to fix green screen of death

### DIFF
--- a/background/redux-slices/migrations/to-16.ts
+++ b/background/redux-slices/migrations/to-16.ts
@@ -68,6 +68,9 @@ export default (prevState: Record<string, unknown>): NewState => {
 
   Object.keys(typedPrevState.activities).forEach((address) => {
     Object.keys(typedPrevState.activities[address]).forEach((chainID) => {
+      if (chainID === "ids" || chainID === "entities") {
+        return
+      }
       Object.keys(typedPrevState.activities[address][chainID].entities).forEach(
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         (_) => {


### PR DESCRIPTION
# What 

An old migration didn't move the `ids` and `entities` from the address level into the `chainID` level but copied it. Because of this these keys are still in the state and there is is entities field inside the `ids` or `entities` array. This has caused migration issues for some folks on brave. The easy nondestructive fix is simply ignore these properties. Because the slice will be refactored soon it did not worth the risk to remove those keys from state.

# Test

⚠️ We don't have a way to reproduce the green screen issue. We just know the error message/line of code and the state of the environment where it happened. So these tests are only to verify that nothing is broken and generally the migrations
are safe. For more context see #2334 

- [x] clean up the dist folder `rm -rf ./dist/chrome/*`
- [x] checkout `v0.14.0` tag
- [x] `yarn build --config-name chrome`
- [x] Install the chrome folder in brave, import seed
- [x] check activity tab, wait for some activity to load
- [x] checkout this branch 
- [x] `yarn build`
- [x] reload the extension, verify the version number change
- [ ] check that you don't get green screen of death

Closes #2334