### PR TITLE
Union Jack: Rework SignDataRequest as MessageSigningRequest discriminated union

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -99,7 +99,7 @@ import {
   signDataRequest,
 } from "./redux-slices/signing"
 
-import { SignTypedDataRequest, SignDataRequest } from "./utils/signing"
+import { SignTypedDataRequest, MessageSigningRequest } from "./utils/signing"
 import {
   emitter as earnSliceEmitter,
   setVaultsAsStale,
@@ -1040,7 +1040,7 @@ export default class Main extends BaseService<never> {
         resolver,
         rejecter,
       }: {
-        payload: SignDataRequest
+        payload: MessageSigningRequest
         resolver: (result: string | PromiseLike<string>) => void
         rejecter: () => void
       }) => {

--- a/background/services/internal-ethereum-provider/index.ts
+++ b/background/services/internal-ethereum-provider/index.ts
@@ -27,7 +27,7 @@ import { internalProviderPort } from "../../redux-slices/utils/contract-utils"
 
 import {
   SignTypedDataRequest,
-  SignDataRequest,
+  MessageSigningRequest,
   parseSigningData,
 } from "../../utils/signing"
 import { SUPPORT_OPTIMISM } from "../../features"
@@ -72,7 +72,7 @@ type Events = ServiceLifecycleEvents & {
     SignedTransaction
   >
   signTypedDataRequest: DAppRequestEvent<SignTypedDataRequest, string>
-  signDataRequest: DAppRequestEvent<SignDataRequest, string>
+  signDataRequest: DAppRequestEvent<MessageSigningRequest, string>
   // connect
   // disconnet
   // account change
@@ -396,7 +396,7 @@ export default class InternalEthereumProviderService extends BaseService<Events>
     const hexInput = input.match(/^0x[0-9A-Fa-f]*$/)
       ? input
       : hexlify(toUtf8Bytes(input))
-    const { data, type } = parseSigningData(input)
+    const typeAndData = parseSigningData(input)
     const activeNetwork = await this.getActiveOrDefaultNetwork(origin)
 
     return new Promise<string>((resolve, reject) => {
@@ -406,9 +406,8 @@ export default class InternalEthereumProviderService extends BaseService<Events>
             address: account,
             network: activeNetwork,
           },
-          signingData: data,
-          messageType: type,
           rawSigningData: hexInput,
+          ...typeAndData,
         },
         resolver: resolve,
         rejecter: reject,

--- a/background/utils/signing.ts
+++ b/background/utils/signing.ts
@@ -34,17 +34,26 @@ export type SignTypedDataRequest = {
 
 export type ExpectedSigningData = EIP191Data | EIP4361Data
 
-export type SignDataRequest = {
-  account: AddressOnNetwork
-  rawSigningData: string
-  signingData: ExpectedSigningData
-  messageType: SignDataMessageType
+type EIP191SigningData = {
+  messageType: "eip191"
+  signingData: EIP191Data
 }
 
-export enum SignDataMessageType {
-  EIP191 = 0,
-  EIP4361 = 1,
+type EIP4361SigningData = {
+  messageType: "eip4361"
+  signingData: EIP4361Data
 }
+
+export type MessageSigningData = EIP191SigningData | EIP4361SigningData
+
+export type MessageSigningRequest<
+  T extends MessageSigningData = MessageSigningData
+> = T & {
+  account: AddressOnNetwork
+  rawSigningData: string
+}
+
+export type SigningDataType = "eip191" | "eip4361"
 
 type EIP2612Message = {
   owner: HexString
@@ -89,10 +98,7 @@ const checkEIP4361: (message: string) => EIP4361Data | undefined = (
  *
  * EIP4361 standard can be found https://eips.ethereum.org/EIPS/eip-4361
  */
-export const parseSigningData: (signingData: string) => {
-  data: ExpectedSigningData
-  type: SignDataMessageType
-} = (signingData) => {
+export function parseSigningData(signingData: string): MessageSigningData {
   let normalizedData = signingData
 
   // Attempt to normalize hex signing data to a UTF-8 string message. If the
@@ -121,19 +127,13 @@ export const parseSigningData: (signingData: string) => {
   const data = checkEIP4361(normalizedData)
   if (data) {
     return {
-      data,
-      type: SignDataMessageType.EIP4361,
+      messageType: "eip4361",
+      signingData: data,
     }
   }
 
-  // data = checkOtherType(lines)
-  // if (!!data) {
-  // return data
-  // }
-
-  // add additional checks for any other types to add in the future
   return {
-    data: normalizedData,
-    type: SignDataMessageType.EIP191,
+    messageType: "eip191",
+    signingData: normalizedData,
   }
 }

--- a/ui/components/SignData/EIP191Info.tsx
+++ b/ui/components/SignData/EIP191Info.tsx
@@ -1,9 +1,9 @@
 import React from "react"
-import { SignDataRequest } from "@tallyho/tally-background/utils/signing"
+import { MessageSigningRequest } from "@tallyho/tally-background/utils/signing"
 import { useTranslation } from "react-i18next"
 
 const EIP191Info: React.FC<{
-  signingData: SignDataRequest["signingData"]
+  signingData: MessageSigningRequest["signingData"]
   account: string
   internal: boolean
   // FIXME Drop this once new signing flow is final.

--- a/ui/components/Signing/SignatureDetails/DataSignatureDetails/MessageDataSignatureDetails.tsx
+++ b/ui/components/Signing/SignatureDetails/DataSignatureDetails/MessageDataSignatureDetails.tsx
@@ -1,35 +1,28 @@
 import { assertUnreachable } from "@tallyho/tally-background/lib/utils/type-guards"
-import {
-  EIP4361Data,
-  SignDataMessageType,
-  SignDataRequest,
-} from "@tallyho/tally-background/utils/signing"
+import { MessageSigningRequest } from "@tallyho/tally-background/utils/signing"
 import React, { ReactElement } from "react"
 import EIP191Info from "../../../SignData/EIP191Info"
 import EIP4361Info from "../../../SignData/EIP4361Info"
 import DataSignatureDetails from "."
 
 export type MessageDataSignatureDetailsProps = {
-  messageRequest: SignDataRequest
+  messageRequest: MessageSigningRequest
 }
 
 export default function MessageDataSignatureDetails({
   messageRequest,
 }: MessageDataSignatureDetailsProps): ReactElement {
   switch (messageRequest.messageType) {
-    case SignDataMessageType.EIP4361:
+    case "eip4361":
       return (
         <DataSignatureDetails
-          requestingSource={(messageRequest.signingData as EIP4361Data).domain}
+          requestingSource={messageRequest.signingData.domain}
           excludeTitle
         >
-          <EIP4361Info
-            signingData={messageRequest.signingData as EIP4361Data}
-            excludeHeader
-          />
+          <EIP4361Info signingData={messageRequest.signingData} excludeHeader />
         </DataSignatureDetails>
       )
-    case SignDataMessageType.EIP191:
+    case "eip191":
       return (
         <DataSignatureDetails>
           <EIP191Info
@@ -41,6 +34,6 @@ export default function MessageDataSignatureDetails({
         </DataSignatureDetails>
       )
     default:
-      return assertUnreachable(messageRequest.messageType)
+      return assertUnreachable(messageRequest)
   }
 }

--- a/ui/components/Signing/SignatureDetails/index.tsx
+++ b/ui/components/Signing/SignatureDetails/index.tsx
@@ -12,7 +12,7 @@ import {
   signTransaction,
 } from "@tallyho/tally-background/redux-slices/transaction-construction"
 import {
-  SignDataRequest,
+  MessageSigningRequest,
   SignTypedDataRequest,
 } from "@tallyho/tally-background/utils/signing"
 import { AccountSigner } from "@tallyho/tally-background/services/signing"
@@ -55,7 +55,7 @@ export function resolveTransactionSignatureDetails({
 export function resolveDataSignatureDetails({
   request,
   accountSigner,
-}: SignOperation<SignDataRequest>): ResolvedSignatureDetails {
+}: SignOperation<MessageSigningRequest>): ResolvedSignatureDetails {
   return {
     signer: accountSigner,
     signingAddress: request.account,

--- a/ui/pages/PersonalSign.tsx
+++ b/ui/pages/PersonalSign.tsx
@@ -9,11 +9,11 @@ import {
   signData,
   selectSigningData,
 } from "@tallyho/tally-background/redux-slices/signing"
-import { SignDataMessageType } from "@tallyho/tally-background/utils/signing"
 import { useHistory } from "react-router-dom"
 import { USE_UPDATED_SIGNING_UI } from "@tallyho/tally-background/features"
 import { ReadOnlyAccountSigner } from "@tallyho/tally-background/services/signing"
 import { useTranslation } from "react-i18next"
+import { SigningDataType } from "@tallyho/tally-background/utils/signing"
 import {
   useBackgroundDispatch,
   useBackgroundSelector,
@@ -23,9 +23,9 @@ import PersonalSignDetailPanel from "./PersonalSignDetailPanel"
 import SignTransactionContainer from "../components/SignTransaction/SignTransactionContainer"
 import Signing from "../components/Signing"
 
-const TITLE: Record<SignDataMessageType, string> = {
-  [SignDataMessageType.EIP4361]: "Sign in with Ethereum",
-  [SignDataMessageType.EIP191]: "Sign Message",
+const TITLE: Record<SigningDataType, string> = {
+  eip4361: "Sign in with Ethereum",
+  eip191: "Sign Message",
 }
 
 export default function PersonalSignData(): ReactElement {

--- a/ui/pages/PersonalSignDetailPanel.tsx
+++ b/ui/pages/PersonalSignDetailPanel.tsx
@@ -1,7 +1,3 @@
-import {
-  EIP4361Data,
-  SignDataMessageType,
-} from "@tallyho/tally-background/utils/signing"
 import { selectSigningData } from "@tallyho/tally-background/redux-slices/signing"
 import React from "react"
 import { EIP191Info, EIP4361Info } from "../components/SignData"
@@ -18,13 +14,11 @@ export default function PersonalSignDetailPanel(): JSX.Element {
         <div className="container">
           {(() => {
             switch (signingDataRequest.messageType) {
-              case SignDataMessageType.EIP4361:
+              case "eip4361":
                 return (
-                  <EIP4361Info
-                    signingData={signingDataRequest.signingData as EIP4361Data}
-                  />
+                  <EIP4361Info signingData={signingDataRequest.signingData} />
                 )
-              case SignDataMessageType.EIP191:
+              case "eip191":
               default:
                 return (
                   <EIP191Info


### PR DESCRIPTION
> [The **Union Jack**, or **Union Flag**, is the de facto national flag of the United Kingdom. Although no law has been passed making the Union Jack the official national flag of the United Kingdom, it has effectively become such through precedent. It is sometimes asserted that the term *Union Jack* properly refers only to naval usage, but this assertion was dismissed by the Flag Institute in 2013 following historical investigations.](https://en.wikipedia.org/wiki/Union_Jack)

`SignDataRequest` was an envelope container for (personal, non-typed-data) message signing requests that were further subdivided by type, and different message types (such as SIWE messages) had more specific parsed data types in a `signingData` field. `SignDataMessageType` was an integer enum that was used for message types.

The complicating factor with this approach was that trying to narrow the types in consuming code was impossible, as the types were represented without a way to type-guard the parsed message data. The result was a need to check against `messageType` and the `SignDataMessageType` enum, followed by an ostensibly unguarded `as` cast for the parsed data in `signingData` itself.

The new approach uses a `MessageSigningRequest` envelope type that is specialized by a type parameter, and that type parameter is a discriminated union of possible signing data types called `MessageSigningData`. The envelope type is structured the exact same way as previously, but the typing allows for the `messageType` to be used as a discriminant that guards the `signingData` type as well, removing the need for an `as` cast and requiring instantiating code to adhere to one of the discriminated type/data pairs rather than allowing for instantiation of mixed types.

One other notable change here is moving away from enums, which are a less favored TypeScript feature, to a simple discriminated union type of string constants for the different message types.

## Testing

- [x] Check Sign In With Ethereum signatures still works as expected. Can be checked at https://login.xyz/ under Get Started.
- [x] Check regular message signing still works as expected. Can be checked at https://mintkudos.xyz/ on Polygon by hitting Connect Wallet.

Closes #2332.