### PR TITLE
Add token contract links to the asset selector component

### DIFF
--- a/ui/components/Shared/SharedAssetInput.tsx
+++ b/ui/components/Shared/SharedAssetInput.tsx
@@ -50,6 +50,7 @@ const symbolPriority = Object.fromEntries(
   ])
 )
 interface SelectAssetMenuContentProps<AssetType extends AnyAsset> {
+  currentNetwork: EVMNetwork
   assets: AnyAssetWithOptionalAmount<AssetType>[]
   setSelectedAssetAndClose: (
     asset: AnyAssetWithOptionalAmount<AssetType>
@@ -116,7 +117,7 @@ function SelectAssetMenuContent<T extends AnyAsset>(
   props: SelectAssetMenuContentProps<T>
 ): ReactElement {
   const { t } = useTranslation()
-  const { setSelectedAssetAndClose, assets } = props
+  const { setSelectedAssetAndClose, assets, currentNetwork } = props
   const [searchTerm, setSearchTerm] = useState("")
   const searchInput = useRef<HTMLInputElement | null>(null)
 
@@ -177,6 +178,7 @@ function SelectAssetMenuContent<T extends AnyAsset>(
               }
               assetAndAmount={assetWithOptionalAmount}
               onClick={() => setSelectedAssetAndClose(assetWithOptionalAmount)}
+              currentNetwork={currentNetwork}
             />
           )
         })}
@@ -481,6 +483,7 @@ export default function SharedAssetInput<T extends AnyAsset>(
       >
         {assetsAndAmounts && (
           <SelectAssetMenuContent
+            currentNetwork={currentNetwork}
             assets={assetsAndAmounts}
             setSelectedAssetAndClose={setSelectedAssetAndClose}
           />

--- a/ui/components/Shared/SharedAssetItem.tsx
+++ b/ui/components/Shared/SharedAssetItem.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement, useEffect, useState } from "react"
 import { AnyAsset, AnyAssetAmount } from "@tallyho/tally-background/assets"
 import { EVMNetwork } from "@tallyho/tally-background/networks"
+import { RSK } from "@tallyho/tally-background/constants"
 import SharedAssetIcon from "./SharedAssetIcon"
 import SharedIcon from "./SharedIcon"
 import { scanWebsite } from "../../utils/constants"
@@ -45,7 +46,9 @@ export default function SharedAssetItem<T extends AnyAsset>(
   useEffect(() => {
     const baseLink = scanWebsite[currentNetwork.chainID]?.url
     if ("contractAddress" in asset && baseLink) {
-      setContractLink(`${baseLink}/token/${asset.contractAddress}`)
+      const contractBase =
+        currentNetwork.chainID === RSK.chainID ? "address" : "token"
+      setContractLink(`${baseLink}/${contractBase}/${asset.contractAddress}`)
     } else {
       setContractLink("")
     }


### PR DESCRIPTION
Ref #2583
### What
Let's add a link to the scan website to make it easier for users to know what token it is - to avoid confusion where there are multiple tokens with the same or very similar names on the list.

https://user-images.githubusercontent.com/20949277/201067230-deca9eea-542f-4b2f-a915-00d83f73f088.mov


### Testing

- [ ] open asset selector (send or swap page) and check if links are working correctly
- [ ] base asset won't have link to the contract as it is not a token

Latest build: [extension-builds-2584](https://github.com/tallycash/extension/suites/9232166466/artifacts/431486585) (as of Thu, 10 Nov 2022 10:33:34 GMT).