### PR TITLE
Throttle CoinGecko API calls.

### DIFF
--- a/background/lib/prices.ts
+++ b/background/lib/prices.ts
@@ -17,27 +17,6 @@ import { USD } from "../constants"
 
 const COINGECKO_API_ROOT = "https://api.coingecko.com/api/v3"
 
-export async function getPrice(
-  coingeckoCoinId = "ethereum",
-  currencySymbol = "usd"
-): Promise<number | null> {
-  const url = `${COINGECKO_API_ROOT}/simple/price?ids=${coingeckoCoinId}&vs_currencies=${currencySymbol}&include_last_updated_at=true`
-
-  const json = await fetchJson(url)
-
-  if (!isValidCoinGeckoPriceResponse(json)) {
-    logger.warn(
-      "CoinGecko price response didn't validate, did the API change?",
-      json,
-      isValidCoinGeckoPriceResponse.errors
-    )
-
-    return null
-  }
-
-  return json?.[coingeckoCoinId]?.[currencySymbol] || null
-}
-
 export async function getPrices(
   assets: (AnyAsset & CoinGeckoAsset)[],
   vsCurrencies: FiatCurrency[]

--- a/background/tests/prices.test.ts
+++ b/background/tests/prices.test.ts
@@ -4,7 +4,7 @@ import * as ethers from "@ethersproject/web" // << THIS IS THE IMPORTANT TRICK
 import logger from "../lib/logger"
 import { BTC, ETH, FIAT_CURRENCIES, USD } from "../constants"
 import { CoinGeckoAsset } from "../assets"
-import { getPrice, getPrices } from "../lib/prices"
+import { getPrices } from "../lib/prices"
 import { isValidCoinGeckoPriceResponse } from "../lib/validate"
 
 const dateNow = 1634911514834
@@ -128,45 +128,6 @@ describe("lib/prices.ts", () => {
 
       expect(isValidCoinGeckoPriceResponse.errors).toMatchObject(error)
       expect(validationResult).toBeFalsy()
-    })
-  })
-  describe("getPrice", () => {
-    beforeEach(() => {
-      // Important to clean up the internal mock variables between tests
-      jest.clearAllMocks()
-    })
-    it("should return correct price if the data exist", async () => {
-      const response = {
-        ethereum: {
-          usd: 3832.26,
-          last_updated_at: 1634671650,
-        },
-      }
-
-      jest.spyOn(ethers, "fetchJson").mockResolvedValue(response)
-      await expect(getPrice("ethereum", "usd")).resolves.toEqual(
-        response.ethereum.usd
-      )
-      expect(ethers.fetchJson).toHaveBeenCalledTimes(1)
-    })
-    it("should return null if the data DOESN'T exist", async () => {
-      const response = {
-        ethereum: {
-          last_updated_at: 1634671650,
-        },
-      }
-
-      jest.spyOn(ethers, "fetchJson").mockResolvedValue(response)
-      await expect(getPrice("ethereum", "usd")).resolves.toBeNull()
-      expect(ethers.fetchJson).toHaveBeenCalledTimes(1)
-    })
-    it("should return null if the api response does not fit the schema", async () => {
-      const response = "Na na na na na na na na na na na na ... BATMAN!"
-
-      jest.spyOn(ethers, "fetchJson").mockResolvedValue(response)
-
-      await expect(getPrice("ethereum", "usd")).resolves.toBeNull()
-      expect(ethers.fetchJson).toHaveBeenCalledTimes(1)
     })
   })
   describe("getPrices", () => {


### PR DESCRIPTION
This PR fixes an issue where if the product of (Addresses & Networks) was more than 60 - users would _always_ hit the coingecko ratelimit - and if it was less than that they were likely to when adding multiple addresses or networks at once (or while using coingecko.com).

This PR lays down some groundwork for https://github.com/tallycash/extension/issues/2134

There are two common scenarios happening that may rate-limit coingecko for users (and result in inconsistent prices).

1.  When the extension is first loaded - chain service emits every account on every network as part of the `newAccountToTrack` event - each of which triggers a call to `handlePricealarm`.

2.  When a user switches to a network for the first time - a `newAccountToTrack` event is emitted for every account in the wallet.

By throttling the `handlePriceAlarm` function - we ensure that these bursts of `newAccounttoTrack` events do not result in repeated duplicate calls to coinGecko - and mitigate the risk of the user exceeding the coingecko API limits.

### To Test
- [ ] Load up a new wallet, Open network tab in devtools.
- [ ] Prices should load for ethereum wallet.
- [ ] Switch to polygon - prices should load.
- [ ] Switch to optimism / arbitrum - prices should load.
- [ ] "Refresh" the wallet via - filter the devtools panel - you should see:
  - [ ] One request to `/simple/prices?ids=...`
  - [ ] N requests to `/simple/token_price/...` where N is the number of networks you have added.
  - [ ] Crucially you should not see multiple requests to the same URL within 5 seconds.