### PR TITLE
(*・‿・)ノ⌒*:･ﾟ✧ Remove the `$schema` prop from yearn token list

### DIFF
--- a/background/lib/token-lists.ts
+++ b/background/lib/token-lists.ts
@@ -22,6 +22,11 @@ const cleanTokenListResponse = (json: any, url: string) => {
       const { tags, ...cleanedJson } = json
       return cleanedJson
     }
+  } else if (url.includes("meta.yearn.finance/api/tokens/list")) {
+    if (typeof json === "object" && json !== null && "$schema" in json) {
+      const { $schema, ...cleanedJson } = json
+      return cleanedJson
+    }
   }
   return json
 }


### PR DESCRIPTION
> [Glitter Whip](https://www.fastemoji.com/(*%E3%83%BB%E2%80%BF%E3%83%BB)%E3%83%8E%E2%8C%92*:%EF%BD%A5%EF%BE%9F%E2%9C%A7-Meaning-Emoji-Emoticon-Glitter-Whip-Ascii-Art-Fancy-Happy-Funny-Japanese-Kaomoji-Smileys-9299.html)
> (*・‿・)ノ⌒*:･ﾟ✧


The uniswap token list format validation does not pass because of this extra parameter.