### PR TITLE
Add Stats to NFT header

### DIFF
--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -230,7 +230,16 @@
     "empty": "Looks like you don't have any NFTs yet? Get some and view them here!",
     "noTitle": "No title",
     "NFTPricingComingSoon": "Coming soon: NFT price + sending",
+    "units": {
+      "nft_one": "NFT",
+      "nft_other": "NFTs",
+      "badge_one": "Badge",
+      "badge_other": "Badges",
+      "collection_one": "Collection",
+      "collection_other": "Collections"
+    },
     "header": {
+      "title": "Estimated total NFTs value",
       "addAccountCTA": "Add account",
       "emptyTitle": "No NFTs here",
       "emptyDesc": "Add more accounts to see your NFTs, you can also just add read-only accounts"

--- a/ui/components/NFTS_update/NFTsHeader.tsx
+++ b/ui/components/NFTS_update/NFTsHeader.tsx
@@ -1,12 +1,32 @@
 import React, { ReactElement } from "react"
+import { useTranslation } from "react-i18next"
 import { HeaderContainer, EmptyHeader } from "./NFTsHeaderBase"
+import SharedLoadingSpinner from "../Shared/SharedLoadingSpinner"
 
 type HeaderProps = {
-  hasNFTs: boolean
+  loading: boolean
+  nfts: number
+  collections: number
+  badges: number
+  totalInCurrency: string
+  totalInETH: string
+  mainCurrencySign: string
 }
 
-export default function NFTsHeader({ hasNFTs }: HeaderProps): ReactElement {
-  if (!hasNFTs) {
+export default function NFTsHeader({
+  nfts,
+  collections,
+  badges,
+  totalInCurrency,
+  totalInETH,
+  mainCurrencySign,
+  loading,
+}: HeaderProps): ReactElement {
+  const { t } = useTranslation("translation", {
+    keyPrefix: "nfts",
+  })
+
+  if (nfts < 1) {
     return (
       <HeaderContainer>
         <EmptyHeader />
@@ -14,5 +34,105 @@ export default function NFTsHeader({ hasNFTs }: HeaderProps): ReactElement {
     )
   }
 
-  return <div>{/* TODO */}</div>
+  return (
+    <HeaderContainer>
+      <div className="stats_container">
+        <div className="stats_title">{t("header.title")}</div>
+        <div className="stats_totals">
+          <span className="currency_sign">{mainCurrencySign}</span>
+          <span className="currency_total">{totalInCurrency}</span>
+          {loading && (
+            <SharedLoadingSpinner size="small" variant="transparent" />
+          )}
+        </div>
+        <div className="crypto_total">{totalInETH}</div>
+      </div>
+      <ul className="nft_counts">
+        <li>
+          <strong>{collections}</strong>
+          {t("units.collection", { count: collections })}
+        </li>
+        <li className="spacer" role="presentation" />
+        <li>
+          <strong>{nfts}</strong>
+          {t("units.nft", { count: nfts })}
+        </li>
+        <li className="spacer" role="presentation" />
+        <li>
+          <strong>{badges}</strong>
+          {t("units.badge", { count: badges })}
+        </li>
+      </ul>
+      <style jsx>{`
+        .stats_container {
+          text-align: center;
+          margin-bottom: 24px;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+        }
+
+        .stats_title {
+          font-size: 14px;
+          font-weight: 500;
+          line-height: 16px;
+          letter-spacing: 0.03em;
+        }
+
+        .stats_totals {
+          display: flex;
+          flex-direction: row;
+          gap: 4px;
+          align-items: center;
+        }
+
+        .currency_total {
+          font-size: 36px;
+          font-weight: 500;
+          line-height: 48px;
+          letter-spacing: 0em;
+          color: #fff;
+        }
+
+        .currency_sign {
+          font-size: 18px;
+          font-weight: 600;
+          line-height: 24px;
+          letter-spacing: 0em;
+          color: var(--green-40);
+        }
+
+        .crypto_total {
+          font-size: 14px;
+          font-weight: 500;
+          line-height: 16px;
+          letter-spacing: 0.03em;
+          color: var(--green-20);
+        }
+
+        .nft_counts {
+          display: flex;
+          flex-direction: row;
+          align-items: center;
+          gap: 16px;
+        }
+
+        li {
+          color: var(--green-40);
+          font-weight: 600;
+          font-size: 18px;
+          line-height: 24px;
+        }
+
+        li strong {
+          color: var(--white);
+        }
+
+        li.spacer {
+          border: 1px solid var(--green-80);
+          align-self: stretch;
+        }
+      `}</style>
+    </HeaderContainer>
+  )
 }

--- a/ui/components/NFTS_update/NFTsHeader.tsx
+++ b/ui/components/NFTS_update/NFTsHeader.tsx
@@ -118,6 +118,10 @@ export default function NFTsHeader({
         }
 
         li {
+          display: flex;
+          flex-wrap: wrap;
+          justify-content: center;
+          gap: 8px;
           color: var(--green-40);
           font-weight: 600;
           font-size: 18px;
@@ -129,7 +133,7 @@ export default function NFTsHeader({
         }
 
         li.spacer {
-          border: 1px solid var(--green-80);
+          border: 0.5px solid var(--green-80);
           align-self: stretch;
         }
       `}</style>

--- a/ui/components/NFTS_update/NFTsHeader.tsx
+++ b/ui/components/NFTS_update/NFTsHeader.tsx
@@ -77,6 +77,7 @@ export default function NFTsHeader({
           font-weight: 500;
           line-height: 16px;
           letter-spacing: 0.03em;
+          color: var(--green-20);
         }
 
         .stats_totals {
@@ -100,6 +101,8 @@ export default function NFTsHeader({
           line-height: 24px;
           letter-spacing: 0em;
           color: var(--green-40);
+          align-self: start;
+          margin-top: 7px;
         }
 
         .crypto_total {

--- a/ui/components/Shared/SharedLoadingSpinner.tsx
+++ b/ui/components/Shared/SharedLoadingSpinner.tsx
@@ -1,11 +1,38 @@
-import React, { ReactElement } from "react"
+import React, { ReactElement, useMemo } from "react"
 import classNames from "classnames"
+import { assertUnreachable } from "@tallyho/tally-background/lib/utils/type-guards"
 
-export default function SharedLoadingSpinner(props: {
+type SharedLoadingSpinnerProps = {
   size: "small" | "medium"
-}): ReactElement {
-  const { size } = props
+  variant?: "dark-gold" | "transparent"
+}
 
+function getVariantStyles(
+  variant: Exclude<SharedLoadingSpinnerProps["variant"], undefined>
+) {
+  let styles: [string, string]
+  switch (variant) {
+    case "dark-gold":
+      styles = ["var(--green-80)", "var(--trophygold)"]
+      break
+
+    case "transparent":
+      styles = ["var(--green-20)", "transparent"]
+      break
+
+    default:
+      assertUnreachable(variant)
+  }
+
+  return styles
+}
+
+export default function SharedLoadingSpinner(
+  props: SharedLoadingSpinnerProps
+): ReactElement {
+  const { size, variant = "dark-gold" } = props
+
+  const [color, accent] = useMemo(() => getVariantStyles(variant), [variant])
   return (
     <div className={classNames("spinner", size)}>
       <style jsx>
@@ -14,8 +41,8 @@ export default function SharedLoadingSpinner(props: {
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            border: 2px solid var(--green-80);
-            border-top-color: var(--trophy-gold);
+            border: 2px solid ${color};
+            border-top-color: ${accent};
             box-sizing: border-box;
             animation: spinner 1s linear infinite;
           }

--- a/ui/pages/NFTs.tsx
+++ b/ui/pages/NFTs.tsx
@@ -1,14 +1,42 @@
+import {
+  selectMainCurrencySign,
+  selectMainCurrencySymbol,
+} from "@tallyho/tally-background/redux-slices/selectors"
+import { formatCurrencyAmount } from "@tallyho/tally-background/redux-slices/utils/asset-utils"
 import React, { ReactElement } from "react"
 import NFTsExploreBanner from "../components/NFTS_update/NFTsExploreBanner"
 import NFTsHeader from "../components/NFTS_update/NFTsHeader"
 import { useBackgroundSelector } from "../hooks"
 
+// TODO: Remove these stubs
+const stubSelectNFTCount = () => 16
+const stubSelectCollectionCount = () => 2
+const stubSelectBadgeCount = () => 5
+
 export default function NFTs(): ReactElement {
-  const hasNFTs = useBackgroundSelector(() => false)
+  const nftCounts = useBackgroundSelector(stubSelectNFTCount)
+  const collectionCount = useBackgroundSelector(stubSelectCollectionCount)
+  const badgeCount = useBackgroundSelector(stubSelectBadgeCount)
+
+  const mainCurrencySign = useBackgroundSelector(selectMainCurrencySign)
+  const mainCurrencySymbol = useBackgroundSelector(selectMainCurrencySymbol)
+  const NFTsLoading = useBackgroundSelector(() => false)
+
+  // TODO: Remove these stubs
+  const someAmount = formatCurrencyAmount(mainCurrencySymbol, 240_241, 0)
+  const someAmountInETH = "21.366 ETH"
 
   return (
     <div className="page_content">
-      <NFTsHeader hasNFTs={hasNFTs} />
+      <NFTsHeader
+        nfts={nftCounts}
+        collections={collectionCount}
+        badges={badgeCount}
+        totalInCurrency={someAmount}
+        totalInETH={someAmountInETH}
+        mainCurrencySign={mainCurrencySign}
+        loading={NFTsLoading}
+      />
 
       {/* TODO: Move these to their respective tab */}
       <NFTsExploreBanner type="nfts" />


### PR DESCRIPTION
<img width="368" title="nftstats" src="https://user-images.githubusercontent.com/28708889/203649108-a3578ab3-83c4-4248-9589-fabf6549d903.png"/>

## Testing Env

```
SUPPORT_NFT_TAB=true
```

## To Test
- [ ] Import an account
- [ ] ~Go to the new NFTs page, after loading, counts and estimates should show up for that account~ ( this will be wired up in a different PR to not block this one )

Latest build: [extension-builds-2670](https://github.com/tallycash/extension/suites/9506349443/artifacts/451097785) (as of Fri, 25 Nov 2022 14:06:45 GMT).