### PR TITLE
Show real data in NFTs statistics

### DIFF
--- a/background/lib/nfts_update.ts
+++ b/background/lib/nfts_update.ts
@@ -3,7 +3,11 @@ import {
   getSimpleHashCollections,
   getSimpleHashNFTs,
 } from "./simple-hash_update"
-import { getPoapNFTs, getPoapCollections } from "./poap_update"
+import {
+  getPoapNFTs,
+  getPoapCollections,
+  POAP_COLLECTION_ID,
+} from "./poap_update"
 import {
   NFT,
   CHAIN_ID_TO_NFT_METADATA_PROVIDER,
@@ -40,7 +44,7 @@ export function getNFTs(
         NFT_PROVIDER_TO_CHAIN.poap.includes(chainID)
       )
 
-      if (poapChains.length) {
+      if (poapChains.length && collections.includes(POAP_COLLECTION_ID)) {
         const { nfts: poapNFTs } = await getPoapNFTs(address)
         nfts.push(...poapNFTs)
       }
@@ -52,6 +56,8 @@ export function getNFTs(
       if (simpleHashChains.length) {
         await Promise.allSettled(
           collections.map(async (collectionID) => {
+            if (collectionID === POAP_COLLECTION_ID) return // Don't fetch POAP from SimpleHash
+
             const { nfts: simpleHashNFTs, nextPageURL } =
               await getSimpleHashNFTs(address, collectionID, simpleHashChains)
 

--- a/background/lib/poap_update.ts
+++ b/background/lib/poap_update.ts
@@ -4,6 +4,7 @@ import { ETHEREUM } from "../constants"
 import { NFT, NFTCollection, NFTsWithPagesResponse } from "../nfts"
 
 export const POAP_CONTRACT = "poap_contract"
+export const POAP_COLLECTION_ID = "POAP"
 
 type PoapNFTModel = {
   event: {
@@ -53,7 +54,7 @@ function poapNFTModelToNFT(original: PoapNFTModel, owner: string): NFT {
       { trait: "City", value: city },
       { trait: "Year", value: year?.toString() },
     ],
-    collectionID: "POAP",
+    collectionID: POAP_COLLECTION_ID,
     contract: POAP_CONTRACT, // contract address doesn't make sense for POAPs
     owner,
     network: ETHEREUM,
@@ -101,8 +102,8 @@ export async function getPoapCollections(
   address: string
 ): Promise<NFTCollection> {
   return {
-    id: "POAP", // let's keep POAPs in one collection
-    name: "POAP",
+    id: POAP_COLLECTION_ID, // let's keep POAPs in one collection
+    name: POAP_COLLECTION_ID,
     nftCount: undefined, // TODO: we don't know at this point how many POAPs this address has
     owner: address,
     hasBadges: true,

--- a/background/lib/poap_update.ts
+++ b/background/lib/poap_update.ts
@@ -58,9 +58,7 @@ function poapNFTModelToNFT(original: PoapNFTModel, owner: string): NFT {
     contract: POAP_CONTRACT, // contract address doesn't make sense for POAPs
     owner,
     network: ETHEREUM,
-    badge: {
-      url: `https://app.poap.xyz/token/${tokenId}`,
-    },
+    isBadge: true,
   }
 }
 

--- a/background/lib/simple-hash_update.ts
+++ b/background/lib/simple-hash_update.ts
@@ -112,7 +112,7 @@ function simpleHashCollectionModelToCollection(
   return {
     id,
     name: original.name || "",
-    nftCount: original.distinct_nft_count || 0,
+    nftCount: original.distinct_nfts_owned || 0,
     totalNftCount: original.distinct_nft_count || 0,
     owner,
     thumbnail: original.image_url || "",

--- a/background/lib/simple-hash_update.ts
+++ b/background/lib/simple-hash_update.ts
@@ -138,8 +138,6 @@ function simpleHashNFTModelToNFT(
     extra_metadata: metadata,
   } = original
 
-  const isAchievement = isGalxeAchievement(nftURL)
-
   const thumbnail =
     previewURL ||
     previews?.image_large_url ||
@@ -174,7 +172,7 @@ function simpleHashNFTModelToNFT(
     contract: contractAddress,
     owner,
     network: NETWORK_BY_CHAIN_ID[chainID],
-    badge: isAchievement && nftURL ? { url: nftURL } : null,
+    isBadge: isGalxeAchievement(nftURL),
   }
 }
 

--- a/background/nfts.ts
+++ b/background/nfts.ts
@@ -50,9 +50,7 @@ export type NFT = {
   contract: string
   owner: string
   network: EVMNetwork
-  badge: null | {
-    url: string
-  }
+  isBadge: boolean
 }
 
 export type NFTCollection = {

--- a/background/redux-slices/selectors/nftsSelectors_update.ts
+++ b/background/redux-slices/selectors/nftsSelectors_update.ts
@@ -66,7 +66,7 @@ export const selectNFTBadgesCount = createSelector(
 )
 
 export const selectNFTCollectionsCount = createSelector(
-  selectAllCollections,
+  selectNFTCollections,
   (collections) => collections.length
 )
 

--- a/background/redux-slices/selectors/nftsSelectors_update.ts
+++ b/background/redux-slices/selectors/nftsSelectors_update.ts
@@ -3,6 +3,8 @@ import { RootState } from ".."
 import { normalizeEVMAddress } from "../../lib/utils"
 import { selectCurrentAccount } from "./uiSelectors"
 
+const ETH_SYMBOLS = ["ETH", "WETH"]
+
 const selectNFTs = createSelector(
   (state: RootState) => state.nftsUpdate,
   (slice) => slice.nfts
@@ -70,7 +72,18 @@ export const selectNFTCollectionsCount = createSelector(
   (collections) => collections.length
 )
 
-export const selectTotalFloorPrice = createSelector(
-  selectNFTs,
-  () => "00.00" // TODO
+export const selectTotalFloorPriceInETH = createSelector(
+  selectAllCollections,
+  (collections) => {
+    return collections.reduce((sum, collection) => {
+      if (
+        collection.floorPrice &&
+        ETH_SYMBOLS.includes(collection.floorPrice.tokenSymbol)
+      ) {
+        return sum + collection.floorPrice.value * (collection.nftCount ?? 0)
+      }
+
+      return sum
+    }, 0)
+  }
 )

--- a/background/services/nfts/db.ts
+++ b/background/services/nfts/db.ts
@@ -29,6 +29,30 @@ export class NFTsDatabase extends Dexie {
     await this.collections.bulkPut(collections)
   }
 
+  async updateCollectionData(
+    collectionID: string,
+    { address, network }: AddressOnNetwork,
+    data: Partial<NFTCollection>
+  ): Promise<NFTCollection | undefined> {
+    const collection = await this.collections.get({
+      id: collectionID,
+      owner: address,
+      "network.chainID": network.chainID,
+    })
+
+    if (collection) {
+      const updatedCollection = {
+        ...collection,
+        ...data,
+      }
+      await this.updateCollections([updatedCollection])
+
+      return updatedCollection
+    }
+
+    return undefined
+  }
+
   async getAllCollections(): Promise<NFTCollection[]> {
     return this.collections.toArray()
   }

--- a/background/services/nfts/index.ts
+++ b/background/services/nfts/index.ts
@@ -105,7 +105,7 @@ export default class NFTsService extends BaseService<Events> {
               nftCount: updatedNFTs.length,
             }
           )
-        } else if (updatedNFTs.some((nft) => !!nft.badge)) {
+        } else if (updatedNFTs.some((nft) => nft.isBadge)) {
           // update collection as a badges collection
           updatedCollection = await this.db.updateCollectionData(
             collectionID,

--- a/background/services/nfts/index.ts
+++ b/background/services/nfts/index.ts
@@ -1,6 +1,7 @@
 import { AddressOnNetwork } from "../../accounts"
 import { FeatureFlags, isEnabled } from "../../features"
 import { getNFTCollections, getNFTs } from "../../lib/nfts_update"
+import { POAP_COLLECTION_ID } from "../../lib/poap_update"
 import { NFTCollection, NFT } from "../../nfts"
 import BaseService from "../base"
 import ChainService from "../chain"
@@ -92,6 +93,32 @@ export default class NFTsService extends BaseService<Events> {
           collectionID,
           account
         )
+
+        let updatedCollection: NFTCollection | undefined
+
+        if (collectionID === POAP_COLLECTION_ID) {
+          // update number of poaps
+          updatedCollection = await this.db.updateCollectionData(
+            collectionID,
+            account,
+            {
+              nftCount: updatedNFTs.length,
+            }
+          )
+        } else if (updatedNFTs.some((nft) => !!nft.badge)) {
+          // update collection as a badges collection
+          updatedCollection = await this.db.updateCollectionData(
+            collectionID,
+            account,
+            {
+              hasBadges: true,
+            }
+          )
+        }
+
+        if (updatedCollection) {
+          this.emitter.emit("updateCollections", [updatedCollection])
+        }
 
         this.emitter.emit("updateNFTs", {
           collectionID,

--- a/ui/components/NFTS_update/ExploreMarketLink.tsx
+++ b/ui/components/NFTS_update/ExploreMarketLink.tsx
@@ -69,7 +69,7 @@ export function getRelevantMarketsList(nft: NFT): MarketDetails[] {
   if (nft.contract === POAP_CONTRACT) {
     return [MARKET_LINK.poap]
   }
-  if (nft.badge) {
+  if (nft.isBadge) {
     return [MARKET_LINK.galxe]
   }
   if (nft.network.chainID !== ETHEREUM.chainID) {

--- a/ui/components/NFTS_update/NFTItem.tsx
+++ b/ui/components/NFTS_update/NFTItem.tsx
@@ -16,7 +16,7 @@ export default function NFTItem<T extends NFT | NFTCollectionCached>(props: {
   const floorPrice =
     "floorPrice" in item && item.floorPrice?.value && item.floorPrice
   const nftsCount = "nfts" in item && item.nfts.length
-  const isBadge = "badge" in item && !!item.badge
+  const isBadge = "isBadge" in item && item.isBadge
   return (
     <div className="nft_item">
       <div className="nft_image">

--- a/ui/components/NFTS_update/NFTPreview.tsx
+++ b/ui/components/NFTS_update/NFTPreview.tsx
@@ -62,7 +62,7 @@ export default function NFTPreview(props: NFTWithCollection): ReactElement {
     owner,
     description,
     attributes,
-    badge,
+    isBadge,
   } = nft
   const { totalNftCount } = collection
   const floorPrice = collection.floorPrice?.value && collection.floorPrice
@@ -77,7 +77,7 @@ export default function NFTPreview(props: NFTWithCollection): ReactElement {
     <>
       <div className="preview_wrapper">
         <div className="preview_image">
-          <NFTImage src={thumbnail} alt={name} width={384} isBadge={!!badge} />
+          <NFTImage src={thumbnail} alt={name} width={384} isBadge={isBadge} />
           <div className="preview_network">
             <SharedNetworkIcon network={network} size={24} hasBackground />
           </div>

--- a/ui/components/NFTS_update/NFTsHeader.tsx
+++ b/ui/components/NFTS_update/NFTsHeader.tsx
@@ -5,18 +5,18 @@ import SharedLoadingSpinner from "../Shared/SharedLoadingSpinner"
 
 type HeaderProps = {
   loading: boolean
-  nfts: number
-  collections: number
-  badges: number
+  nftsCount: number
+  collectionsCount: number
+  badgesCount: number
   totalInCurrency: string
   totalInETH: string
   mainCurrencySign: string
 }
 
 export default function NFTsHeader({
-  nfts,
-  collections,
-  badges,
+  nftsCount,
+  collectionsCount,
+  badgesCount,
   totalInCurrency,
   totalInETH,
   mainCurrencySign,
@@ -26,7 +26,7 @@ export default function NFTsHeader({
     keyPrefix: "nfts",
   })
 
-  if (nfts < 1) {
+  if (nftsCount < 1) {
     return (
       <HeaderContainer>
         <EmptyHeader />
@@ -49,18 +49,18 @@ export default function NFTsHeader({
       </div>
       <ul className="nft_counts">
         <li>
-          <strong>{collections}</strong>
-          {t("units.collection", { count: collections })}
+          <strong>{collectionsCount}</strong>
+          {t("units.collection", { count: collectionsCount })}
         </li>
         <li className="spacer" role="presentation" />
         <li>
-          <strong>{nfts}</strong>
-          {t("units.nft", { count: nfts })}
+          <strong>{nftsCount}</strong>
+          {t("units.nft", { count: nftsCount })}
         </li>
         <li className="spacer" role="presentation" />
         <li>
-          <strong>{badges}</strong>
-          {t("units.badge", { count: badges })}
+          <strong>{badgesCount}</strong>
+          {t("units.badge", { count: badgesCount })}
         </li>
       </ul>
       <style jsx>{`

--- a/ui/components/NFTS_update/NFTsHeader.tsx
+++ b/ui/components/NFTS_update/NFTsHeader.tsx
@@ -1,32 +1,31 @@
 import React, { ReactElement } from "react"
 import { useTranslation } from "react-i18next"
-import { HeaderContainer, EmptyHeader } from "./NFTsHeaderBase"
+import {
+  selectMainCurrencySign,
+  selectNFTBadgesCount,
+  selectNFTCollectionsCount,
+  selectNFTsCount,
+} from "@tallyho/tally-background/redux-slices/selectors"
+
 import SharedLoadingSpinner from "../Shared/SharedLoadingSpinner"
+import { HeaderContainer, EmptyHeader } from "./NFTsHeaderBase"
+import { useBackgroundSelector, useTotalNFTsFloorPrice } from "../../hooks"
 
-type HeaderProps = {
-  loading: boolean
-  nftsCount: number
-  collectionsCount: number
-  badgesCount: number
-  totalInCurrency: string
-  totalInETH: string
-  mainCurrencySign: string
-}
-
-export default function NFTsHeader({
-  nftsCount,
-  collectionsCount,
-  badgesCount,
-  totalInCurrency,
-  totalInETH,
-  mainCurrencySign,
-  loading,
-}: HeaderProps): ReactElement {
+export default function NFTsHeader(): ReactElement {
   const { t } = useTranslation("translation", {
     keyPrefix: "nfts",
   })
+  const isLoading = useBackgroundSelector(() => false)
+  const nftCount = useBackgroundSelector(selectNFTsCount)
 
-  if (nftsCount < 1) {
+  const collectionCount = useBackgroundSelector(selectNFTCollectionsCount)
+  const badgeCount = useBackgroundSelector(selectNFTBadgesCount)
+  const mainCurrencySign = useBackgroundSelector(selectMainCurrencySign)
+
+  const { totalFloorPriceInETH, totalFloorPriceInUSD } =
+    useTotalNFTsFloorPrice()
+
+  if (nftCount < 1) {
     return (
       <HeaderContainer>
         <EmptyHeader />
@@ -40,27 +39,27 @@ export default function NFTsHeader({
         <div className="stats_title">{t("header.title")}</div>
         <div className="stats_totals">
           <span className="currency_sign">{mainCurrencySign}</span>
-          <span className="currency_total">{totalInCurrency}</span>
-          {loading && (
+          <span className="currency_total">{totalFloorPriceInUSD}</span>
+          {isLoading && (
             <SharedLoadingSpinner size="small" variant="transparent" />
           )}
         </div>
-        <div className="crypto_total">{totalInETH}</div>
+        <div className="crypto_total">{totalFloorPriceInETH} ETH</div>
       </div>
       <ul className="nft_counts">
         <li>
-          <strong>{collectionsCount}</strong>
-          {t("units.collection", { count: collectionsCount })}
+          <strong>{collectionCount}</strong>
+          {t("units.collection", { count: collectionCount })}
         </li>
         <li className="spacer" role="presentation" />
         <li>
-          <strong>{nftsCount}</strong>
-          {t("units.nft", { count: nftsCount })}
+          <strong>{nftCount}</strong>
+          {t("units.nft", { count: nftCount })}
         </li>
         <li className="spacer" role="presentation" />
         <li>
-          <strong>{badgesCount}</strong>
-          {t("units.badge", { count: badgesCount })}
+          <strong>{badgeCount}</strong>
+          {t("units.badge", { count: badgeCount })}
         </li>
       </ul>
       <style jsx>{`

--- a/ui/components/Overview/NFTsPortfolioOverview.tsx
+++ b/ui/components/Overview/NFTsPortfolioOverview.tsx
@@ -1,18 +1,23 @@
 import React, { ReactElement } from "react"
 import { Trans, useTranslation } from "react-i18next"
+import {
+  selectNFTBadgesCount,
+  selectNFTCollectionsCount,
+  selectNFTsCount,
+} from "@tallyho/tally-background/redux-slices/selectors"
+import { useBackgroundSelector } from "../../hooks"
 
 export default function NFTsPortfolioOverview(): ReactElement {
   const { t } = useTranslation()
 
-  // TODO: Replace these stubs
-  const nftCount = 10
-  const collectionCount = 12
-  const badgeCount = 6
+  const nftCount = useBackgroundSelector(selectNFTsCount)
+  const collectionCount = useBackgroundSelector(selectNFTCollectionsCount)
+  const badgeCount = useBackgroundSelector(selectNFTBadgesCount)
 
   return (
     <section>
       <header>
-        <h5 className="nft-count">NFT(30)</h5>
+        <h5 className="nft-count">NFT({nftCount + badgeCount})</h5>
         <span className="estimate">~$24,231,00</span>
       </header>
       <div>

--- a/ui/components/Overview/NFTsPortfolioOverview.tsx
+++ b/ui/components/Overview/NFTsPortfolioOverview.tsx
@@ -5,7 +5,7 @@ import {
   selectNFTCollectionsCount,
   selectNFTsCount,
 } from "@tallyho/tally-background/redux-slices/selectors"
-import { useBackgroundSelector } from "../../hooks"
+import { useBackgroundSelector, useTotalNFTsFloorPrice } from "../../hooks"
 
 export default function NFTsPortfolioOverview(): ReactElement {
   const { t } = useTranslation()
@@ -14,11 +14,12 @@ export default function NFTsPortfolioOverview(): ReactElement {
   const collectionCount = useBackgroundSelector(selectNFTCollectionsCount)
   const badgeCount = useBackgroundSelector(selectNFTBadgesCount)
 
+  const { totalFloorPriceInUSD } = useTotalNFTsFloorPrice()
   return (
     <section>
       <header>
         <h5 className="nft-count">NFT({nftCount + badgeCount})</h5>
-        <span className="estimate">~$24,231,00</span>
+        <span className="estimate">~${totalFloorPriceInUSD}</span>
       </header>
       <div>
         <Trans

--- a/ui/hooks/index.ts
+++ b/ui/hooks/index.ts
@@ -7,6 +7,7 @@ export * from "./redux-hooks"
 export * from "./signing-hooks"
 export * from "./dom-hooks"
 export * from "./validation-hooks"
+export * from "./nft-hooks"
 
 export function useIsDappPopup(): boolean {
   const [isDappPopup, setIsDappPopup] = useState(false)

--- a/ui/hooks/nft-hooks.ts
+++ b/ui/hooks/nft-hooks.ts
@@ -1,0 +1,45 @@
+/* eslint-disable import/prefer-default-export */
+import {
+  getAssetsState,
+  selectMainCurrencySymbol,
+  selectTotalFloorPriceInETH,
+} from "@tallyho/tally-background/redux-slices/selectors"
+import {
+  enrichAssetAmountWithMainCurrencyValues,
+  formatCurrencyAmount,
+} from "@tallyho/tally-background/redux-slices/utils/asset-utils"
+import { ETH } from "@tallyho/tally-background/constants"
+import { selectAssetPricePoint } from "@tallyho/tally-background/redux-slices/assets"
+import { useBackgroundSelector } from "./redux-hooks"
+
+export const useTotalNFTsFloorPrice = (): {
+  totalFloorPriceInETH: string
+  totalFloorPriceInUSD: string
+} => {
+  const assets = useBackgroundSelector(getAssetsState)
+  const mainCurrencySymbol = useBackgroundSelector(selectMainCurrencySymbol)
+  const totalFloorPriceInETH = useBackgroundSelector(selectTotalFloorPriceInETH)
+
+  const totalFloorPriceInETHFormatted = formatCurrencyAmount(
+    mainCurrencySymbol,
+    totalFloorPriceInETH,
+    4
+  )
+  const ETHPricePoint = selectAssetPricePoint(
+    assets,
+    ETH.symbol,
+    mainCurrencySymbol
+  )
+
+  const totalFloorPriceLocalized =
+    enrichAssetAmountWithMainCurrencyValues(
+      { asset: ETH, amount: BigInt(totalFloorPriceInETH * 10 ** ETH.decimals) },
+      ETHPricePoint,
+      2
+    ).localizedMainCurrencyAmount ?? "-"
+
+  return {
+    totalFloorPriceInETH: totalFloorPriceInETHFormatted,
+    totalFloorPriceInUSD: totalFloorPriceLocalized,
+  }
+}

--- a/ui/pages/NFTs.tsx
+++ b/ui/pages/NFTs.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement, useState } from "react"
 import classNames from "classnames"
 import { selectNFTsCount } from "@tallyho/tally-background/redux-slices/selectors"
+import { useTranslation } from "react-i18next"
 import SharedPanelSwitcher from "../components/Shared/SharedPanelSwitcher"
 import NFTsExploreBanner from "../components/NFTS_update/NFTsExploreBanner"
 import NFTsHeader from "../components/NFTS_update/NFTsHeader"
@@ -12,6 +13,9 @@ const PANEL_NAMES = ["NFTs", "Badges"]
 
 export default function NFTs(): ReactElement {
   const nftCount = useBackgroundSelector(selectNFTsCount)
+  const { t } = useTranslation("translation", {
+    keyPrefix: "nfts",
+  })
 
   const [panelNumber, setPanelNumber] = useState(0)
 
@@ -32,13 +36,19 @@ export default function NFTs(): ReactElement {
       <div className="standard_width">
         {panelNumber === 0 &&
           (nftCount > 0 ? (
-            <NFTListPortfolio />
+            <>
+              <h2>{t("units.collection_other")}</h2>
+              <NFTListPortfolio />
+            </>
           ) : (
             <NFTsExploreBanner type="nfts" />
           ))}
         {panelNumber === 1 &&
           (nftCount > 0 ? (
-            <NFTListPortfolioBadges />
+            <>
+              <h2>{t("units.badge_other")}</h2>
+              <NFTListPortfolioBadges />
+            </>
           ) : (
             <NFTsExploreBanner type="badge" />
           ))}
@@ -57,6 +67,12 @@ export default function NFTs(): ReactElement {
           }
           .panel_switcher_wrap.margin {
             margin-bottom: 16px;
+          }
+          .page_content h2 {
+            font-weight: 600;
+            font-size: 18px;
+            line-height: 24px;
+            margin: 10px 0 0;
           }
         `}
       </style>

--- a/ui/pages/NFTs.tsx
+++ b/ui/pages/NFTs.tsx
@@ -1,13 +1,6 @@
 import React, { ReactElement, useState } from "react"
 import classNames from "classnames"
-import {
-  selectMainCurrencySign,
-  selectMainCurrencySymbol,
-  selectNFTBadgesCount,
-  selectNFTCollectionsCount,
-  selectNFTsCount,
-} from "@tallyho/tally-background/redux-slices/selectors"
-import { formatCurrencyAmount } from "@tallyho/tally-background/redux-slices/utils/asset-utils"
+import { selectNFTsCount } from "@tallyho/tally-background/redux-slices/selectors"
 import SharedPanelSwitcher from "../components/Shared/SharedPanelSwitcher"
 import NFTsExploreBanner from "../components/NFTS_update/NFTsExploreBanner"
 import NFTsHeader from "../components/NFTS_update/NFTsHeader"
@@ -19,29 +12,12 @@ const PANEL_NAMES = ["NFTs", "Badges"]
 
 export default function NFTs(): ReactElement {
   const nftCount = useBackgroundSelector(selectNFTsCount)
-  const collectionCount = useBackgroundSelector(selectNFTCollectionsCount)
-  const badgeCount = useBackgroundSelector(selectNFTBadgesCount)
 
-  const mainCurrencySign = useBackgroundSelector(selectMainCurrencySign)
-  const mainCurrencySymbol = useBackgroundSelector(selectMainCurrencySymbol)
-  const isLoading = useBackgroundSelector(() => false)
-
-  // TODO: Remove these stubs
-  const someAmount = formatCurrencyAmount(mainCurrencySymbol, 240_241, 0)
-  const someAmountInETH = "21.366 ETH"
   const [panelNumber, setPanelNumber] = useState(0)
 
   return (
     <div className="page_content">
-      <NFTsHeader
-        nftsCount={nftCount}
-        collectionsCount={collectionCount}
-        badgesCount={badgeCount}
-        totalInCurrency={someAmount}
-        totalInETH={someAmountInETH}
-        mainCurrencySign={mainCurrencySign}
-        loading={isLoading}
-      />
+      <NFTsHeader />
       <div
         className={classNames("panel_switcher_wrap", {
           margin: !(nftCount > 0),

--- a/ui/pages/NFTs.tsx
+++ b/ui/pages/NFTs.tsx
@@ -3,6 +3,9 @@ import classNames from "classnames"
 import {
   selectMainCurrencySign,
   selectMainCurrencySymbol,
+  selectNFTBadgesCount,
+  selectNFTCollectionsCount,
+  selectNFTsCount,
 } from "@tallyho/tally-background/redux-slices/selectors"
 import { formatCurrencyAmount } from "@tallyho/tally-background/redux-slices/utils/asset-utils"
 import SharedPanelSwitcher from "../components/Shared/SharedPanelSwitcher"
@@ -14,15 +17,10 @@ import NFTListPortfolioBadges from "../components/NFTS_update/NFTListPortfolioBa
 
 const PANEL_NAMES = ["NFTs", "Badges"]
 
-// TODO: Remove these stubs
-const stubSelectNFTCount = () => 16
-const stubSelectCollectionCount = () => 2
-const stubSelectBadgeCount = () => 5
-
 export default function NFTs(): ReactElement {
-  const nftCounts = useBackgroundSelector(stubSelectNFTCount)
-  const collectionCount = useBackgroundSelector(stubSelectCollectionCount)
-  const badgeCount = useBackgroundSelector(stubSelectBadgeCount)
+  const nftCount = useBackgroundSelector(selectNFTsCount)
+  const collectionCount = useBackgroundSelector(selectNFTCollectionsCount)
+  const badgeCount = useBackgroundSelector(selectNFTBadgesCount)
 
   const mainCurrencySign = useBackgroundSelector(selectMainCurrencySign)
   const mainCurrencySymbol = useBackgroundSelector(selectMainCurrencySymbol)
@@ -36,9 +34,9 @@ export default function NFTs(): ReactElement {
   return (
     <div className="page_content">
       <NFTsHeader
-        nfts={nftCounts}
-        collections={collectionCount}
-        badges={badgeCount}
+        nftsCount={nftCount}
+        collectionsCount={collectionCount}
+        badgesCount={badgeCount}
         totalInCurrency={someAmount}
         totalInETH={someAmountInETH}
         mainCurrencySign={mainCurrencySign}
@@ -46,7 +44,7 @@ export default function NFTs(): ReactElement {
       />
       <div
         className={classNames("panel_switcher_wrap", {
-          margin: !(nftCounts > 0),
+          margin: !(nftCount > 0),
         })}
       >
         <SharedPanelSwitcher
@@ -57,13 +55,13 @@ export default function NFTs(): ReactElement {
       </div>
       <div className="standard_width">
         {panelNumber === 0 &&
-          (nftCounts > 0 ? (
+          (nftCount > 0 ? (
             <NFTListPortfolio />
           ) : (
             <NFTsExploreBanner type="nfts" />
           ))}
         {panelNumber === 1 &&
-          (nftCounts > 0 ? (
+          (nftCount > 0 ? (
             <NFTListPortfolioBadges />
           ) : (
             <NFTsExploreBanner type="badge" />


### PR DESCRIPTION
### What

- update collections as NFTs are loaded - POAPs collection should update number of NFTs it contains, Galxe collections should be marked as badges
- show number of NFTs, badges and collections in the stats UI for NFTs and Portfolio page
- calculate the total floor price for NFTs from loaded accounts and show it in stats

**Note: as loading NFTs is improved in [this PR ](https://github.com/tallycash/extension/pull/2703) here stats are updating as user is expanding collections - visible for POAPs and Galxe NFTs. In the linked PR action that triggers update is changed from expanding collection to collection being visible on the screen so it will be much nicer UX.**

### Testing

- [ ] load account with NFTs and expand some collections so more data is loaded
- [ ] check the stats numbers on NFTs page and Portfolio page

![image](https://user-images.githubusercontent.com/20949277/205316857-5bf8d0f5-5bc9-4852-a4b9-5124b5374a35.png)
![image](https://user-images.githubusercontent.com/20949277/205316897-d0139b99-f9b8-429c-af0e-eca89c8fecbc.png)

Latest build: [extension-builds-2710](https://github.com/tallycash/extension/suites/9668601723/artifacts/462737410) (as of Mon, 05 Dec 2022 10:14:42 GMT).