### PR TITLE
Mock Websocket Connections - Fix a number of issues relating to tests running inconsistently in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,14 +12,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Read .nvmrc
       run: echo "::set-output name=NVMRC::$(cat ./.nvmrc)"
       id: nvm
     - name: Use Node + Yarn
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: "${{ steps.nvm.outputs.NVMRC }}"
         cache: "yarn"
@@ -42,7 +42,7 @@ jobs:
         COMMIT_SHA: ${{ github.sha }}
     - name: Upload build asset
       if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: extension-builds
         path: dist/*.zip
@@ -57,12 +57,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Read .nvmrc
       run: echo "::set-output name=NVMRC::$(cat ./.nvmrc)"
       id: nvm
     - name: Use Node + Yarn
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: "${{ steps.nvm.outputs.NVMRC }}"
         cache: "yarn"
@@ -71,12 +71,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Read .nvmrc
       run: echo "::set-output name=NVMRC::$(cat ./.nvmrc)"
       id: nvm
     - name: Use Node + Yarn
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: "${{ steps.nvm.outputs.NVMRC }}"
         cache: "yarn"

--- a/background/services/chain/tests/index.unit.test.ts
+++ b/background/services/chain/tests/index.unit.test.ts
@@ -7,6 +7,7 @@ import {
   createAddressOnNetwork,
   createBlockPrices,
   createChainService,
+  makeSerialFallbackProvider,
 } from "../../../tests/factories"
 import { UNIXTime } from "../../../types"
 import {
@@ -14,6 +15,7 @@ import {
   EnrichedLegacyTransactionSignatureRequest,
 } from "../../enrichment"
 import { AddressOnNetwork } from "../../../accounts"
+import * as serialFallbackProvider from "../serial-fallback-provider"
 
 type ChainServiceExternalized = Omit<ChainService, ""> & {
   populatePartialEIP1559TransactionRequest: () => void
@@ -36,6 +38,11 @@ describe("Chain Service", () => {
   let chainService: ChainService
   beforeEach(async () => {
     sandbox.restore()
+    sandbox
+      .stub(serialFallbackProvider, "makeSerialFallbackProvider")
+      .callsFake(() => {
+        return makeSerialFallbackProvider() as any
+      })
     chainService = await createChainService()
   })
 

--- a/background/services/chain/tests/index.unit.test.ts
+++ b/background/services/chain/tests/index.unit.test.ts
@@ -111,6 +111,10 @@ describe("Chain Service", () => {
       await chainService.startService()
     })
 
+    afterEach(async () => {
+      await chainService.stopService()
+    })
+
     it("should correctly update lastUserActivityOnNetwork", async () => {
       jest.useFakeTimers()
 
@@ -148,6 +152,10 @@ describe("Chain Service", () => {
     beforeEach(async () => {
       sandbox.stub(chainService, "supportedNetworks").value([ETHEREUM])
       await chainService.startService()
+    })
+
+    afterEach(async () => {
+      await chainService.stopService()
     })
 
     it("should call markNetworkActivity with the correct network", async () => {

--- a/background/services/chain/tests/index.unit.test.ts
+++ b/background/services/chain/tests/index.unit.test.ts
@@ -7,7 +7,6 @@ import {
   createAddressOnNetwork,
   createBlockPrices,
   createChainService,
-  makeSerialFallbackProvider,
 } from "../../../tests/factories"
 import { UNIXTime } from "../../../types"
 import {
@@ -15,7 +14,6 @@ import {
   EnrichedLegacyTransactionSignatureRequest,
 } from "../../enrichment"
 import { AddressOnNetwork } from "../../../accounts"
-import * as serialFallbackProvider from "../serial-fallback-provider"
 
 type ChainServiceExternalized = Omit<ChainService, ""> & {
   populatePartialEIP1559TransactionRequest: () => void
@@ -38,11 +36,7 @@ describe("Chain Service", () => {
   let chainService: ChainService
   beforeEach(async () => {
     sandbox.restore()
-    sandbox
-      .stub(serialFallbackProvider, "makeSerialFallbackProvider")
-      .callsFake(() => {
-        return makeSerialFallbackProvider() as any
-      })
+
     chainService = await createChainService()
   })
 

--- a/background/services/name/tests/index.integration.test.ts
+++ b/background/services/name/tests/index.integration.test.ts
@@ -18,6 +18,7 @@ describe("NameService", () => {
   })
 
   it("Looks up and returns names from built-in contracts", async () => {
+    sandbox.stub(nameService, "lookUpAvatar").callsFake(async () => undefined)
     const nameRecord = await nameService.lookUpName({
       address: "0x52ec2f3d7c5977a8e558c8d9c6000b615098e8fc",
       network: ETHEREUM,

--- a/background/tests/factories.ts
+++ b/background/tests/factories.ts
@@ -1,4 +1,7 @@
+/* eslint-disable class-methods-use-this */
+import { Block, FeeData } from "@ethersproject/abstract-provider"
 import { DexieOptions } from "dexie"
+import { BigNumber } from "ethers"
 import { keccak256 } from "ethers/lib/utils"
 import { AccountBalance, AddressOnNetwork } from "../accounts"
 import { ETH, ETHEREUM, OPTIMISM } from "../constants"
@@ -17,6 +20,7 @@ import {
   PreferenceService,
   SigningService,
 } from "../services"
+import SerialFallbackProvider from "../services/chain/serial-fallback-provider"
 
 const createRandom0xHash = () =>
   keccak256(Buffer.from(Math.random().toString()))
@@ -202,3 +206,57 @@ export const createBlockPrices = (
   network: ETHEREUM,
   ...overrides,
 })
+
+export const makeEthersBlock = (overrides?: Partial<Block>): Block => {
+  return {
+    hash: "0x20567436620bf18c07cf34b3ec4af3e530d7a2391d7a87fb0661565186f4e834",
+    parentHash:
+      "0x9b97cacd4900848628fb9efcc25da51e56c08f27604b5947151ccf6401b915c6",
+    number: 30639839,
+    timestamp: 1666373439,
+    nonce: "0x0000000000000000",
+    difficulty: 2,
+    gasLimit: BigNumber.from(15000000),
+    gasUsed: BigNumber.from(295345),
+    miner: "0x0000000000000000000000000000000000000000",
+    extraData:
+      "0xd98301090a846765746889676f312e31352e3133856c696e75780000000000006028a2a4a8d227a5f0b51f8c71096d9b86374a7831ec6928f00d296eac6a42850d332d31c15b6f71509708a252f1af3317c35b137d6411710b13f90a0a1148e900",
+    transactions: [
+      "0x2fe683d3a72693e9c338f430e9af68a3b69d449ab04f191d5eff9010c4e94da0",
+    ],
+    _difficulty: BigNumber.from(2),
+    ...overrides,
+  }
+}
+
+export const makeEthersFeeData = (overrides?: Partial<FeeData>): FeeData => {
+  return {
+    maxFeePerGas: BigNumber.from(123274909666),
+    maxPriorityFeePerGas: BigNumber.from(2500000000),
+    gasPrice: BigNumber.from(91426599419),
+    ...overrides,
+  }
+}
+
+export const makeSerialFallbackProvider =
+  (): Partial<SerialFallbackProvider> => {
+    class MockSerialFallbackProvider {
+      async getBlock() {
+        return makeEthersBlock()
+      }
+
+      async getBlockNumber() {
+        return 1
+      }
+
+      async getBalance() {
+        return BigNumber.from(100)
+      }
+
+      async getFeeData() {
+        return makeEthersFeeData()
+      }
+    }
+
+    return new MockSerialFallbackProvider()
+  }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@tallyho/window-provider": "0.0.1",
     "buffer": "^6.0.3",
     "react": "^17.0.2",
+    "sinon": "^14.0.1",
     "webext-options-sync": "^2.0.1",
     "webext-redux": "^2.1.7",
     "webextension-polyfill": "^0.7.0"

--- a/setupJest.env.ts
+++ b/setupJest.env.ts
@@ -1,3 +1,19 @@
+import sinon from "sinon"
+import SerialFallbackProvider, * as serialFallbackProvider from "@tallyho/tally-background/services/chain/serial-fallback-provider"
+import { makeSerialFallbackProvider } from "@tallyho/tally-background/tests/factories"
+
+const sandbox = sinon.createSandbox()
+/* Reset IndexedDB between tests */
+beforeEach(() => {
+  sandbox.restore()
+  sandbox
+    .stub(serialFallbackProvider, "makeSerialFallbackProvider")
+    .callsFake(() => {
+      return makeSerialFallbackProvider() as SerialFallbackProvider
+    })
+  global.indexedDB = new IDBFactory()
+})
+
 /* Reset IndexedDB between tests */
 afterEach(() => {
   global.indexedDB = new IDBFactory()

--- a/yarn.lock
+++ b/yarn.lock
@@ -11608,6 +11608,18 @@ sinon@^14.0.0:
     nise "^5.1.1"
     supports-color "^7.2.0"
 
+sinon@^14.0.1:
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-14.0.1.tgz#9f02e13ad86b695c0c554525e3bf7f8245b31a9c"
+  integrity sha512-JhJ0jCiyBWVAHDS+YSjgEbDn7Wgz9iIjA1/RK+eseJN0vAAWIWiXBdrnb92ELPyjsfreCYntD1ORtLSfIrlvSQ==
+  dependencies:
+    "@sinonjs/commons" "^1.8.3"
+    "@sinonjs/fake-timers" "^9.1.2"
+    "@sinonjs/samsam" "^6.1.1"
+    diff "^5.0.0"
+    nise "^5.1.1"
+    supports-color "^7.2.0"
+
 sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"


### PR DESCRIPTION
This PR addresses a number of issues encountered while debugging tests failing in CI (but passing locally)

### Highlights
- Global mock (during tests) of the SerialFallbackProvider to avoid creating websocket connections during testing.
- [Upgraded from node12 to node 16 github actions.](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)
- Attempt local name resolution prior to using remote name resolvers.
- Explicitly stop chain after tests which start it are run.
- [Fix to an intermittently failing name service test.]

### To Test
- [ ] CHIEFLY - tests should pass locally without network connectivity (turn off wifi).
- [ ] `yarn test` should not fail the `NameService Looks up and returns names from built-in contracts` test
- [ ] Address name resolution should continue to work as expected in activities / send asset / read-only import.
- [ ] Our builds in github should no longer contain warnings about using an out-of-date version of Node.