### PR TITLE
docs: fix ui README extension output directory

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -40,7 +40,9 @@ Then, start up the dev server:
 yarn start
 ```
 
-Load the unpacked extension for your web browser via the `/build` directory. Currently builds are tested to work on Chrome and Brave browser.
+Load the unpacked extension for your web browser from the appropriate
+`/dist/<browser>` directory. Currently builds are tested to work on Chrome and
+Brave browser.
 
 ## Primary file structure 📁
 


### PR DESCRIPTION
## Summary
- update `ui/README.md` to point unpacked-extension loading at the existing `dist/<browser>` output directory
- align the UI package README with the top-level README so local setup instructions no longer contradict each other

## Testing
- not run (docs-only change)