### PR TITLE
rename `NetworkSettingsOptimismAndArbitrum` > `NetworkSettingsOptimism ` for unambiguity

### DIFF
--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -172,7 +172,7 @@
       "invalidLimit": "Gas Limit must be a number",
       "lowGas": "Low"
     },
-    "optimismOrArbitrum": {
+    "optimism": {
       "title": "Network fees",
       "header": "Gas fees on {{name}} work differently from Ethereum.",
       "transactionFee": "Transaction fee",

--- a/ui/components/NetworkFees/NetworkSettingsChooser.tsx
+++ b/ui/components/NetworkFees/NetworkSettingsChooser.tsx
@@ -11,7 +11,7 @@ import {
 } from "@tallyho/tally-background/redux-slices/selectors/transactionConstructionSelectors"
 import { useBackgroundDispatch, useBackgroundSelector } from "../../hooks"
 import NetworkSettingsSelect from "./NetworkSettingsSelect"
-import NetworkSettingsOptimismAndArbitrum from "./NetworkSettingsSelectOptimismAndArbitrum"
+import NetworkSettingsOptimism from "./NetworkSettingsSelectOptimism"
 import NetworkSettingsSelectLegacy from "./NetworkSettingsSelectLegacy"
 
 interface NetworkSettingsChooserProps {
@@ -38,7 +38,7 @@ export default function NetworkSettingsChooser({
   function networkSettingsSelectorFinder() {
     if (transactionDetails) {
       if (transactionDetails.network.name === "Optimism") {
-        return <NetworkSettingsOptimismAndArbitrum />
+        return <NetworkSettingsOptimism />
       }
       if (transactionDetails.network.name === "Arbitrum") {
         return (

--- a/ui/components/NetworkFees/NetworkSettingsSelectOptimism.tsx
+++ b/ui/components/NetworkFees/NetworkSettingsSelectOptimism.tsx
@@ -9,9 +9,9 @@ import { useTranslation } from "react-i18next"
 import { useBackgroundSelector } from "../../hooks"
 import SharedButton from "../Shared/SharedButton"
 
-export default function NetworkSettingsOptimismAndArbitrum(): ReactElement {
+export default function NetworkSettingsOptimism(): ReactElement {
   const { t } = useTranslation("translation", {
-    keyPrefix: "networkFees.optimismOrArbitrum",
+    keyPrefix: "networkFees.optimism",
   })
 
   const transactionData = useBackgroundSelector(selectTransactionData)


### PR DESCRIPTION
We have decided to use the legacy networks select panel for gas setting on arbitrum, so it doesn't make sense anymore to keep this nameing. 

Closes #2360