### PR TITLE
Mark Rootstock as beta in network selector

### DIFF
--- a/background/constants/networks.ts
+++ b/background/constants/networks.ts
@@ -9,7 +9,7 @@ export const ETHEREUM: EVMNetwork = {
   coingeckoPlatformID: "ethereum",
 }
 
-export const RSK: EVMNetwork = {
+export const ROOTSTOCK: EVMNetwork = {
   name: "Rootstock",
   baseAsset: RBTC,
   chainID: "30",
@@ -75,7 +75,7 @@ export const CHAINS_WITH_MEMPOOL = new Set(
 export const NETWORK_BY_CHAIN_ID = {
   [ETHEREUM.chainID]: ETHEREUM,
   [POLYGON.chainID]: POLYGON,
-  [RSK.chainID]: RSK,
+  [ROOTSTOCK.chainID]: ROOTSTOCK,
   [ARBITRUM_ONE.chainID]: ARBITRUM_ONE,
   [OPTIMISM.chainID]: OPTIMISM,
   [GOERLI.chainID]: GOERLI,
@@ -127,7 +127,7 @@ export const ALCHEMY_SUPPORTED_CHAIN_IDS = new Set(
 export const CHAIN_ID_TO_RPC_URLS: {
   [chainId: string]: Array<string> | undefined
 } = {
-  [RSK.chainID]: ["https://public-node.rsk.co"],
+  [ROOTSTOCK.chainID]: ["https://public-node.rsk.co"],
   [POLYGON.chainID]: ["https://polygon-rpc.com"],
   [OPTIMISM.chainID]: [
     "https://rpc.ankr.com/optimism",

--- a/background/main.ts
+++ b/background/main.ts
@@ -116,7 +116,7 @@ import {
   GOERLI,
   OPTIMISM,
   POLYGON,
-  RSK,
+  ROOTSTOCK,
 } from "./constants"
 import { clearApprovalInProgress, clearSwapQuote } from "./redux-slices/0x-swap"
 import {
@@ -1226,7 +1226,7 @@ export default class Main extends BaseService<never> {
     providerBridgeSliceEmitter.on("grantPermission", async (permission) => {
       await Promise.all(
         // TODO: replace this with this.chainService.supportedNetworks when removing the chain feature flags
-        [ETHEREUM, POLYGON, OPTIMISM, GOERLI, ARBITRUM_ONE, RSK].map(
+        [ETHEREUM, POLYGON, OPTIMISM, GOERLI, ARBITRUM_ONE, ROOTSTOCK].map(
           async (network) => {
             await this.providerBridgeService.grantPermission({
               ...permission,
@@ -1241,7 +1241,7 @@ export default class Main extends BaseService<never> {
       "denyOrRevokePermission",
       async (permission) => {
         await Promise.all(
-          [ETHEREUM, POLYGON, OPTIMISM, GOERLI, ARBITRUM_ONE, RSK].map(
+          [ETHEREUM, POLYGON, OPTIMISM, GOERLI, ARBITRUM_ONE, ROOTSTOCK].map(
             async (network) => {
               await this.providerBridgeService.denyOrRevokePermission({
                 ...permission,

--- a/background/redux-slices/dapp.ts
+++ b/background/redux-slices/dapp.ts
@@ -3,7 +3,7 @@ import Emittery from "emittery"
 import { PermissionRequest } from "@tallyho/provider-bridge-shared"
 import { createBackgroundAsyncThunk } from "./utils"
 import { keyPermissionsByChainIdAddressOrigin } from "../services/provider-bridge/utils"
-import { ETHEREUM, GOERLI, OPTIMISM, POLYGON, RSK } from "../constants"
+import { ETHEREUM, GOERLI, OPTIMISM, POLYGON, ROOTSTOCK } from "../constants"
 
 export type DAppPermissionState = {
   permissionRequests: { [origin: string]: PermissionRequest }
@@ -118,12 +118,16 @@ const dappSlice = createSlice({
           delete updatedPermissionRequests[permission.origin]
 
           // Support all networks regardless of which one initiated grant request
-          const permissions = [ETHEREUM, RSK, POLYGON, OPTIMISM, GOERLI].map(
-            (network) => ({
-              ...permission,
-              chainID: network.chainID,
-            })
-          )
+          const permissions = [
+            ETHEREUM,
+            ROOTSTOCK,
+            POLYGON,
+            OPTIMISM,
+            GOERLI,
+          ].map((network) => ({
+            ...permission,
+            chainID: network.chainID,
+          }))
 
           const allowedPermission = keyPermissionsByChainIdAddressOrigin(
             permissions,

--- a/background/redux-slices/selectors/transactionConstructionSelectors.ts
+++ b/background/redux-slices/selectors/transactionConstructionSelectors.ts
@@ -3,7 +3,7 @@ import { PricePoint } from "../../assets"
 import { selectCurrentNetwork } from "."
 import { NetworksState } from "../networks"
 import { LegacyEVMTransactionRequest } from "../../networks"
-import { RSK } from "../../constants/networks"
+import { ROOTSTOCK } from "../../constants/networks"
 import {
   TransactionConstruction,
   NetworkFeeSettings,
@@ -43,7 +43,7 @@ export const selectDefaultNetworkFeeSettings = createSelector(
         maxFeePerGas: selectedFeesPerGas?.maxFeePerGas ?? 0n,
         maxPriorityFeePerGas: selectedFeesPerGas?.maxPriorityFeePerGas ?? 0n,
         gasPrice:
-          currentNetwork.chainID === RSK.chainID
+          currentNetwork.chainID === ROOTSTOCK.chainID
             ? (
                 transactionConstruction.transactionRequest as LegacyEVMTransactionRequest
               )?.gasPrice

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -20,7 +20,7 @@ import { AssetTransfer } from "../../assets"
 import {
   HOUR,
   ETHEREUM,
-  RSK,
+  ROOTSTOCK,
   POLYGON,
   ARBITRUM_ONE,
   OPTIMISM,
@@ -259,7 +259,7 @@ export default class ChainService extends BaseService<Events> {
       OPTIMISM,
       GOERLI,
       ARBITRUM_ONE,
-      ...(isEnabled(FeatureFlags.SUPPORT_RSK) ? [RSK] : []),
+      ...(isEnabled(FeatureFlags.SUPPORT_RSK) ? [ROOTSTOCK] : []),
     ]
 
     this.trackedNetworks = []
@@ -1257,7 +1257,7 @@ export default class ChainService extends BaseService<Events> {
     incomingOnly = false
   ): Promise<void> {
     if (
-      [ETHEREUM, POLYGON, OPTIMISM, ARBITRUM_ONE, GOERLI, RSK].every(
+      [ETHEREUM, POLYGON, OPTIMISM, ARBITRUM_ONE, GOERLI, ROOTSTOCK].every(
         (network) => network.chainID !== addressOnNetwork.network.chainID
       )
     ) {

--- a/background/services/name/resolvers/rns.ts
+++ b/background/services/name/resolvers/rns.ts
@@ -1,7 +1,7 @@
 import { JsonRpcProvider } from "@ethersproject/providers"
 import { Contract, utils, constants } from "ethers"
 import { AddressOnNetwork, NameOnNetwork } from "../../../accounts"
-import { RSK } from "../../../constants"
+import { ROOTSTOCK } from "../../../constants"
 import { sameNetwork } from "../../../networks"
 import { NameResolver } from "../name-resolver"
 import logger from "../../../lib/logger"
@@ -43,7 +43,7 @@ export default function rnsResolver(): NameResolver<"RNS"> {
       return false
     },
     canAttemptAddressResolution({ name, network }: NameOnNetwork): boolean {
-      return sameNetwork(network, RSK) && name.endsWith(".rsk")
+      return sameNetwork(network, ROOTSTOCK) && name.endsWith(".rsk")
     },
 
     async lookUpAddressForName({

--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -292,6 +292,7 @@
   "popupEdition": "Community Edition",
   "protocol": {
     "mainnet": "Mainnet",
+    "beta": "Mainnet (beta)",
     "testnet": "Test Network",
     "l2": "L2 scaling solution",
     "compatibleChain": "Ethereum-compatible blockchain",

--- a/ui/components/NetworkFees/FeeSettingsText.tsx
+++ b/ui/components/NetworkFees/FeeSettingsText.tsx
@@ -18,7 +18,7 @@ import { selectCurrentNetwork } from "@tallyho/tally-background/redux-slices/sel
 import {
   ARBITRUM_ONE,
   OPTIMISM,
-  RSK,
+  ROOTSTOCK,
 } from "@tallyho/tally-background/constants"
 import {
   EVMNetwork,
@@ -92,7 +92,7 @@ const estimateGweiAmount = (options: {
 
   let desiredDecimals = 0
 
-  if (RSK.chainID === network.chainID) {
+  if (ROOTSTOCK.chainID === network.chainID) {
     estimatedSpendPerGas = networkSettings.values.gasPrice ?? 0n
     desiredDecimals = 2
   }

--- a/ui/components/NetworkFees/NetworkSettingsChooser.tsx
+++ b/ui/components/NetworkFees/NetworkSettingsChooser.tsx
@@ -9,6 +9,11 @@ import {
   selectDefaultNetworkFeeSettings,
   selectTransactionData,
 } from "@tallyho/tally-background/redux-slices/selectors/transactionConstructionSelectors"
+import {
+  ARBITRUM_ONE,
+  OPTIMISM,
+  RSK,
+} from "@tallyho/tally-background/constants"
 import { useBackgroundDispatch, useBackgroundSelector } from "../../hooks"
 import NetworkSettingsSelect from "./NetworkSettingsSelect"
 import NetworkSettingsOptimism from "./NetworkSettingsSelectOptimism"
@@ -38,13 +43,13 @@ export default function NetworkSettingsChooser({
 
   function networkSettingsSelectorFinder() {
     if (transactionDetails) {
-      if (transactionDetails.network.name === "Optimism") {
+      if (transactionDetails.network.name === OPTIMISM.name) {
         return <NetworkSettingsOptimism />
       }
-      if (transactionDetails.network.name === "Rootstock") {
+      if (transactionDetails.network.name === RSK.name) {
         return <NetworkSettingsRSK />
       }
-      if (transactionDetails.network.name === "Arbitrum") {
+      if (transactionDetails.network.name === ARBITRUM_ONE.name) {
         return (
           <NetworkSettingsSelectArbitrum
             estimatedFeesPerGas={estimatedFeesPerGas}

--- a/ui/components/NetworkFees/NetworkSettingsChooser.tsx
+++ b/ui/components/NetworkFees/NetworkSettingsChooser.tsx
@@ -12,7 +12,7 @@ import {
 import {
   ARBITRUM_ONE,
   OPTIMISM,
-  RSK,
+  ROOTSTOCK,
 } from "@tallyho/tally-background/constants"
 import { useBackgroundDispatch, useBackgroundSelector } from "../../hooks"
 import NetworkSettingsSelect from "./NetworkSettingsSelect"
@@ -46,7 +46,7 @@ export default function NetworkSettingsChooser({
       if (transactionDetails.network.name === OPTIMISM.name) {
         return <NetworkSettingsOptimism />
       }
-      if (transactionDetails.network.name === RSK.name) {
+      if (transactionDetails.network.name === ROOTSTOCK.name) {
         return <NetworkSettingsRSK />
       }
       if (transactionDetails.network.name === ARBITRUM_ONE.name) {

--- a/ui/components/NetworkFees/NetworkSettingsSelectRSK.tsx
+++ b/ui/components/NetworkFees/NetworkSettingsSelectRSK.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from "react"
 import { selectTransactionData } from "@tallyho/tally-background/redux-slices/selectors/transactionConstructionSelectors"
-import { RSK } from "@tallyho/tally-background/constants"
+import { ROOTSTOCK } from "@tallyho/tally-background/constants"
 import { useTranslation } from "react-i18next"
 import { useBackgroundSelector } from "../../hooks"
 import SharedButton from "../Shared/SharedButton"
@@ -11,7 +11,7 @@ export default function NetworkSettingsRSK(): ReactElement {
   })
   const transactionData = useBackgroundSelector(selectTransactionData)
 
-  if (transactionData?.network.chainID !== RSK.chainID) {
+  if (transactionData?.network.chainID !== ROOTSTOCK.chainID) {
     throw new Error(
       "NetworkSettingsSelect mismatch - expected an RSK transaction"
     )

--- a/ui/components/Shared/SharedAssetItem.tsx
+++ b/ui/components/Shared/SharedAssetItem.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useEffect, useState } from "react"
 import { AnyAsset, AnyAssetAmount } from "@tallyho/tally-background/assets"
 import { EVMNetwork } from "@tallyho/tally-background/networks"
-import { RSK } from "@tallyho/tally-background/constants"
+import { ROOTSTOCK } from "@tallyho/tally-background/constants"
 import SharedAssetIcon from "./SharedAssetIcon"
 import SharedIcon from "./SharedIcon"
 import { scanWebsite } from "../../utils/constants"
@@ -47,7 +47,7 @@ export default function SharedAssetItem<T extends AnyAsset>(
     const baseLink = scanWebsite[currentNetwork.chainID]?.url
     if ("contractAddress" in asset && baseLink) {
       const contractBase =
-        currentNetwork.chainID === RSK.chainID ? "address" : "token"
+        currentNetwork.chainID === ROOTSTOCK.chainID ? "address" : "token"
       setContractLink(`${baseLink}/${contractBase}/${asset.contractAddress}`)
     } else {
       setContractLink("")

--- a/ui/components/TopMenu/TopMenuProtocolList.tsx
+++ b/ui/components/TopMenu/TopMenuProtocolList.tsx
@@ -5,7 +5,7 @@ import {
   GOERLI,
   OPTIMISM,
   POLYGON,
-  RSK,
+  ROOTSTOCK,
 } from "@tallyho/tally-background/constants"
 import { FeatureFlags, isEnabled } from "@tallyho/tally-background/features"
 import { sameNetwork } from "@tallyho/tally-background/networks"
@@ -37,7 +37,7 @@ const productionNetworks = [
   ...(isEnabled(FeatureFlags.SUPPORT_RSK)
     ? [
         {
-          network: RSK,
+          network: ROOTSTOCK,
           info: i18n.t("protocol.mainnet"),
         },
       ]

--- a/ui/components/TopMenu/TopMenuProtocolList.tsx
+++ b/ui/components/TopMenu/TopMenuProtocolList.tsx
@@ -38,7 +38,7 @@ const productionNetworks = [
     ? [
         {
           network: ROOTSTOCK,
-          info: i18n.t("protocol.mainnet"),
+          info: i18n.t("protocol.beta"),
         },
       ]
     : []),

--- a/ui/hooks/validation-hooks.ts
+++ b/ui/hooks/validation-hooks.ts
@@ -1,5 +1,5 @@
 import { AddressOnNetwork } from "@tallyho/tally-background/accounts"
-import { RSK } from "@tallyho/tally-background/constants"
+import { ROOTSTOCK } from "@tallyho/tally-background/constants"
 import {
   isProbablyEVMAddress,
   normalizeEVMAddress,
@@ -165,7 +165,7 @@ export const useAddressOrNameValidation: AsyncValidationHook<
       } else if (isProbablyEVMAddress(trimmed)) {
         // Apply checksum validation only for RSK network
         if (
-          RSK.chainID === network.chainID &&
+          ROOTSTOCK.chainID === network.chainID &&
           isMixedCaseAddress(trimmed) &&
           !isValidChecksumAddress(trimmed, +network.chainID)
         ) {

--- a/ui/utils/constants.ts
+++ b/ui/utils/constants.ts
@@ -4,7 +4,7 @@ import {
   GOERLI,
   OPTIMISM,
   POLYGON,
-  RSK,
+  ROOTSTOCK,
 } from "@tallyho/tally-background/constants"
 import { NetworkFeeTypeChosen } from "@tallyho/tally-background/redux-slices/transaction-construction"
 import { i18n } from "../_locales/i18n"
@@ -13,7 +13,7 @@ export const doggoTokenDecimalDigits = 18
 
 export const scanWebsite = {
   [ETHEREUM.chainID]: { title: "Etherscan", url: "https://etherscan.io" },
-  [RSK.chainID]: { title: "RSKExplorer", url: "https://explorer.rsk.co" },
+  [ROOTSTOCK.chainID]: { title: "RSKExplorer", url: "https://explorer.rsk.co" },
   [OPTIMISM.chainID]: {
     title: "Etherscan",
     url: "https://optimistic.etherscan.io",


### PR DESCRIPTION
Since we don't yet fully support ledger on rootstock - lets mark it as beta until we do.

This PR also changes the name of the `RSK` network to `ROOTSTOCK` to align with the naming of the other networks in the extension.

cc @alepc253

<img width="382" alt="image" src="https://user-images.githubusercontent.com/94649004/201930789-ce957b1e-9d8e-4db4-aaee-314a65b36c8b.png">


Latest build: [extension-builds-2625](https://github.com/tallycash/extension/suites/9315040506/artifacts/437473896) (as of Tue, 15 Nov 2022 13:32:18 GMT).