### PR TITLE
Reload NFTs without a loader

### DIFF
--- a/background/redux-slices/nfts_update.ts
+++ b/background/redux-slices/nfts_update.ts
@@ -68,7 +68,7 @@ function updateCollection(
   acc.nfts[chainID][ownerAddress][collection.id] = {
     id,
     name,
-    nftCount,
+    nftCount: nftCount ?? savedCollection.nftCount ?? 0, // POAPs has no nftCount until the NFTs are loaded, let's fallback to old number
     totalNftCount,
     nfts: savedCollection.nfts ?? [],
     hasBadges: savedCollection.hasBadges || hasBadges, // once we know it has badges it should stay like that

--- a/ui/hooks/nft-hooks.ts
+++ b/ui/hooks/nft-hooks.ts
@@ -13,7 +13,6 @@ import { selectAssetPricePoint } from "@tallyho/tally-background/redux-slices/as
 import {
   cleanCachedNFTs,
   refetchCollections,
-  updateIsReloading,
 } from "@tallyho/tally-background/redux-slices/nfts_update"
 import { useEffect } from "react"
 import { useBackgroundDispatch, useBackgroundSelector } from "./redux-hooks"
@@ -57,12 +56,8 @@ export const useNFTsReload = (): void => {
   const dispatch = useBackgroundDispatch()
 
   useEffect(() => {
-    // TODO: to avoid flash of the list on the first render - not perfect
-    dispatch(updateIsReloading(true))
     dispatch(refetchCollections())
     return () => {
-      // TODO: prepare for the next refetch - works if this component was unmounted correctly (closing extension is not updating it correctly)
-      dispatch(updateIsReloading(true))
       dispatch(cleanCachedNFTs())
     }
   }, [dispatch])


### PR DESCRIPTION
Resolves #2737

### What
On NFTs reload let's not show the page loader.
NFTs should be updated without huge layout shifts. Let's show the loader only when NFTs are fetched for the first time for some account - as we don't know what collections should we expect there.

### Testing

- [ ] add a new account and go to the NFTs page quickly - you may see the "doggo loader"
- [ ] go to Wallet pge and go back to the NFTs page - there should be no loader but NFTs are updated in the background. If the account receives a new NFT then it should be visible on the next NFTs page visit.  