### PR TITLE
Prefer alchemy provider for signing

### DIFF
--- a/background/constants/networks.ts
+++ b/background/constants/networks.ts
@@ -145,7 +145,10 @@ export const CHAIN_ID_TO_RPC_URLS: {
     "https://optimism-mainnet.public.blastapi.io",
   ],
   [ETHEREUM.chainID]: ["https://rpc.ankr.com/eth"],
-  [ARBITRUM_ONE.chainID]: ["https://rpc.ankr.com/arbitrum"],
+  [ARBITRUM_ONE.chainID]: [
+    "https://arb1.arbitrum.io/rpc",
+    "https://rpc.ankr.com/arbitrum",
+  ],
   [GOERLI.chainID]: ["https://ethereum-goerli-rpc.allthatnode.com"],
   [AVALANCHE.chainID]: ["https://api.avax.network/ext/bc/C/rpc"],
 }

--- a/background/services/chain/serial-fallback-provider.ts
+++ b/background/services/chain/serial-fallback-provider.ts
@@ -3,6 +3,7 @@ import {
   AlchemyWebSocketProvider,
   EventType,
   JsonRpcProvider,
+  JsonRpcSigner,
   Listener,
   WebSocketProvider,
 } from "@ethersproject/providers"
@@ -475,6 +476,14 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
     this.currentProvider.off(eventName, listenerToRemove)
 
     return this
+  }
+
+  override getSigner(addressOrIndex?: string | number): JsonRpcSigner {
+    // Prefer alchemy for signing as public rpcs might not be as reliable
+    if (this.supportsAlchemy && this.alchemyProvider) {
+      return this.alchemyProvider.getSigner(addressOrIndex)
+    }
+    return super.getSigner(addressOrIndex)
   }
 
   /**


### PR DESCRIPTION
- Fallback provider `getSigner` was returning a public RPC signer, causing some transactions to fail.
- Added another Arbitrum public RPC, since the previous one had somewhat strict rate limits.

## To Test: 
- [ ] Switch to arbitrum, try to swap, you should not see "Transaction failed to broadcast"

Latest build: [extension-builds-2656](https://github.com/tallycash/extension/suites/9425282592/artifacts/445345547) (as of Mon, 21 Nov 2022 16:03:04 GMT).