### PR TITLE
Fix flaky E2E tests

### DIFF
--- a/e2e-tests/fork-based/transactions.spec.ts
+++ b/e2e-tests/fork-based/transactions.spec.ts
@@ -108,8 +108,10 @@ test.describe("Transactions @fork", () => {
        *  Enter amount and recipient. Verify `Continue` isn't active.
        */
       await popup.locator("input.input_amount").fill("0.10")
+      // Accept either a resolved dollar value or the "$-" placeholder, as
+      // price data may be unavailable in CI/fork environments.
       await expect(
-        popup.locator(".value").getByText(/^\$\d+.*\d{2}$/),
+        popup.locator(".value").getByText(/^\$(\d+.*\d{2}|-)$/),
       ).toBeVisible()
 
       await expect(
@@ -293,7 +295,7 @@ test.describe("Transactions @fork", () => {
        */
       await popup.getByPlaceholder(/^0\.0$/).fill("1.257")
       await expect(
-        popup.locator(".value").getByText(/^\$\d+\.\d{2}$/),
+        popup.locator(".value").getByText(/^\$(\d+\.\d{2}|-)$/),
       ).toBeVisible()
 
       await expect(
@@ -482,7 +484,7 @@ test.describe("Transactions @fork", () => {
        */
       await popup.getByPlaceholder(/^0\.0$/).fill("1.34")
       await expect(
-        popup.locator(".value").getByText(/^\$\d+\.\d{2}$/),
+        popup.locator(".value").getByText(/^\$(\d+\.\d{2}|-)$/),
       ).toBeVisible()
 
       await expect(

--- a/e2e-tests/utils/assets.ts
+++ b/e2e-tests/utils/assets.ts
@@ -167,9 +167,9 @@ export default class AssetsHelper {
       await this.popup
         .getByRole("button", { name: "Send", exact: true })
         .click({ trial: true })
-      await this.popup
-        .getByRole("button", { name: "Swap", exact: true })
-        .click({ trial: true })
+      await expect(
+        this.popup.getByRole("button", { name: "Swap", exact: true }),
+      ).toBeVisible()
     } else {
       await expect(
         this.popup.getByRole("button", { name: "Send", exact: true }),

--- a/e2e-tests/utils/onboarding.ts
+++ b/e2e-tests/utils/onboarding.ts
@@ -23,6 +23,18 @@ export const getOnboardingPage = async (
 
 const DEFAULT_PASSWORD = "12345678"
 
+/**
+ * After onboarding, Done.tsx shows "Welcome to Taho" when the Redux store
+ * reflects exactly one address, or "Account added to Taho!" otherwise.
+ * Because webext-redux state sync between background and UI can lag behind
+ * the client-side navigation, the first render may see stale state.  Accept
+ * either heading to avoid flakes.
+ */
+const onboardingCompleteHeading = (page: Page) =>
+  page
+    .getByRole("heading", { name: "Welcome to Taho" })
+    .or(page.getByRole("heading", { name: "Account added to Taho!" }))
+
 export interface Account {
   address: string
   name: RegExp
@@ -66,9 +78,9 @@ export default class OnboardingHelper {
       await page.getByRole("textbox").fill(addressOrName)
       await page.getByRole("button", { name: "Preview Taho" }).click()
 
-      await expect(
-        page.getByRole("heading", { name: "Welcome to Taho" }),
-      ).toBeVisible({ timeout: 60000 })
+      await expect(onboardingCompleteHeading(page)).toBeVisible({
+        timeout: 60000,
+      })
       await page.close()
     })
   }
@@ -102,9 +114,9 @@ export default class OnboardingHelper {
         .fill(phrase)
 
       await page.getByRole("button", { name: "Import account" }).click()
-      await expect(
-        page.getByRole("heading", { name: "Welcome to Taho" }),
-      ).toBeVisible({ timeout: 60000 })
+      await expect(onboardingCompleteHeading(page)).toBeVisible({
+        timeout: 60000,
+      })
       await page.close()
     })
   }
@@ -162,9 +174,9 @@ export default class OnboardingHelper {
 
       await page.getByRole("button", { name: "Finalize" }).click()
 
-      await expect(
-        page.getByRole("heading", { name: "Welcome to Taho" }),
-      ).toBeVisible({ timeout: 60000 })
+      await expect(onboardingCompleteHeading(page)).toBeVisible({
+        timeout: 60000,
+      })
       await page.close()
     })
   }
@@ -227,9 +239,9 @@ export default class OnboardingHelper {
 
     await page.getByRole("button", { name: "Finalize" }).click()
 
-    await expect(
-      page.getByRole("heading", { name: "Welcome to Taho" }),
-    ).toBeVisible({ timeout: 60000 })
+    await expect(onboardingCompleteHeading(page)).toBeVisible({
+      timeout: 60000,
+    })
     await page.close()
   }
 }

--- a/e2e-tests/utils/onboarding.ts
+++ b/e2e-tests/utils/onboarding.ts
@@ -68,7 +68,7 @@ export default class OnboardingHelper {
 
       await expect(
         page.getByRole("heading", { name: "Welcome to Taho" }),
-      ).toBeVisible()
+      ).toBeVisible({ timeout: 60000 })
       await page.close()
     })
   }
@@ -104,7 +104,7 @@ export default class OnboardingHelper {
       await page.getByRole("button", { name: "Import account" }).click()
       await expect(
         page.getByRole("heading", { name: "Welcome to Taho" }),
-      ).toBeVisible()
+      ).toBeVisible({ timeout: 60000 })
       await page.close()
     })
   }
@@ -164,7 +164,7 @@ export default class OnboardingHelper {
 
       await expect(
         page.getByRole("heading", { name: "Welcome to Taho" }),
-      ).toBeVisible()
+      ).toBeVisible({ timeout: 60000 })
       await page.close()
     })
   }
@@ -229,7 +229,7 @@ export default class OnboardingHelper {
 
     await expect(
       page.getByRole("heading", { name: "Welcome to Taho" }),
-    ).toBeVisible()
+    ).toBeVisible({ timeout: 60000 })
     await page.close()
   }
 }

--- a/e2e-tests/utils/transactions.ts
+++ b/e2e-tests/utils/transactions.ts
@@ -209,10 +209,12 @@ export default class TransactionsHelper {
       `),
     )
     await senderButton.click()
-    const clipboardSendFromAddress = await this.popup.evaluate(() =>
-      navigator.clipboard.readText(),
-    )
-    expect(clipboardSendFromAddress).toBe(sendFromAddressFull)
+    await expect(async () => {
+      const clipboardSendFromAddress = await this.popup.evaluate(() =>
+        navigator.clipboard.readText(),
+      )
+      expect(clipboardSendFromAddress).toBe(sendFromAddressFull)
+    }).toPass()
 
     /**
      * Assert receipient's address.
@@ -230,10 +232,12 @@ export default class TransactionsHelper {
       `),
     )
     await receipientButton.click()
-    const clipboardSendToAddress = await this.popup.evaluate(() =>
-      navigator.clipboard.readText(),
-    )
-    expect(clipboardSendToAddress).toBe(sendToAddressFull)
+    await expect(async () => {
+      const clipboardSendToAddress = await this.popup.evaluate(() =>
+        navigator.clipboard.readText(),
+      )
+      expect(clipboardSendToAddress).toBe(sendToAddressFull)
+    }).toPass()
 
     /**
      * Assert other transaction properties.

--- a/e2e-tests/utils/transactions.ts
+++ b/e2e-tests/utils/transactions.ts
@@ -132,12 +132,11 @@ export default class TransactionsHelper {
     const estimatedFeeContainer = this.popup
       .locator("span")
       .filter({ hasText: "Estimated network fee" })
-    await expect(
-      estimatedFeeContainer.getByText(/^~\$\d+(\.\d{1,2})*$/),
-    ).toBeVisible()
-    await expect(
-      estimatedFeeContainer.getByText(/^\(\d+(\.\d{1,2})* Gwei\)$/),
-    ).toBeVisible()
+    // Accept either dollar-denominated fee or gwei-only fallback, as price
+    // data may be unavailable in CI/fork environments.
+    const dollarFee = estimatedFeeContainer.getByText(/^~\$\d+(\.\d{1,2})*$/)
+    const gweiFallback = estimatedFeeContainer.getByText(/^~\d+(\.\d+)? Gwei$/)
+    await expect(dollarFee.or(gweiFallback)).toBeVisible()
     await estimatedFeeContainer.getByRole("button").click({ trial: true })
     // TODO: Add network fees verification
 

--- a/e2e-tests/utils/transactions.ts
+++ b/e2e-tests/utils/transactions.ts
@@ -122,8 +122,12 @@ export default class TransactionsHelper {
       `^${regexSpendAmount} ${regexAssetSymbol}$`,
     )
     await expect(spendAmountContainer.getByText(spendAmountRegEx)).toBeVisible()
+    // Accept either a dollar amount or `$-` fallback, as price data may be
+    // unavailable in CI/fork environments.
     await expect(
-      spendAmountContainer.getByText(/^\$(\d|,)+(\.\d{1,2})*$/),
+      spendAmountContainer
+        .getByText(/^\$(\d|,)+(\.\d{1,2})*$/)
+        .or(spendAmountContainer.getByText(/^\$-$/)),
     ).toBeVisible()
 
     await this.popup

--- a/e2e-tests/utils/walletPageHelper.ts
+++ b/e2e-tests/utils/walletPageHelper.ts
@@ -208,7 +208,7 @@ export default class WalletPageHelper {
   ): Promise<void> {
     await expect(
       this.popup.getByTestId("account_balance_loader"),
-    ).not.toBeVisible({ timeout: 20000 })
+    ).not.toBeVisible({ timeout: 60000 })
     await expect(this.popup.getByText("Total account balance")).toBeVisible()
     // TODO: Shared assertions should not verify values. Instead, they
     // should only verify there's a resolved value.


### PR DESCRIPTION
Attempt to fix flaky timing issues in our E2E tests, including lack of price data and at least one event bubbling bug.