### PR TITLE
Add POAP NFTs support

### DIFF
--- a/background/constants/networks.ts
+++ b/background/constants/networks.ts
@@ -89,11 +89,13 @@ export const NETWORK_FOR_LEDGER_SIGNING = [ETHEREUM, POLYGON]
 
 // Networks that are not added to this struct will
 // not have an in-wallet NFT tab
-export const CHAIN_ID_TO_NFT_METADATA_PROVIDER = {
-  [ETHEREUM.chainID]: "alchemy" as const,
-  [POLYGON.chainID]: "alchemy" as const,
-  [OPTIMISM.chainID]: "simplehash" as const,
-  [ARBITRUM_ONE.chainID]: "simplehash" as const,
+export const CHAIN_ID_TO_NFT_METADATA_PROVIDER: {
+  [chainID: string]: ("alchemy" | "simplehash" | "poap")[]
+} = {
+  [ETHEREUM.chainID]: ["alchemy", "poap"],
+  [POLYGON.chainID]: ["alchemy"],
+  [OPTIMISM.chainID]: ["simplehash"],
+  [ARBITRUM_ONE.chainID]: ["simplehash"],
 }
 
 export const NETWORKS_SUPPORTING_NFTS = new Set(

--- a/background/lib/poap.ts
+++ b/background/lib/poap.ts
@@ -1,0 +1,55 @@
+import logger from "./logger"
+import { AddressOnNetwork } from "../accounts"
+import { fetchWithTimeout } from "../utils/fetching"
+
+export type PoapNFTModel = {
+  event: {
+    id: number
+    fancy_id: string
+    name: string
+    event_url: string
+    image_url: string
+    country: string
+    city: string
+    description: string
+    year: number
+    start_date: string
+    end_date: string
+    expiry_date: string
+    supply: number
+  }
+  tokenId: string
+  owner: string
+  chain: string
+}
+
+/**
+ * Returns list of POAPs for a given address. Doesn't take into account the network as
+ * most of the POAPs are on the Gnosis chain, small % on Ethereum mainnet. This function should
+ * return all POAPs, regardeless of the chain.
+ *
+ * More information: https://documentation.poap.tech/reference/getactionsscan-5
+ *
+ * @param address address of account that holds POAPs
+ * @returns
+ */
+export async function getNFTs({
+  address,
+}: AddressOnNetwork): Promise<PoapNFTModel[]> {
+  const requestURL = new URL(`https://api.poap.tech/actions/scan/${address}`)
+  const headers = new Headers()
+  headers.set("X-API-KEY", process.env.POAP_API_KEY ?? "")
+
+  try {
+    const result = (await (
+      await fetchWithTimeout(requestURL.toString(), {
+        headers,
+      })
+    ).json()) as unknown as PoapNFTModel[]
+    return result
+  } catch (err) {
+    logger.error("Errr retrieving NFTs", err)
+  }
+
+  return []
+}


### PR DESCRIPTION
### What

- Show POAP in NFTs tabs
- Treat them as Achievements on Ethereum mainnet - as we aren't currently supporting Gnosis chain. 

### Testing

- [ ] add addresses that have POAPs, check them out in Portfolio page and Wallet page
- [ ] check the POAP NFT link - it should lead to the POAPs scan website

![image](https://user-images.githubusercontent.com/20949277/201682758-05578414-111a-4c9e-aa8c-675dea877dc1.png)
![image](https://user-images.githubusercontent.com/20949277/201682941-36804cc6-bf05-486e-b8c8-748b80a0a9f6.png)



Latest build: [extension-builds-2608](https://github.com/tallycash/extension/suites/9293170709/artifacts/435886969) (as of Mon, 14 Nov 2022 14:21:04 GMT).