### PR TITLE
Add staking.polygon.technology to Metamask impersonation whitelist

### DIFF
--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -22,6 +22,7 @@ import monitorForWalletConnectionPrompts from "./wallet-connection-handlers"
 const impersonateMetamaskWhitelist = [
   "transferto.xyz",
   "opensea.io",
+  "staking.polygon.technology",
   "gmx.io",
   "app.lyra.finance",
   "matcha.xyz",


### PR DESCRIPTION
### Acceptance Criteria
- [x] navigate to https://staking.polygon.technology
- [x] With both Metamask & Tally Ho Installed - clicking the `MetaMask` connection option should open up the metamask connection prompt
- [x] With both Metamask & Tally Ho Installed and **Tally Ho set as default wallet** - clicking the `MetaMask` connection option should open up the Tally Ho connection prompt

Latest build: [extension-builds-2704](https://github.com/tallycash/extension/suites/9613916352/artifacts/458884753) (as of Thu, 01 Dec 2022 16:30:03 GMT).