### PR TITLE
[FIX] Remove RSK Testnet option from dPath dropdown

### DIFF
--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -166,8 +166,7 @@
       "bip44": "BIP 44 (Trezor, 🦊)",
       "ethTestnet": "Ethereum Testnet",
       "ledgerLegacy": "Ledger Legacy",
-      "rsk": "RSK",
-      "rskTestnet": "RSK Tetnet"
+      "rsk": "RSK"
     }
   },
   "networkFees": {

--- a/ui/components/Onboarding/OnboardingDerivationPathSelect.tsx
+++ b/ui/components/Onboarding/OnboardingDerivationPathSelect.tsx
@@ -35,10 +35,6 @@ const initialDerivationPaths: Option[] = [
     value: "m/44'/137'/0'/0",
     label: i18n.t("ledger.derivationPaths.rsk"),
   },
-  {
-    value: "m/44'/37310'/0'/0",
-    label: i18n.t("ledger.derivationPaths.rskTestnet"),
-  },
 ]
 
 const initialCustomPath = {


### PR DESCRIPTION
## Description
This PR removes RSK testnet option from derivation path selection screen as this is not required for RSK integration release. 

## Demo 
<img width="415" alt="Screenshot 2022-10-25 at 6 35 07 PM" src="https://user-images.githubusercontent.com/104683677/197803547-1186487a-f12c-4f43-89a5-8aac8f241a97.png">


## Type of Change
- [X] Bug Fix

## Testing information
- Activate `HIDE_IMPORT_DERIVATION_PATH` env flag
- Now check the Import account screen (dpath select dropdown)

## Checklist
- [X] Git hooks enabled
- [X] No lint errors
- [X] Git commit is signed
