### PR TITLE
Fix account settings icon not displaying

### DIFF
--- a/background/services/preferences/db.ts
+++ b/background/services/preferences/db.ts
@@ -7,13 +7,13 @@ import DEFAULT_PREFERENCES from "./defaults"
 import { AccountSignerSettings } from "../../ui"
 import { AccountSignerWithId } from "../../signing"
 
+type SignerRecordId = `${AccountSignerWithId["type"]}/${string}`
+
 /**
  * Returns a unique id for an account signer
  * in the form of "signerType/someId" e.g. "ledger/deviceId"
  */
-const getSignerRecordId = (
-  signer: AccountSignerWithId
-): `${AccountSignerWithId["type"]}/${string}` => {
+const getSignerRecordId = (signer: AccountSignerWithId): SignerRecordId => {
   const id = signer.type === "keyring" ? signer.keyringID : signer.deviceID
   return `${signer.type}/${id}`
 }
@@ -34,7 +34,7 @@ export class PreferenceDatabase extends Dexie {
   private preferences!: Dexie.Table<Preferences, number>
 
   private signersSettings!: Dexie.Table<
-    AccountSignerSettings & { id: `${"ledger" | "keyring"}/${string}` },
+    AccountSignerSettings & { id: SignerRecordId },
     string
   >
 

--- a/ui/components/AccountItem/AccountItemOptionsMenu.tsx
+++ b/ui/components/AccountItem/AccountItemOptionsMenu.tsx
@@ -73,14 +73,15 @@ export default function AccountItemOptionsMenu({
         </div>
       </SharedSlideUpMenu>
       <SharedDropdown
-        toggler={
+        toggler={(toggle) => (
           <button
             type="button"
             className="icon_settings"
             role="menu"
+            onClick={() => toggle()}
             tabIndex={0}
           />
-        }
+        )}
         options={[
           {
             key: "edit",

--- a/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
+++ b/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
@@ -146,14 +146,15 @@ function WalletTypeHeader({
         </h2>
         {accountType !== AccountType.ReadOnly && (
           <SharedDropdown
-            toggler={
+            toggler={(toggle) => (
               <SharedIcon
                 color="var(--green-40)"
                 customStyles="cursor: pointer;"
                 width={24}
+                onClick={() => toggle()}
                 icon="settings.svg"
               />
-            }
+            )}
             options={[
               {
                 key: "edit",

--- a/ui/components/Shared/SharedDropDown.test.tsx
+++ b/ui/components/Shared/SharedDropDown.test.tsx
@@ -8,7 +8,11 @@ describe("SharedDropdown", () => {
     const itemAction = jest.fn()
     const ui = render(
       <SharedDropdown
-        toggler={<button type="button">hello</button>}
+        toggler={(toggle) => (
+          <button type="button" onClick={() => toggle()}>
+            toggle dropdown
+          </button>
+        )}
         options={[
           {
             key: "test",
@@ -20,7 +24,7 @@ describe("SharedDropdown", () => {
       />
     )
 
-    const toggler = await ui.findByText("hello")
+    const toggler = await ui.findByText("toggle dropdown")
     expect(toggler).toBeInTheDocument()
 
     expect(ui.queryByText("First Item")).not.toBeInTheDocument()
@@ -34,7 +38,11 @@ describe("SharedDropdown", () => {
     const itemAction = jest.fn()
     const ui = render(
       <SharedDropdown
-        toggler={<button type="button">hello</button>}
+        toggler={(toggle) => (
+          <button type="button" onClick={() => toggle()}>
+            toggle dropdown
+          </button>
+        )}
         options={[
           {
             key: "test",
@@ -46,7 +54,7 @@ describe("SharedDropdown", () => {
       />
     )
 
-    const toggler = await ui.findByText("hello")
+    const toggler = await ui.findByText("toggle dropdown")
     expect(toggler).toBeInTheDocument()
 
     await userEvent.click(toggler)

--- a/ui/components/Shared/SharedDropDown.tsx
+++ b/ui/components/Shared/SharedDropDown.tsx
@@ -25,7 +25,9 @@ const useDropdownContext = () => {
 
 type DropdownContainerProps = { children: React.ReactNode }
 
-type TogglerProps = { children: React.ReactNode }
+type TogglerProps = {
+  children: (toggle: DropdownContextValue["toggle"]) => React.ReactNode
+}
 
 type ContentProps = {
   children:
@@ -59,16 +61,7 @@ function DropdownContainer({ children }: DropdownContainerProps): ReactElement {
 function DropdownToggler({ children }: TogglerProps): ReactElement {
   const { toggle } = useDropdownContext()
 
-  return (
-    <div
-      role="button"
-      tabIndex={-1}
-      onClick={() => toggle(true)}
-      onKeyUp={() => toggle(true)}
-    >
-      {children}
-    </div>
-  )
+  return <div role="presentation">{children(toggle)}</div>
 }
 
 function FadeIn({
@@ -151,7 +144,7 @@ export default function SharedDropdown({
   options,
   toggler,
 }: {
-  toggler: React.ReactElement
+  toggler: (toggle: DropdownContextValue["toggle"]) => React.ReactElement
   options: Array<DropdownOption | undefined>
 }): React.ReactElement {
   const { t } = useTranslation()


### PR DESCRIPTION
The settings icon was not displaying because when #2523 got tested and merged it did not include a recently merged update to `SharedIcon` rendering 

Latest build: [extension-builds-2541](https://github.com/tallycash/extension/suites/9082050358/artifacts/420636406) (as of Wed, 02 Nov 2022 06:10:09 GMT).