### PR TITLE
chore: remove unnecessary useMemo for showHiddenAssets

### DIFF
--- a/ui/pages/Wallet.tsx
+++ b/ui/pages/Wallet.tsx
@@ -96,8 +96,7 @@ export default function Wallet(): ReactElement {
     (background) => background.ui?.initializationLoadingTimeExpired,
   )
 
-  const showHiddenAssets =
-    showUnverifiedAssets && unverifiedAssetAmounts.length > 0
+  const showHiddenAssets = showUnverifiedAssets && unverifiedAssetAmounts.length > 0
 
   const panelNames = [t("wallet.pages.assets")]
 

--- a/ui/pages/Wallet.tsx
+++ b/ui/pages/Wallet.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useMemo, useState } from "react"
+import React, { ReactElement, useEffect, useState } from "react"
 import dayjs from "dayjs"
 import isBetween from "dayjs/plugin/isBetween"
 
@@ -96,10 +96,8 @@ export default function Wallet(): ReactElement {
     (background) => background.ui?.initializationLoadingTimeExpired,
   )
 
-  const showHiddenAssets = useMemo(
-    () => showUnverifiedAssets && unverifiedAssetAmounts.length > 0,
-    [showUnverifiedAssets, unverifiedAssetAmounts.length],
-  )
+  const showHiddenAssets =
+    showUnverifiedAssets && unverifiedAssetAmounts.length > 0
 
   const panelNames = [t("wallet.pages.assets")]
 


### PR DESCRIPTION
Removes an unnecessary useMemo wrapper around a simple boolean expression. The computation is trivial and does not benefit from memoization, so simplifying it improves readability without changing behavior.
