### PR TITLE
Trackmania - separate active, tracked, and current networks.

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -538,7 +538,7 @@ export default class Main extends BaseService<never> {
       setNewSelectedAccount({
         address: accounts[0].address,
         network:
-          await this.internalEthereumProviderService.getActiveOrDefaultNetwork(
+          await this.internalEthereumProviderService.getCurrentOrDefaultNetworkForOrigin(
             TALLY_INTERNAL_ORIGIN
           ),
       })

--- a/background/main.ts
+++ b/background/main.ts
@@ -517,13 +517,13 @@ export default class Main extends BaseService<never> {
       address: string
     }>
   ): Promise<void> {
-    const activeNetworks = await this.chainService.getActiveNetworks()
+    const trackedNetworks = await this.chainService.getTrackedNetworks()
     await Promise.all(
       accounts.map(async ({ path, address }) => {
         await this.ledgerService.saveAddress(path, address)
 
         await Promise.all(
-          activeNetworks.map(async (network) => {
+          trackedNetworks.map(async (network) => {
             const addressNetwork = {
               address,
               network,
@@ -869,8 +869,8 @@ export default class Main extends BaseService<never> {
     })
 
     this.keyringService.emitter.on("address", async (address) => {
-      const activeNetworks = await this.chainService.getActiveNetworks()
-      activeNetworks.forEach((network) => {
+      const trackedNetworks = await this.chainService.getTrackedNetworks()
+      trackedNetworks.forEach((network) => {
         // Mark as loading and wire things up.
         this.store.dispatch(
           loadAccount({

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -144,10 +144,10 @@ export default class IndexingService extends BaseService<Events> {
     this.connectChainServiceEvents()
 
     this.chainService.emitter.once("serviceStarted").then(async () => {
-      const activeNetworks = await this.chainService.getActiveNetworks()
+      const trackedNetworks = await this.chainService.getTrackedNetworks()
 
       // Push any assets we have cached in the db for all active networks
-      activeNetworks.forEach(async (network) => {
+      trackedNetworks.forEach(async (network) => {
         await this.cacheAssetsForNetwork(network)
         this.emitter.emit("assets", this.cachedAssets[network.chainID])
       })
@@ -609,13 +609,15 @@ export default class IndexingService extends BaseService<Events> {
 
     // get the prices of all assets to track and save them
     const assetsToTrack = await this.db.getAssetsToTrack()
-    const activeNetworks = await this.chainService.getActiveNetworks()
+    const trackedNetworks = await this.chainService.getTrackedNetworks()
 
     // Filter all assets based on supported networks
     const activeAssetsToTrack = assetsToTrack.filter(
       (asset) =>
         asset.symbol === "ETH" ||
-        activeNetworks.map((n) => n.chainID).includes(asset.homeNetwork.chainID)
+        trackedNetworks
+          .map((n) => n.chainID)
+          .includes(asset.homeNetwork.chainID)
     )
 
     try {
@@ -623,7 +625,7 @@ export default class IndexingService extends BaseService<Events> {
 
       const allActiveAssetsByAddress = getAssetsByAddress(activeAssetsToTrack)
 
-      const activeAssetsByNetwork = activeNetworks.map((network) => ({
+      const activeAssetsByNetwork = trackedNetworks.map((network) => ({
         activeAssetsByAddress: getActiveAssetsByAddressForNetwork(
           network,
           activeAssetsToTrack
@@ -733,11 +735,11 @@ export default class IndexingService extends BaseService<Events> {
     this.fetchAndCacheTokenLists()
 
     const assetsToTrack = await this.db.getAssetsToTrack()
-    const activeNetworks = await this.chainService.getActiveNetworks()
+    const trackedNetworks = await this.chainService.getTrackedNetworks()
     // TODO doesn't support multi-network assets
     // like USDC or CREATE2-based contracts on L1/L2
     const activeAssetsToTrack = assetsToTrack.filter((asset) =>
-      activeNetworks.map((n) => n.chainID).includes(asset.homeNetwork.chainID)
+      trackedNetworks.map((n) => n.chainID).includes(asset.homeNetwork.chainID)
     )
 
     // wait on balances being written to the db, don't wait on event emission

--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -129,7 +129,7 @@ export default class ProviderBridgeService extends BaseService<Events> {
     }
 
     const { chainID } =
-      await this.internalEthereumProviderService.getActiveOrDefaultNetwork(
+      await this.internalEthereumProviderService.getCurrentOrDefaultNetworkForOrigin(
         origin
       )
 
@@ -276,7 +276,7 @@ export default class ProviderBridgeService extends BaseService<Events> {
       // we know that url exists because it was required to store the port
       const { origin } = new URL(port.sender?.url as string)
       const { chainID } =
-        await this.internalEthereumProviderService.getActiveOrDefaultNetwork(
+        await this.internalEthereumProviderService.getCurrentOrDefaultNetworkForOrigin(
           origin
         )
       if (await this.checkPermission(origin, chainID)) {


### PR DESCRIPTION
Since we are moving towards a new definition of what an "active" network is as shown in https://github.com/tallycash/extension/pull/2301, https://github.com/tallycash/extension/pull/2318, https://github.com/tallycash/extension/pull/2338 its important we update our nomenclature in the codebase as well.

This PR attempts to split up the idea of an Supported Network / Active Network / Tracked Network / Current Network and codify that semantic splitting through method and variable names.  

The loose definitions are:
- Supported Network: A network that the extension is able to track
- Tracked Network: A network that the extension is tracking or has ever tracked.
- Active Network: A network that the extension is actively tracking / listening to.
- Current Network: The network that a given dapp (or the internal wallet) is connected to.

I suspect once our work to limit JSON-RPC usage the distinction between Supported Network and Tracked Network will disappear (in fact this could be an indicator of the success of that effort) but we are not there quite yet.