### PR TITLE
Prevent background dapp connections from marking network activity.

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -1117,7 +1117,7 @@ export default class Main extends BaseService<never> {
     )
 
     this.providerBridgeService.emitter.on(
-      "permissionQueriedForChain",
+      "dappOpenedOnChain",
       async (chainID: string) => {
         this.chainService.markNetworkActivity(chainID)
       }


### PR DESCRIPTION
In our current implementation - a dapp connected to tally in an active or inactive tab will reset `lastUserNetworkActivity` each time it sends a request to the wallet.

This change updates that logic to only set `lastUserNetworkActivity` when `eth_requestAccounts` is received - which is indicative of a user actively navigating to a dapp.