### PR TITLE
Disable Arbitrum generic RPC

### DIFF
--- a/background/constants/networks.ts
+++ b/background/constants/networks.ts
@@ -145,7 +145,10 @@ export const CHAIN_ID_TO_RPC_URLS: {
     "https://optimism-mainnet.public.blastapi.io",
   ],
   [ETHEREUM.chainID]: ["https://rpc.ankr.com/eth"],
-  [ARBITRUM_ONE.chainID]: ["https://rpc.ankr.com/arbitrum"],
+  [ARBITRUM_ONE.chainID]: [
+    // This one is having issues with signing/other endpoints
+    // "https://rpc.ankr.com/arbitrum"
+  ],
   [GOERLI.chainID]: ["https://ethereum-goerli-rpc.allthatnode.com"],
   [AVALANCHE.chainID]: ["https://api.avax.network/ext/bc/C/rpc"],
 }


### PR DESCRIPTION
This RPC is causing swaps to fail, disabling it as a quick fix to use alchemy while we find and test a different provider

Refs: #2656

## To Test: 
- [ ] Switch to Arbitrum, try to swap, you should not see "Transaction failed to broadcast"


Latest build: [extension-builds-2657](https://github.com/tallycash/extension/suites/9426857886/artifacts/445460044) (as of Mon, 21 Nov 2022 17:18:19 GMT).