### PR TITLE
Don't inject provider on non html documents

### DIFF
--- a/provider-bridge/index.ts
+++ b/provider-bridge/index.ts
@@ -67,6 +67,8 @@ export function connectProviderBridge(): void {
 }
 
 export function injectTallyWindowProvider(): void {
+  if (document.contentType !== "text/html") return
+
   try {
     const container = document.head || document.documentElement
     const scriptTag = document.createElement("script")


### PR DESCRIPTION
This should prevent weird script tags from appearing on xml docs

<img width="833" alt="image" src="https://user-images.githubusercontent.com/28708889/196252856-5ae9d69a-ae67-4648-8875-67beddde0f5b.png">


Ref: https://discord.com/channels/808358975287722045/888500174685614090/1031480622377615420

## To Test:
- [ ] [Open an xml document](https://www.w3schools.com/xml/note.xml), it should display correctly
- [ ] Check the script tag does not appear in other document formats