### PR TITLE
Add FAQ link to Settings page

### DIFF
--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -362,6 +362,7 @@
     "bugReport": "Bug report",
     "connectedWebsites": "Connected websites",
     "analytics": "Analytics",
+    "needHelp": "Need Help?",
     "showBanners": "Show achievement banners",
     "joinTitle": "Join our community",
     "joinDesc": "Join our Discord to give us feedback!",

--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -364,9 +364,6 @@
     "analytics": "Analytics",
     "needHelp": "Need Help?",
     "showBanners": "Show achievement banners",
-    "joinTitle": "Join our community",
-    "joinDesc": "Join our Discord to give us feedback!",
-    "joinBtn": "Join and give feedback",
     "versionLabel": "Version {{version}}",
     "unknownVersionOrCommit": "<unknown>",
     "exportLogs": {

--- a/ui/pages/Settings.tsx
+++ b/ui/pages/Settings.tsx
@@ -20,10 +20,25 @@ import { getLanguageIndex, getAvalableLanguages } from "../_locales"
 import { getLanguage, setLanguage } from "../_locales/i18n"
 import SettingButton from "./Settings/SettingButton"
 import { useBackgroundSelector } from "../hooks"
+import SharedIcon from "../components/Shared/SharedIcon"
 
 const NUMBER_OF_CLICKS_FOR_DEV_PANEL = 15
 const FAQ_URL =
   "https://tallyhowallet.notion.site/Tally-Ho-Knowledge-Base-4d95ed5439c64d6db3d3d27abf1fdae5"
+const FOOTER_ACTIONS = [
+  {
+    icon: "icons/m/discord",
+    linkTo: "https://chat.tally.cash/",
+  },
+  {
+    icon: "twitter",
+    linkTo: "https://twitter.com/TallyCash",
+  },
+  {
+    icon: "icons/m/github",
+    linkTo: "https://github.com/tallycash/extension",
+  },
+]
 
 function VersionLabel(): ReactElement {
   const { t } = useTranslation()
@@ -263,8 +278,24 @@ export default function Settings(): ReactElement {
             />
           ))}
         </ul>
-        <VersionLabel />
       </section>
+      <div className="footer">
+        <div className="action_icons">
+          {FOOTER_ACTIONS.map(({ icon, linkTo }) => (
+            <SharedIcon
+              icon={`${icon}.svg`}
+              width={18}
+              color="var(--green-20)"
+              hoverColor="var(--trophy-gold)"
+              transitionHoverTime="0.2s"
+              onClick={() => {
+                window.open(linkTo, "_blank")?.focus()
+              }}
+            />
+          ))}
+        </div>
+        <VersionLabel />
+      </div>
       <style jsx>
         {`
           section {
@@ -286,15 +317,18 @@ export default function Settings(): ReactElement {
             font-weight: 400;
             line-height: 24px;
           }
-          .mega_discord_chat_bubble_button {
-            background: url("./images/tally_ho_chat_bubble@2x.png");
-            background-size: cover;
-            width: 266px;
-            height: 120px;
-            margin-top: 20px;
+          .footer {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            padding-top: 16px;
+            width: 100%;
+            background-color: var(--green-95);
           }
-          .mega_discord_chat_bubble_button:hover {
-            opacity: 0.8;
+          .action_icons {
+            display: flex;
+            justify-content: center;
+            gap: 24px;
           }
         `}
       </style>

--- a/ui/pages/Settings.tsx
+++ b/ui/pages/Settings.tsx
@@ -23,6 +23,8 @@ import SettingButton from "./Settings/SettingButton"
 import { useBackgroundSelector } from "../hooks"
 
 const NUMBER_OF_CLICKS_FOR_DEV_PANEL = 15
+const FAQ_URL =
+  "https://tallyhowallet.notion.site/Tally-Ho-Knowledge-Base-4d95ed5439c64d6db3d3d27abf1fdae5"
 
 function VersionLabel(): ReactElement {
   const { t } = useTranslation()
@@ -173,6 +175,18 @@ export default function Settings(): ReactElement {
     ),
   }
 
+  const needHelp = {
+    title: "",
+    component: () => (
+      <SettingButton
+        label={t("settings.needHelp")}
+        ariaLabel={t("settings.needHelp")}
+        icon="new-tab"
+        onClick={() => window.open(FAQ_URL, "_blank")?.focus()}
+      />
+    ),
+  }
+
   const bugReport = {
     title: "",
     component: () => (
@@ -180,6 +194,7 @@ export default function Settings(): ReactElement {
         link="/settings/export-logs"
         label={t("settings.bugReport")}
         ariaLabel={t("settings.exportLogs.ariaLabel")}
+        icon="continue"
       />
     ),
   }
@@ -191,6 +206,7 @@ export default function Settings(): ReactElement {
         link="/settings/connected-websites"
         label={t("settings.connectedWebsites")}
         ariaLabel={t("settings.connectedWebsitesSettings.ariaLabel")}
+        icon="continue"
       />
     ),
   }
@@ -202,6 +218,7 @@ export default function Settings(): ReactElement {
         link="/settings/analytics"
         label={t("settings.analytics")}
         ariaLabel={t("settings.analyticsSetUp.ariaLabel")}
+        icon="continue"
       />
     ),
   }
@@ -222,6 +239,7 @@ export default function Settings(): ReactElement {
     ...(isEnabled(FeatureFlags.SUPPORT_MULTIPLE_LANGUAGES) ? [languages] : []),
     enableTestNetworks,
     dAppsSettings,
+    needHelp,
     bugReport,
     ...(isEnabled(FeatureFlags.ENABLE_ANALYTICS_DEFAULT_ON) ? [analytics] : []),
     ...(isEnabled(FeatureFlags.SUPPORT_ACHIEVEMENTS_BANNER)

--- a/ui/pages/Settings.tsx
+++ b/ui/pages/Settings.tsx
@@ -14,7 +14,6 @@ import {
 import { FeatureFlags, isEnabled } from "@tallyho/tally-background/features"
 import { useHistory } from "react-router-dom"
 import { selectMainCurrencySign } from "@tallyho/tally-background/redux-slices/selectors"
-import SharedButton from "../components/Shared/SharedButton"
 import SharedToggleButton from "../components/Shared/SharedToggleButton"
 import SharedSelect from "../components/Shared/SharedSelect"
 import { getLanguageIndex, getAvalableLanguages } from "../_locales"
@@ -264,21 +263,6 @@ export default function Settings(): ReactElement {
             />
           ))}
         </ul>
-        <div className="community_cta_wrap">
-          <h2>{t("settings.joinTitle")}</h2>
-          <p>{t("settings.joinDesc")}</p>
-          <SharedButton
-            type="primary"
-            size="large"
-            iconMedium="discord"
-            iconPosition="left"
-            onClick={() => {
-              window.open(`https://chat.tally.cash/`, "_blank")?.focus()
-            }}
-          >
-            {t("settings.joinBtn")}
-          </SharedButton>
-        </div>
         <VersionLabel />
       </section>
       <style jsx>
@@ -289,37 +273,12 @@ export default function Settings(): ReactElement {
             height: 544px;
             background-color: var(--hunter-green);
           }
-          .community_cta_wrap {
-            width: 100vw;
-            margin-top: 20px;
-            margin-left: -21px;
-            background-color: var(--green-95);
-            text-align: center;
-            padding: 24px 0px;
-            box-sizing: border-box;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-          }
           h1 {
             color: #fff;
             font-size: 22px;
             font-weight: 500;
             line-height: 32px;
             margin-bottom: 5px;
-          }
-          h2 {
-            font-weight: 500;
-            font-size: 22px;
-            padding: 0px;
-            margin: 0px 0px -1px 0px;
-          }
-          p {
-            color: var(--green-20);
-            text-align: center;
-            font-size: 16px;
-            margin-top: 6px;
-            margin-bottom: 24px;
           }
           span {
             color: var(--green-40);

--- a/ui/pages/Settings.tsx
+++ b/ui/pages/Settings.tsx
@@ -266,8 +266,8 @@ export default function Settings(): ReactElement {
   }
 
   return (
-    <>
-      <section className="standard_width_padded">
+    <section className="standard_width_padded">
+      <div className="menu">
         <h1>{t("settings.mainMenu")}</h1>
         <ul>
           {settings.general.map((setting) => (
@@ -278,7 +278,7 @@ export default function Settings(): ReactElement {
             />
           ))}
         </ul>
-      </section>
+      </div>
       <div className="footer">
         <div className="action_icons">
           {FOOTER_ACTIONS.map(({ icon, linkTo }) => (
@@ -301,8 +301,15 @@ export default function Settings(): ReactElement {
           section {
             display: flex;
             flex-flow: column;
+            justify-content: space-between;
             height: 544px;
             background-color: var(--hunter-green);
+          }
+          .menu {
+            display: flex;
+            justify-content: space-between;
+            display: flex;
+            flex-direction: column;
           }
           h1 {
             color: #fff;
@@ -318,12 +325,16 @@ export default function Settings(): ReactElement {
             line-height: 24px;
           }
           .footer {
+            width: 100vw;
+            margin-top: 20px;
+            margin-left: -24px;
+            background-color: var(--green-95);
+            text-align: center;
+            padding-top: 16px;
+            box-sizing: border-box;
             display: flex;
             flex-direction: column;
             align-items: center;
-            padding-top: 16px;
-            width: 100%;
-            background-color: var(--green-95);
           }
           .action_icons {
             display: flex;
@@ -332,6 +343,6 @@ export default function Settings(): ReactElement {
           }
         `}
       </style>
-    </>
+    </section>
   )
 }

--- a/ui/pages/Settings/SettingButton.tsx
+++ b/ui/pages/Settings/SettingButton.tsx
@@ -3,18 +3,20 @@ import SharedButton from "../../components/Shared/SharedButton"
 import SharedIcon from "../../components/Shared/SharedIcon"
 
 export default function SettingButton(props: {
-  link: string
   label: string
   ariaLabel: string
+  icon: string
+  link?: string
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void
 }): ReactElement {
-  const { link, ariaLabel, label } = props
+  const { link, ariaLabel, label, icon, onClick } = props
 
   return (
-    <SharedButton type="unstyled" size="medium" linkTo={link}>
+    <SharedButton type="unstyled" size="medium" linkTo={link} onClick={onClick}>
       <div className="button_row">
         <div className="action_name">{label}</div>
         <SharedIcon
-          icon="icons/s/continue.svg"
+          icon={`icons/s/${icon}.svg`}
           width={16}
           color="var(--green-20)"
           ariaLabel={ariaLabel}


### PR DESCRIPTION
Closes #2763 

This PR updates the Settings page and adds FAQ link.

Changes:
- Remove the current "Join Community" banner
- Add social icons in the footer
-  Add Need help button  

## UI
![Screenshot 2022-12-15 at 13 05 27](https://user-images.githubusercontent.com/23117945/207855037-8a4da43e-a8ef-47c9-8158-b92c1bab0a05.png)


## To Test
- [ ] check that the social icons move you to correct page
- [ ] check that after clicking the ,,Need help?" button FAQ page will be open

Latest build: [extension-builds-2785](https://github.com/tallycash/extension/suites/9886761639/artifacts/477393896) (as of Thu, 15 Dec 2022 13:20:31 GMT).