### PR TITLE
Inject Tally Ho as a connection option on abroad.exchange

### DIFF
--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -36,6 +36,7 @@ const impersonateMetamaskWhitelist = [
   "apex.exchange",
   "app.yieldprotocol.com",
   "tofunft.com",
+  "aboard.exchange",
 ]
 
 export default class TallyWindowProvider extends EventEmitter {

--- a/window-provider/wallet-connection-handlers.ts
+++ b/window-provider/wallet-connection-handlers.ts
@@ -171,11 +171,39 @@ function findAndReplaceTofuNftMetamaskOption(addedNode: Node): void {
   }
 }
 
+function findAndReplaceAboardMetamaskOption(addedNode: Node): void {
+  if (moreThanOneWalletInstalledAndTallyIsNotDefault()) {
+    return
+  }
+
+  const maybeIconsContainer = (addedNode as HTMLElement)?.children?.[0]
+    ?.children?.[0]?.children?.[0]?.children?.[1]?.children?.[1]
+
+  if (
+    !maybeIconsContainer ||
+    !maybeIconsContainer.classList.contains("wallets-wrapper")
+  ) {
+    return
+  }
+
+  // children are `HTMLCollection`'s without array methods.
+  // eslint-disable-next-line no-restricted-syntax
+  for (const child of maybeIconsContainer.children?.[0]?.children) {
+    if (child.innerHTML.includes("img/metamask")) {
+      child.innerHTML = child.innerHTML.replace(
+        /\ssrc="(.+)"\s/,
+        ` src="${TALLY_ICON_URL}" `
+      )
+    }
+  }
+}
+
 const hostnameToHandler = {
   "uniswap.org": findAndReplaceUniswapInjectedOption,
   "gmx.io": findAndReplaceGMXMetamaskOption,
   "app.yieldprotocol.com": findAndReplaceYieldProtocolMetamaskOption,
   "tofunft.com": findAndReplaceTofuNftMetamaskOption,
+  "aboard.exchange": findAndReplaceAboardMetamaskOption,
 } as const
 
 export default function monitorForWalletConnectionPrompts(): void {


### PR DESCRIPTION

https://user-images.githubusercontent.com/94649004/197816072-cccca7bc-55b9-4fde-9be3-13ed040af757.mov

### To Test
- [ ] Navigate to [abroad.exchange](https://app.aboard.exchange/futures/arbitrum/#/ETH-USDC)
- [ ] Attempt to Connect Wallet
  - [ ] If Metamask is not installed - Tally Ho should be an option.
  - [ ] If Metamask is installed and Tally Ho is set as default - Tally Ho should be an option.
  - [ ] IF Metamask is installed and Tally Ho is not default - Tally Ho should not be an option.