### PR TITLE
Transitional Fossil: Transition icon colors on hover where relevant

### DIFF
--- a/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
+++ b/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
@@ -285,6 +285,7 @@ export default function AccountsNotificationPanelAccounts({
                           width={25}
                           color="var(--green-40)"
                           hoverColor={`var(--${keyringData.color})`}
+                          transitionHoverTime="0.2s"
                         />
                       </button>
                     )}

--- a/ui/components/Shared/SharedIcon.tsx
+++ b/ui/components/Shared/SharedIcon.tsx
@@ -6,6 +6,7 @@ type Props = {
   height?: number
   color?: string
   hoverColor?: string
+  transitionHoverTime: string
   customStyles?: string
   ariaLabel?: string
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void
@@ -18,6 +19,7 @@ export default function SharedIcon(props: Props): ReactElement {
     height = width,
     color = "transparent",
     hoverColor = color,
+    transitionHoverTime,
     customStyles = "",
     ariaLabel,
     onClick,
@@ -39,6 +41,7 @@ export default function SharedIcon(props: Props): ReactElement {
           cursor: ${onClick ? "pointer" : "auto"};
           background-color: ${color};
           ${customStyles};
+          transition: background-color ${transitionHoverTime};
         }
         .icon:hover {
           background-color: ${hoverColor};
@@ -46,4 +49,8 @@ export default function SharedIcon(props: Props): ReactElement {
       `}</style>
     </button>
   )
+}
+
+SharedIcon.defaultProps = {
+  transitionHoverTime: "0",
 }

--- a/ui/pages/Send.tsx
+++ b/ui/pages/Send.tsx
@@ -337,7 +337,7 @@ export default function Send(): ReactElement {
             background-color: var(--green-95);
             padding: 0px 16px;
 
-            transition: padding-bottom 300ms;
+            transition: padding-bottom 0.2s;
           }
           input#send_address::placeholder {
             color: var(--green-40);
@@ -373,10 +373,13 @@ export default function Send(): ReactElement {
             margin-left: 16px;
             margin-bottom: 5px;
 
-            transition: color 300ms;
+            transition: color 0.2s;
           }
           input#send_address ~ .address:hover {
             color: var(--gold-80);
+          }
+          input#send_address ~ .address > :global(.icon) {
+            transition: background-color 0.2s;
           }
           input#send_address ~ .address:hover > :global(.icon) {
             background-color: var(--gold-80);


### PR DESCRIPTION
In a few places, icons were being used alongside text whose color transitioned on hover. Because the icons are not colored the same way, the icon colors would change instantly instead of transitioning, which led to a jerkiness in the hover animation.

SharedIcon now has a transitionHoverTime property that sets the time it takes to transition the icon color on hover. This is applied appropriately for the account lock/unlock button in the accounts panel, as well as for the address copy button on the Send page.

## Testing

- [ ] Hover over the “Unlock signing” button in the accounts panel and note that the text and icon transition simultaneously instead of the icon switching colors immediately.
- [ ] Hover over the "Lock signing" button after unlocking, and see the same.
- [ ] Go to the Send page, enter an ENS or local account name. Hover over the resolved address below the name and note the text and icon transitioning simultaneously.