### PR TITLE
add arbiscan url for nft links

### DIFF
--- a/ui/components/NFTs/NFTsSlideUpPreviewContent.tsx
+++ b/ui/components/NFTs/NFTsSlideUpPreviewContent.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from "react"
 import {
+  ARBITRUM_ONE,
   ETHEREUM,
   OPTIMISM,
   POLYGON,
@@ -25,6 +26,7 @@ function getPreviewLink(nft: NFT) {
     [POLYGON.chainID]: `/token/${contractAddress}?a=${parsedTokenID}`,
     [ETHEREUM.chainID]: `/nft/${contractAddress}/${parsedTokenID}`,
     [OPTIMISM.chainID]: `/token/${contractAddress}?a=${parsedTokenID}`,
+    [ARBITRUM_ONE.chainID]: `/token/${contractAddress}?a=${parsedTokenID}`,
   }
 
   return `${scanWebsite[chainID].url}${previewURL[chainID]}`


### PR DESCRIPTION
# Test

- add `0x77f6e4ea32f0b807dcaaddbec9dabe0131614cd5 ` as a readonly address
- check if the snolizard is linked properly to arbiscan
  - [reference url](https://arbiscan.io//token/0x0dCCAb3f2FC587b67bFDC66ffd2c87a567B21394?a=1742)

Closes #2375 