### PR TITLE
Fix: weblate badge URL in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,5 +351,5 @@ Tally currently only support English as the default language. We distil english 
 For other languages, we will use language code defined in [Support locales](https://developer.chrome.com/docs/webstore/i18n/#choosing-locales-to-support). We will use [weblate](https://hosted.weblate.org/projects/tallycash/extension/) for crowd translation, and will commit back to the github periodically after these translations are QA'ed.
 
 <a href="https://hosted.weblate.org/engage/tallycash/">
-<img src="https://hosted.weblate.org/widgets/tallycash/-/extension/multi-auto.svg" alt="Translation status" />
+<img src="https://hosted.weblate.org/widgets/tallycash/-/svg-badge.svg" alt="Translation status" />
 </a>


### PR DESCRIPTION
The badge src was wrong:
<img width="857" alt="Screenshot 2022-10-20 at 18 41 56" src="https://user-images.githubusercontent.com/381895/197008492-6cb37636-0c4f-4bec-9790-ac31cec2b61d.png">

After the fix:

<img width="857" alt="Screenshot 2022-10-20 at 18 42 43" src="https://user-images.githubusercontent.com/381895/197008642-c565f478-96d9-4a25-b745-73420d1efc75.png">
