### PR TITLE
Add the apex.exchange to the 'impersonate MM'

### DIFF
--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -31,6 +31,7 @@ const impersonateMetamaskWhitelist = [
   "stargate.finance",
   "etherscan.io",
   "swapr.eth.link",
+  "apex.exchange",
 ]
 
 export default class TallyWindowProvider extends EventEmitter {


### PR DESCRIPTION
Closes #2452 

This PR adds the Apex to the 'impersonate MM' list . Swapr was added earlier. 

**Before**
<img width="240" alt="Screenshot 2022-10-19 at 11 48 15" src="https://user-images.githubusercontent.com/23117945/196661443-16428dc1-95c5-470b-ad70-34e56ef58c51.png">
**After**
<img width="240" alt="Screenshot 2022-10-19 at 11 53 24" src="https://user-images.githubusercontent.com/23117945/196661460-0cc9330b-f4a1-4e38-9935-a4b6342f1584.png">

**To Test**
Set Tally Ho as default wallet.
- [ ] go to [apex.exchange](https://apex.exchange/) and choose MM wallet 