### PR TITLE
Impersonate MM on tally.xyz and polygon.technology

### DIFF
--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -23,7 +23,7 @@ const impersonateMetamaskWhitelist = [
   "traderjoexyz.com",
   "transferto.xyz",
   "opensea.io",
-  "staking.polygon.technology",
+  "polygon.technology",
   "gmx.io",
   "app.lyra.finance",
   "matcha.xyz",


### PR DESCRIPTION
Resolves https://github.com/tahowallet/extension/issues/3187
Resolves https://github.com/tahowallet/extension/issues/3168

### What
Add websites to impersonate MM whitelist

### Testing
- connect wallet to [tally.xyz](https://www.tally.xyz/)
- connect wallet to [polygon.technology](https://wallet.polygon.technology/)

Latest build: [extension-builds-3194](https://github.com/tahowallet/extension/suites/11838407578/artifacts/618517771) (as of Mon, 27 Mar 2023 16:56:07 GMT).