### PR TITLE
Restrict the running of e2e tests only to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn lint
   e2e-tests:
+    if: github.ref == 'refs/heads/main'
     needs: build
     timeout-minutes: 60
     runs-on: ubuntu-latest


### PR DESCRIPTION
e2e tests depend on external services eg. cowswap which can result in false negatives. To prevent this from affecting developer velocity we run this only on main. This way we can be notified if something is broken without affecting other workflows.

## Test 

We don't really have a way to test this change before actually merging on main. 