### PR TITLE
Add transferto.xyz to MetaMask impersonation list

### DIFF
--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -20,6 +20,7 @@ import monitorForWalletConnectionPrompts from "./wallet-connection-handlers"
 // TODO: we don't want to impersonate MetaMask everywhere to not break existing integrations,
 //       so let's do this only on the websites that need this feature
 const impersonateMetamaskWhitelist = [
+  "transferto.xyz",
   "opensea.io",
   "gmx.io",
   "app.lyra.finance",


### PR DESCRIPTION
## To test
- [ ] Go to https://transferto.xyz, try to connect your wallet

Latest build: [extension-builds-2605](https://github.com/tallycash/extension/suites/9262627746/artifacts/433616041) (as of Fri, 11 Nov 2022 20:14:04 GMT).