### PR TITLE
Add across.to to MetaMask impersonation list

### DIFF
--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -20,6 +20,7 @@ import monitorForWalletConnectionPrompts from "./wallet-connection-handlers"
 // TODO: we don't want to impersonate MetaMask everywhere to not break existing integrations,
 //       so let's do this only on the websites that need this feature
 const impersonateMetamaskWhitelist = [
+  "across.to",
   "transferto.xyz",
   "opensea.io",
   "gmx.io",


### PR DESCRIPTION
Many users have reported issues connecting to Across with Tally installed. A number of these errors are due to conflicting extensions, but there are still cases where some users are unable to connect despite having disabled all other extensions and restarted their browser.

This commit is therefore a last-ditch effort to flush out some other underlying issue, and to provide users with a way to reliably use Tally on across until the underlying efforts are identified and corrected.