### PR TITLE
[FIX] Use `RSK` network in `RNS` resolver

### DIFF
--- a/background/services/name/resolvers/rns.ts
+++ b/background/services/name/resolvers/rns.ts
@@ -1,7 +1,7 @@
 import { JsonRpcProvider } from "@ethersproject/providers"
 import { Contract, utils, constants } from "ethers"
 import { AddressOnNetwork, NameOnNetwork } from "../../../accounts"
-import { ETHEREUM } from "../../../constants"
+import { RSK } from "../../../constants"
 import { sameNetwork } from "../../../networks"
 import { NameResolver } from "../name-resolver"
 import logger from "../../../lib/logger"
@@ -43,7 +43,7 @@ export default function rnsResolver(): NameResolver<"RNS"> {
       return false
     },
     canAttemptAddressResolution({ name, network }: NameOnNetwork): boolean {
-      return sameNetwork(network, ETHEREUM) && name.endsWith(".rsk")
+      return sameNetwork(network, RSK) && name.endsWith(".rsk")
     },
 
     async lookUpAddressForName({


### PR DESCRIPTION
## Description
This PR fixes `rnsResolver` to use `RSK` network. Using `ETHEREUM` network in `rnsResolver` is incorrect and due to this reason `RNS` names are not resolving on send screen.

## Demo 
<img width="905" alt="demo" src="https://user-images.githubusercontent.com/104683677/198262886-77d17385-d819-4d05-abdc-ae819758536f.png">


## Type of Change
- [X] Bug Fix

## Testing information
- Activate `SUPPORT_RSK` env flag
- Choose `RSK` network
- Enter an `RNS` name in send field
- Examples Name: `alepc.rsk`, `riverplate.rsk`
- It should resolve to the correct address on rsk network

## Checklist
- [X] Git hooks enabled
- [X] No lint errors
- [X] Git commit is signed
