### PR TITLE
Fix swaps involving assets for which we do not have price data.

### DIFF
--- a/background/redux-slices/utils/0x-swap-utils.ts
+++ b/background/redux-slices/utils/0x-swap-utils.ts
@@ -48,7 +48,7 @@ export async function getAssetPricePoint(
   asset: SmartContractFungibleAsset | FungibleAsset,
   assets: AssetsState,
   network: EVMNetwork
-): Promise<PricePoint> {
+): Promise<PricePoint | undefined> {
   const assetPricesNetworks = assets
     .filter(
       (assetItem) =>
@@ -63,11 +63,11 @@ export async function getAssetPricePoint(
       return contractAddress
     })
 
-  const unitPricePoint = Object.values(
+  const [unitPricePoint] = Object.values(
     await getTokenPrices(assetPricesNetworks, USD, network)
-  )[0]
+  )
 
-  return getPricePoint(asset, unitPricePoint)
+  return (unitPricePoint && getPricePoint(asset, unitPricePoint)) || undefined
 }
 
 export async function getAssetAmount(


### PR DESCRIPTION
Since we are currently somewhat limited by how we can do price discovery for coingecko assets right now - we might not have prices for assets on some chains - especially if a bridged asset has a different contract address on a given L2.

We should still support swapping to / from these assets even if we don't  have a good way of getting their price data currently.

### To Test
- [x] Switch to Optimism
- [x] Try swapping OP <> POOL
- [x] Swap should go through 👍 

Note that currently we display `$0.00` as the price for the asset we're swapping to when a price is unknown - this should probably change to something more descriptive to the user but is out of the scope of this bugfix.