### PR TITLE
Price impact improvements

### DIFF
--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -47,7 +47,8 @@
     "priceImpactTooltip": {
       "firstLine": "Price difference between assets is high.",
       "secondLine": "This is due to low liquidity of the swap pair."
-    }
+    },
+    "noAssetPrice": "No price information"
   },
   "comingSoon": "Coming soon",
   "dappConnection": {

--- a/ui/components/Shared/SharedAssetInput.tsx
+++ b/ui/components/Shared/SharedAssetInput.tsx
@@ -314,13 +314,21 @@ function AdditionalInformation(
     []
   )
 
-  return (
-    <div className="simple_text content_wrap">
-      {showCurrencyAmount && (
+  const renderAmountMainCurrency = () => (
+    <>
+      {priceDetails !== undefined && amountMainCurrency === undefined ? (
+        t("noAssetPrice")
+      ) : (
         <>
           {amountMainCurrency === "0.00" && "<"}${amountMainCurrency || "0.00"}
         </>
       )}
+    </>
+  )
+
+  return (
+    <div className="simple_text content_wrap">
+      {showCurrencyAmount && renderAmountMainCurrency()}
       {showPriceImpact &&
         priceDetails?.priceImpact !== undefined &&
         priceDetails?.priceImpact < 0 && (

--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -605,7 +605,7 @@ export default function Swap(): ReactElement {
                 amount={buyAmount}
                 amountMainCurrency={priceDetails?.buyCurrencyAmount}
                 showCurrencyAmount
-                priceImpact={priceDetails?.priceImpact}
+                showPriceImpact
                 // FIXME Merge master asset list with account balances.
                 assetsAndAmounts={buyAssets.map((asset) => ({ asset }))}
                 selectedAsset={buyAsset}


### PR DESCRIPTION
Closes #2472 

Sometimes we don't get the price of assets. In such cases, we aren't able to display the price in $ and we can't calculate the price impact. The user should be informed of this. 

This PR displays the correct information when we don't have a price for any of the assets.

**UI**
Before
<img width="240" alt="Screenshot 2022-11-08 at 14 04 08" src="https://user-images.githubusercontent.com/23117945/200572129-396664fd-877b-48c4-85bd-99bdb5022cbb.png">

After
<img width="240" alt="Screenshot 2022-11-07 at 15 22 41" src="https://user-images.githubusercontent.com/23117945/200571898-9c2c6ca2-3112-45c2-9c13-bb095ae4722a.png">

**To Test**
- [ ] go to the swap panel and try to swap assets that don't have the price. (OP -> sBTC). Check that the message is visible.