### PR TITLE
Add NFTs support for BSC

### DIFF
--- a/background/constants/coin-types.ts
+++ b/background/constants/coin-types.ts
@@ -11,6 +11,7 @@ export const coinTypesByAssetSymbol = {
   RBTC: 137,
   MATIC: 966,
   AVAX: 9005,
+  BNB: 714,
 } as const
 
 /**

--- a/background/constants/currencies.ts
+++ b/background/constants/currencies.ts
@@ -75,6 +75,18 @@ export const AVAX: NetworkBaseAsset = {
   },
 }
 
+export const BNB: NetworkBaseAsset = {
+  name: "Binance Coin",
+  symbol: "BNB",
+  decimals: 18,
+  coinType: coinTypesByAssetSymbol.BNB,
+  metadata: {
+    coinGeckoID: "binancecoin",
+    tokenLists: [],
+    websiteURL: "https://bnbchain.org",
+  },
+}
+
 export const BTC: NetworkBaseAsset = {
   name: "Bitcoin",
   symbol: "BTC",
@@ -87,7 +99,7 @@ export const BTC: NetworkBaseAsset = {
   },
 }
 
-export const BASE_ASSETS = [ETH, BTC, MATIC, RBTC, OPTIMISTIC_ETH, AVAX]
+export const BASE_ASSETS = [ETH, BTC, MATIC, RBTC, OPTIMISTIC_ETH, AVAX, BNB]
 
 export const BASE_ASSETS_BY_SYMBOL = BASE_ASSETS.reduce<{
   [assetSymbol: string]: NetworkBaseAsset

--- a/background/constants/networks.ts
+++ b/background/constants/networks.ts
@@ -1,5 +1,5 @@
 import { EVMNetwork, Network } from "../networks"
-import { AVAX, BTC, ETH, MATIC, OPTIMISTIC_ETH, RBTC } from "./currencies"
+import { AVAX, BNB, BTC, ETH, MATIC, OPTIMISTIC_ETH, RBTC } from "./currencies"
 
 export const ETHEREUM: EVMNetwork = {
   name: "Ethereum",
@@ -39,6 +39,14 @@ export const AVALANCHE: EVMNetwork = {
   chainID: "43114",
   family: "EVM",
   coingeckoPlatformID: "avalanche",
+}
+
+export const BINANCE_SMART_CHAIN: EVMNetwork = {
+  name: "BNB Chain",
+  baseAsset: BNB,
+  chainID: "56",
+  family: "EVM",
+  coingeckoPlatformID: "binance-smart-chain",
 }
 
 export const ARBITRUM_NOVA: EVMNetwork = {
@@ -85,7 +93,9 @@ export const EIP_1559_COMPLIANT_CHAIN_IDS = new Set(
 )
 
 export const CHAINS_WITH_MEMPOOL = new Set(
-  [ETHEREUM, POLYGON, AVALANCHE, GOERLI].map((network) => network.chainID)
+  [ETHEREUM, POLYGON, AVALANCHE, GOERLI, BINANCE_SMART_CHAIN].map(
+    (network) => network.chainID
+  )
 )
 
 export const NETWORK_BY_CHAIN_ID = {
@@ -96,6 +106,7 @@ export const NETWORK_BY_CHAIN_ID = {
   [AVALANCHE.chainID]: AVALANCHE,
   [ARBITRUM_NOVA.chainID]: ARBITRUM_NOVA,
   [OPTIMISM.chainID]: OPTIMISM,
+  [BINANCE_SMART_CHAIN.chainID]: BINANCE_SMART_CHAIN,
   [GOERLI.chainID]: GOERLI,
   [FORK.chainID]: FORK,
 }
@@ -116,6 +127,7 @@ export const CHAIN_ID_TO_0X_API_BASE: {
   [GOERLI.chainID]: "goerli.api.0x.org",
   [ARBITRUM_ONE.chainID]: "arbitrum.api.0x.org",
   [AVALANCHE.chainID]: "avalanche.api.0x.org",
+  [BINANCE_SMART_CHAIN.chainID]: "bsc.api.0x.org",
 }
 
 export const NETWORKS_SUPPORTING_SWAPS = new Set(
@@ -144,6 +156,10 @@ export const CHAIN_ID_TO_RPC_URLS: {
   [AVALANCHE.chainID]: [
     "https://api.avax.network/ext/bc/C/rpc",
     "https://rpc.ankr.com/avalanche",
+  ],
+  [BINANCE_SMART_CHAIN.chainID]: [
+    "https://rpc.ankr.com/bsc",
+    "https://bsc-dataseed.binance.org",
   ],
 }
 

--- a/background/lib/simple-hash_update.ts
+++ b/background/lib/simple-hash_update.ts
@@ -5,13 +5,15 @@ import { HexString } from "../types"
 import logger from "./logger"
 import { sameEVMAddress } from "./utils"
 
+type SupportedChain = "polygon" | "arbitrum" | "optimism" | "ethereum" | "bsc"
+
 type SimpleHashNFTModel = {
   nft_id: string
   token_id: string | null
   name: string | null
   description: string | null
   contract_address: string
-  chain: "polygon" | "arbitrum" | "optimism" | "ethereum"
+  chain: SupportedChain
   external_url: string | null
   image_url: string | null
   previews?: {
@@ -41,7 +43,7 @@ type SimpleHashCollectionModel = {
   id: string
   name: string | null
   image_url: string | null
-  chain: "polygon" | "arbitrum" | "optimism" | "ethereum"
+  chain: SupportedChain
   distinct_nfts_owned: number | null
   distinct_owner_count: number | null
   distinct_nft_count: number | null
@@ -71,6 +73,7 @@ const CHAIN_ID_TO_NAME = {
   137: "polygon",
   42161: "arbitrum",
   43114: "avalanche",
+  56: "bsc",
 }
 
 const SIMPLE_HASH_CHAIN_TO_ID = {
@@ -79,6 +82,7 @@ const SIMPLE_HASH_CHAIN_TO_ID = {
   polygon: 137,
   arbitrum: 42161,
   avalanche: 43114,
+  bsc: 56,
 }
 
 function isGalxeAchievement(url: string | null | undefined) {

--- a/background/nfts.ts
+++ b/background/nfts.ts
@@ -4,6 +4,7 @@ import {
   OPTIMISM,
   ARBITRUM_ONE,
   AVALANCHE,
+  BINANCE_SMART_CHAIN,
 } from "./constants"
 import { EVMNetwork } from "./networks"
 // Networks that are not added to this struct will
@@ -16,6 +17,7 @@ export const CHAIN_ID_TO_NFT_METADATA_PROVIDER: {
   [OPTIMISM.chainID]: ["simplehash"],
   [ARBITRUM_ONE.chainID]: ["simplehash"],
   [AVALANCHE.chainID]: ["simplehash"],
+  [BINANCE_SMART_CHAIN.chainID]: ["simplehash"],
 }
 
 export const NFT_PROVIDER_TO_CHAIN = {
@@ -26,6 +28,7 @@ export const NFT_PROVIDER_TO_CHAIN = {
     OPTIMISM.chainID,
     ARBITRUM_ONE.chainID,
     AVALANCHE.chainID,
+    BINANCE_SMART_CHAIN.chainID,
   ],
 }
 


### PR DESCRIPTION
Closes #2570 

This PR adds NFTs support for Binance Smart Chain. Uses NFT API from simplehash.

## UI
<img width="240" alt="Screenshot 2022-12-05 at 13 21 24" src="https://user-images.githubusercontent.com/23117945/205639845-dc8a3dfe-7074-4fb2-8f50-710317dc4a30.png">

## To Test
Set`SUPPORT_BINANCE_SMART_CHAIN` to `true`.

- [ ] check NFTs support