### PR TITLE
😢 But why?: remove nonce if received from dapp

### DIFF
--- a/background/services/internal-ethereum-provider/index.ts
+++ b/background/services/internal-ethereum-provider/index.ts
@@ -213,7 +213,11 @@ export default class InternalEthereumProviderService extends BaseService<Events>
       }
       case "eth_sendTransaction":
         return this.signTransaction(
-          params[0] as JsonRpcTransactionRequest,
+          {
+            ...(params[0] as JsonRpcTransactionRequest),
+            // we populate the nonce during the signing process. If we receive one, it's safer to just ignore it.
+            nonce: undefined,
+          },
           origin
         ).then(async (signed) => {
           await this.chainService.broadcastSignedTransaction(signed)


### PR DESCRIPTION
1inch sends nonce from mainnet when approving
assets on arbitrum and this causes the broadcast
to fail

we lookup the nonce during the signing process
so it's safe to ignore this parameter from the dapp

Closes #2370 