### PR TITLE
Instrument RPC traffic and dampen reconnect/retry herd in the provider

### DIFF
--- a/background/lib/perf-metrics.ts
+++ b/background/lib/perf-metrics.ts
@@ -1,0 +1,254 @@
+/**
+ * Process-wide collector for performance counters that describe the health
+ * of RPC traffic and the redux store.
+ *
+ * Counters are intentionally flat and additive so that producers (e.g. the
+ * chain provider, the redux store middleware) can call into this module
+ * without coordinating locks. A periodic consumer (the analytics service)
+ * takes a snapshot, which atomically hands back the accumulated values and
+ * resets the window so the next interval starts clean.
+ *
+ * The collector holds counters in memory only. Losing them on service-worker
+ * restart is acceptable: what matters is the aggregate shape we see over
+ * hours, not individual data points.
+ */
+import { RPCErrorType } from "../services/chain/errors"
+
+/**
+ * Histogram bucket upper bounds in milliseconds. A duration is recorded in
+ * the first bucket whose upper bound is >= the duration; anything larger
+ * goes in the overflow bucket.
+ */
+const DURATION_BUCKETS_MS = [50, 200, 500, 1000, 2000, 5000, 10_000] as const
+
+type DurationBucketLabel =
+  | `le_${(typeof DURATION_BUCKETS_MS)[number]}`
+  | "overflow"
+
+/**
+ * The full set of failure categories we want to distinguish in analytics,
+ * mirroring {@link RPCErrorType} but including a bucket for bookkeeping
+ * misses (e.g. single-flight followers inheriting a rejection).
+ */
+export type RequestFailureCategory = RPCErrorType | "aborted"
+
+type ProviderCounters = {
+  requestsSent: number
+  requestsSucceeded: number
+  requestsFailed: Record<RequestFailureCategory, number>
+  singleFlightCoalesces: number
+  reconnectAttempts: number
+  reconnectSuccesses: number
+  reconnectFailures: number
+  circuitBreakerOpens: number
+  circuitBreakerHalfOpens: number
+  circuitBreakerCloses: number
+  durationHistogramMs: Record<DurationBucketLabel, number>
+}
+
+type ChainCounters = {
+  providers: Map<number, ProviderCounters>
+}
+
+export type PerfMetricsSnapshot = {
+  windowStartedAt: number
+  takenAt: number
+  chains: Record<
+    string,
+    {
+      providers: Array<
+        {
+          providerIndex: number
+        } & Omit<ProviderCounters, "durationHistogramMs"> & {
+            durationHistogramMs: Record<DurationBucketLabel, number>
+          }
+      >
+    }
+  >
+}
+
+function freshFailureCounters(): Record<RequestFailureCategory, number> {
+  return {
+    "batch-limit-exceeded": 0,
+    "rate-limit-error": 0,
+    "network-error": 0,
+    "response-error": 0,
+    "invalid-response-error": 0,
+    "eth-call-gas-error": 0,
+    "unknown-error": 0,
+    aborted: 0,
+  }
+}
+
+function freshDurationHistogram(): Record<DurationBucketLabel, number> {
+  const histogram = { overflow: 0 } as Record<DurationBucketLabel, number>
+  DURATION_BUCKETS_MS.forEach((bound) => {
+    histogram[`le_${bound}`] = 0
+  })
+  return histogram
+}
+
+function freshProviderCounters(): ProviderCounters {
+  return {
+    requestsSent: 0,
+    requestsSucceeded: 0,
+    requestsFailed: freshFailureCounters(),
+    singleFlightCoalesces: 0,
+    reconnectAttempts: 0,
+    reconnectSuccesses: 0,
+    reconnectFailures: 0,
+    circuitBreakerOpens: 0,
+    circuitBreakerHalfOpens: 0,
+    circuitBreakerCloses: 0,
+    durationHistogramMs: freshDurationHistogram(),
+  }
+}
+
+let chains: Map<string, ChainCounters> = new Map()
+let windowStartedAt: number = Date.now()
+
+function providerBucket(
+  chainID: string,
+  providerIndex: number,
+): ProviderCounters {
+  let chain = chains.get(chainID)
+  if (!chain) {
+    chain = { providers: new Map() }
+    chains.set(chainID, chain)
+  }
+
+  let provider = chain.providers.get(providerIndex)
+  if (!provider) {
+    provider = freshProviderCounters()
+    chain.providers.set(providerIndex, provider)
+  }
+  return provider
+}
+
+function bucketForDuration(durationMs: number): DurationBucketLabel {
+  // eslint-disable-next-line no-restricted-syntax
+  for (const bound of DURATION_BUCKETS_MS) {
+    if (durationMs <= bound) {
+      return `le_${bound}`
+    }
+  }
+  return "overflow"
+}
+
+export function recordRequestSent(
+  chainID: string,
+  providerIndex: number,
+): void {
+  providerBucket(chainID, providerIndex).requestsSent += 1
+}
+
+export function recordRequestSucceeded(
+  chainID: string,
+  providerIndex: number,
+  durationMs: number,
+): void {
+  const provider = providerBucket(chainID, providerIndex)
+  provider.requestsSucceeded += 1
+  provider.durationHistogramMs[bucketForDuration(durationMs)] += 1
+}
+
+export function recordRequestFailed(
+  chainID: string,
+  providerIndex: number,
+  category: RequestFailureCategory,
+): void {
+  providerBucket(chainID, providerIndex).requestsFailed[category] += 1
+}
+
+export function recordSingleFlightCoalesce(
+  chainID: string,
+  providerIndex: number,
+): void {
+  providerBucket(chainID, providerIndex).singleFlightCoalesces += 1
+}
+
+export function recordReconnectAttempt(
+  chainID: string,
+  providerIndex: number,
+): void {
+  providerBucket(chainID, providerIndex).reconnectAttempts += 1
+}
+
+export function recordReconnectSucceeded(
+  chainID: string,
+  providerIndex: number,
+): void {
+  providerBucket(chainID, providerIndex).reconnectSuccesses += 1
+}
+
+export function recordReconnectFailed(
+  chainID: string,
+  providerIndex: number,
+): void {
+  providerBucket(chainID, providerIndex).reconnectFailures += 1
+}
+
+export type CircuitBreakerState = "closed" | "open" | "half-open"
+
+export function recordCircuitBreakerTransition(
+  chainID: string,
+  providerIndex: number,
+  nextState: CircuitBreakerState,
+): void {
+  const provider = providerBucket(chainID, providerIndex)
+  switch (nextState) {
+    case "open":
+      provider.circuitBreakerOpens += 1
+      break
+    case "half-open":
+      provider.circuitBreakerHalfOpens += 1
+      break
+    case "closed":
+      provider.circuitBreakerCloses += 1
+      break
+    default:
+      break
+  }
+}
+
+/**
+ * Atomically take a snapshot of the current window and reset the counters.
+ * The returned snapshot is safe to serialize and send to analytics; callers
+ * must not mutate it, and subsequent calls to `record*` accumulate into a
+ * fresh window.
+ */
+export function snapshotAndReset(): PerfMetricsSnapshot {
+  const takenAt = Date.now()
+  const snapshot: PerfMetricsSnapshot = {
+    windowStartedAt,
+    takenAt,
+    chains: {},
+  }
+
+  chains.forEach((chain, chainID) => {
+    const providers = Array.from(chain.providers.entries())
+      .sort(([a], [b]) => a - b)
+      .map(([providerIndex, counters]) => ({
+        providerIndex,
+        ...counters,
+      }))
+
+    if (providers.length > 0) {
+      snapshot.chains[chainID] = { providers }
+    }
+  })
+
+  chains = new Map()
+  windowStartedAt = takenAt
+
+  return snapshot
+}
+
+/**
+ * Test-only reset. Production code should call `snapshotAndReset` instead;
+ * resetting without taking the snapshot discards data silently.
+ */
+export function resetForTests(): void {
+  chains = new Map()
+  windowStartedAt = Date.now()
+}

--- a/background/lib/perf-metrics.ts
+++ b/background/lib/perf-metrics.ts
@@ -50,6 +50,75 @@ type ChainCounters = {
   providers: Map<number, ProviderCounters>
 }
 
+/**
+ * Summary of a scalar measurement over the window. Keeping `sum` alongside
+ * `count` lets consumers compute the arithmetic mean without having to send
+ * every data point, and `max` preserves the worst-case outlier that averages
+ * otherwise obscure. Distribution shape is captured separately by a
+ * histogram where relevant.
+ */
+type AggregateStat = {
+  count: number
+  sum: number
+  max: number
+}
+
+function freshAggregateStat(): AggregateStat {
+  return { count: 0, sum: 0, max: 0 }
+}
+
+function freshDurationHistogram(): Record<DurationBucketLabel, number> {
+  const histogram = { overflow: 0 } as Record<DurationBucketLabel, number>
+  DURATION_BUCKETS_MS.forEach((bound) => {
+    histogram[`le_${bound}`] = 0
+  })
+  return histogram
+}
+
+/* eslint-disable no-param-reassign */
+function updateAggregateStat(stat: AggregateStat, value: number): void {
+  stat.count += 1
+  stat.sum += value
+  if (value > stat.max) {
+    stat.max = value
+  }
+}
+/* eslint-enable no-param-reassign */
+
+/**
+ * Counters describing the cost of the redux store's persistence and UI-diff
+ * paths. These are the dominant contributors to the long redux locks
+ * observed under heavy RPC churn, so tracking average and max cost per
+ * window gives a direct signal on whether subsequent work (batching,
+ * keyed-record slices, objectHash, slice-level persistence) is moving the
+ * needle.
+ */
+type ReduxCounters = {
+  persist: {
+    duration: AggregateStat
+    bytes: AggregateStat
+    durationHistogramMs: Record<DurationBucketLabel, number>
+  }
+  diff: {
+    duration: AggregateStat
+    durationHistogramMs: Record<DurationBucketLabel, number>
+  }
+}
+
+function freshReduxCounters(): ReduxCounters {
+  return {
+    persist: {
+      duration: freshAggregateStat(),
+      bytes: freshAggregateStat(),
+      durationHistogramMs: freshDurationHistogram(),
+    },
+    diff: {
+      duration: freshAggregateStat(),
+      durationHistogramMs: freshDurationHistogram(),
+    },
+  }
+}
+
 export type PerfMetricsSnapshot = {
   windowStartedAt: number
   takenAt: number
@@ -65,6 +134,12 @@ export type PerfMetricsSnapshot = {
       >
     }
   >
+  /**
+   * Only present when at least one redux persist or diff observation was
+   * recorded in the window; empty redux windows are omitted so the analytics
+   * flush does not emit noise for idle sessions.
+   */
+  redux?: ReduxCounters
 }
 
 function freshFailureCounters(): Record<RequestFailureCategory, number> {
@@ -78,14 +153,6 @@ function freshFailureCounters(): Record<RequestFailureCategory, number> {
     "unknown-error": 0,
     aborted: 0,
   }
-}
-
-function freshDurationHistogram(): Record<DurationBucketLabel, number> {
-  const histogram = { overflow: 0 } as Record<DurationBucketLabel, number>
-  DURATION_BUCKETS_MS.forEach((bound) => {
-    histogram[`le_${bound}`] = 0
-  })
-  return histogram
 }
 
 function freshProviderCounters(): ProviderCounters {
@@ -105,7 +172,12 @@ function freshProviderCounters(): ProviderCounters {
 }
 
 let chains: Map<string, ChainCounters> = new Map()
+let redux: ReduxCounters = freshReduxCounters()
 let windowStartedAt: number = Date.now()
+
+function reduxHasObservations(counters: ReduxCounters): boolean {
+  return counters.persist.duration.count > 0 || counters.diff.duration.count > 0
+}
 
 function providerBucket(
   chainID: string,
@@ -188,6 +260,27 @@ export function recordReconnectFailed(
   providerBucket(chainID, providerIndex).reconnectFailures += 1
 }
 
+/**
+ * Record a completed redux persist pass (`encodeJSON(state)` plus the write
+ * to `browser.storage.local`). `bytes` is the length of the serialized
+ * payload; it is accumulated alongside duration so consumers can correlate
+ * state size with persist cost.
+ */
+export function recordReduxPersist(durationMs: number, bytes: number): void {
+  updateAggregateStat(redux.persist.duration, durationMs)
+  updateAggregateStat(redux.persist.bytes, bytes)
+  redux.persist.durationHistogramMs[bucketForDuration(durationMs)] += 1
+}
+
+/**
+ * Record a completed redux diff pass (the call that produces the delta sent
+ * to the UI proxy store).
+ */
+export function recordReduxDiff(durationMs: number): void {
+  updateAggregateStat(redux.diff.duration, durationMs)
+  redux.diff.durationHistogramMs[bucketForDuration(durationMs)] += 1
+}
+
 export type CircuitBreakerState = "closed" | "open" | "half-open"
 
 export function recordCircuitBreakerTransition(
@@ -238,7 +331,12 @@ export function snapshotAndReset(): PerfMetricsSnapshot {
     }
   })
 
+  if (reduxHasObservations(redux)) {
+    snapshot.redux = redux
+  }
+
   chains = new Map()
+  redux = freshReduxCounters()
   windowStartedAt = takenAt
 
   return snapshot
@@ -250,5 +348,6 @@ export function snapshotAndReset(): PerfMetricsSnapshot {
  */
 export function resetForTests(): void {
   chains = new Map()
+  redux = freshReduxCounters()
   windowStartedAt = Date.now()
 }

--- a/background/lib/posthog.ts
+++ b/background/lib/posthog.ts
@@ -20,6 +20,9 @@ export enum AnalyticsEvent {
   CAMPAIGN_MEZO_NFT_ELIGIBLE_BANNER = "in_wallet-claim_sats",
   CAMPAIGN_MEZO_NFT_BORROW_BANNER = "in_wallet-borrow_musd",
   CAMPAIGN_MEZO_NFT_CLAIM_NFT_BANNER = "in_wallet-visit_store",
+  // Aggregate performance counters flushed periodically from the chain
+  // provider layer. Payload shape is defined by PerfMetricsSnapshot.
+  PERF_METRICS_FLUSH = "Performance Metrics Flush",
 }
 
 export enum OneTimeAnalyticsEvent {

--- a/background/lib/tests/perf-metrics.unit.test.ts
+++ b/background/lib/tests/perf-metrics.unit.test.ts
@@ -3,6 +3,8 @@ import {
   recordReconnectAttempt,
   recordReconnectFailed,
   recordReconnectSucceeded,
+  recordReduxDiff,
+  recordReduxPersist,
   recordRequestFailed,
   recordRequestSent,
   recordRequestSucceeded,
@@ -90,5 +92,46 @@ describe("perf-metrics", () => {
     expect(snapshot.chains["1"].providers.map((p) => p.providerIndex)).toEqual([
       0, 1, 2,
     ])
+  })
+
+  describe("redux counters", () => {
+    it("omits the redux key entirely when no observations have been recorded", () => {
+      const snapshot = snapshotAndReset()
+      expect(snapshot.redux).toBeUndefined()
+    })
+
+    it("aggregates persist duration and bytes with running count, sum, and max", () => {
+      recordReduxPersist(40, 1_000)
+      recordReduxPersist(120, 2_000)
+      recordReduxPersist(60, 3_500)
+
+      const snapshot = snapshotAndReset()
+      const { persist } = snapshot.redux!
+      expect(persist.duration).toEqual({ count: 3, sum: 220, max: 120 })
+      expect(persist.bytes).toEqual({ count: 3, sum: 6_500, max: 3_500 })
+      expect(persist.durationHistogramMs.le_50).toBe(1)
+      expect(persist.durationHistogramMs.le_200).toBe(2)
+    })
+
+    it("aggregates diff durations independently of persist", () => {
+      recordReduxDiff(15)
+      recordReduxDiff(300)
+
+      const snapshot = snapshotAndReset()
+      expect(snapshot.redux!.diff.duration).toEqual({
+        count: 2,
+        sum: 315,
+        max: 300,
+      })
+      expect(snapshot.redux!.persist.duration.count).toBe(0)
+    })
+
+    it("resets redux counters after a snapshot", () => {
+      recordReduxPersist(10, 100)
+      recordReduxDiff(5)
+      snapshotAndReset()
+      const second = snapshotAndReset()
+      expect(second.redux).toBeUndefined()
+    })
   })
 })

--- a/background/lib/tests/perf-metrics.unit.test.ts
+++ b/background/lib/tests/perf-metrics.unit.test.ts
@@ -1,0 +1,94 @@
+import {
+  recordCircuitBreakerTransition,
+  recordReconnectAttempt,
+  recordReconnectFailed,
+  recordReconnectSucceeded,
+  recordRequestFailed,
+  recordRequestSent,
+  recordRequestSucceeded,
+  recordSingleFlightCoalesce,
+  resetForTests,
+  snapshotAndReset,
+} from "../perf-metrics"
+
+describe("perf-metrics", () => {
+  beforeEach(() => {
+    resetForTests()
+  })
+
+  it("returns an empty snapshot when no events have been recorded", () => {
+    const snapshot = snapshotAndReset()
+    expect(snapshot.chains).toEqual({})
+  })
+
+  it("aggregates counters per chain and per provider index", () => {
+    recordRequestSent("1", 0)
+    recordRequestSent("1", 0)
+    recordRequestSent("1", 1)
+    recordRequestSent("10", 0)
+
+    recordRequestSucceeded("1", 0, 30)
+    recordRequestSucceeded("1", 0, 300)
+    recordRequestFailed("1", 1, "rate-limit-error")
+    recordSingleFlightCoalesce("1", 0)
+    recordReconnectAttempt("1", 1)
+    recordReconnectSucceeded("1", 1)
+    recordReconnectFailed("1", 1)
+    recordCircuitBreakerTransition("1", 1, "open")
+    recordCircuitBreakerTransition("1", 1, "half-open")
+    recordCircuitBreakerTransition("1", 1, "closed")
+
+    const snapshot = snapshotAndReset()
+
+    expect(Object.keys(snapshot.chains).sort()).toEqual(["1", "10"])
+    const ethProviders = snapshot.chains["1"].providers
+    const primary = ethProviders.find((p) => p.providerIndex === 0)!
+    const secondary = ethProviders.find((p) => p.providerIndex === 1)!
+
+    expect(primary.requestsSent).toBe(2)
+    expect(primary.requestsSucceeded).toBe(2)
+    expect(primary.singleFlightCoalesces).toBe(1)
+    // 30ms falls into le_50, 300ms into le_500
+    expect(primary.durationHistogramMs.le_50).toBe(1)
+    expect(primary.durationHistogramMs.le_500).toBe(1)
+
+    expect(secondary.requestsSent).toBe(1)
+    expect(secondary.requestsFailed["rate-limit-error"]).toBe(1)
+    expect(secondary.reconnectAttempts).toBe(1)
+    expect(secondary.reconnectSuccesses).toBe(1)
+    expect(secondary.reconnectFailures).toBe(1)
+    expect(secondary.circuitBreakerOpens).toBe(1)
+    expect(secondary.circuitBreakerHalfOpens).toBe(1)
+    expect(secondary.circuitBreakerCloses).toBe(1)
+  })
+
+  it("places durations larger than the largest bucket in overflow", () => {
+    recordRequestSent("1", 0)
+    recordRequestSucceeded("1", 0, 30_000)
+
+    const snapshot = snapshotAndReset()
+    const primary = snapshot.chains["1"].providers[0]
+    expect(primary.durationHistogramMs.overflow).toBe(1)
+  })
+
+  it("resets counters after snapshot so the next window starts clean", () => {
+    recordRequestSent("1", 0)
+    const first = snapshotAndReset()
+    expect(first.chains["1"].providers[0].requestsSent).toBe(1)
+
+    const second = snapshotAndReset()
+    expect(second.chains).toEqual({})
+    expect(second.windowStartedAt).toBeGreaterThanOrEqual(first.takenAt)
+  })
+
+  it("sorts providers by index within a chain", () => {
+    recordRequestSent("1", 2)
+    recordRequestSent("1", 0)
+    recordRequestSent("1", 1)
+
+    const snapshot = snapshotAndReset()
+    expect(snapshot.chains["1"].providers.map((p) => p.providerIndex)).toEqual([
+      0, 1, 2,
+    ])
+  })
+})

--- a/background/services/analytics/index.ts
+++ b/background/services/analytics/index.ts
@@ -20,6 +20,12 @@ import SigningService, {
 } from "../signing"
 import InternalSignerService from "../internal-signer"
 import { assertUnreachable } from "../../lib/utils/type-guards"
+import { snapshotAndReset } from "../../lib/perf-metrics"
+
+// Perf metrics are aggregated in memory and flushed at a cadence long enough
+// that a typical wallet session contributes at most a handful of events,
+// but short enough to produce multiple samples per day for active users.
+const PERF_METRICS_FLUSH_INTERVAL_MINUTES = 180
 
 const chainSpecificOneTimeEvents = [OneTimeAnalyticsEvent.CHAIN_ADDED]
 interface Events extends ServiceLifecycleEvents {
@@ -62,7 +68,14 @@ export default class AnalyticsService extends BaseService<Events> {
     private signingService: SigningService,
     private preferenceService: PreferenceService,
   ) {
-    super()
+    super({
+      flushPerfMetrics: {
+        schedule: { periodInMinutes: PERF_METRICS_FLUSH_INTERVAL_MINUTES },
+        handler: () => {
+          this.flushPerfMetrics()
+        },
+      },
+    })
 
     this.internalSignerService.emitter.on(
       "vaultMigrationCompleted",
@@ -192,6 +205,31 @@ export default class AnalyticsService extends BaseService<Events> {
 
     sendPosthogEvent(uuid, eventName, payload)
     this.db.setOneTimeEvent(key)
+  }
+
+  /**
+   * Drains the in-memory perf metrics collector and, if the snapshot contains
+   * any observations and analytics are enabled, emits it as a single event.
+   *
+   * Kept best-effort: failing to flush should never interfere with the rest
+   * of the service, since the next interval will pick up a fresh window.
+   */
+  private async flushPerfMetrics(): Promise<void> {
+    try {
+      const snapshot = snapshotAndReset()
+      if (Object.keys(snapshot.chains).length === 0) {
+        return
+      }
+
+      await this.sendAnalyticsEvent(AnalyticsEvent.PERF_METRICS_FLUSH, {
+        windowStartedAt: snapshot.windowStartedAt,
+        takenAt: snapshot.takenAt,
+        windowDurationMs: snapshot.takenAt - snapshot.windowStartedAt,
+        chains: snapshot.chains,
+      })
+    } catch (error) {
+      logger.debug("Perf metrics flush failed: ", error)
+    }
   }
 
   async removeAnalyticsData(): Promise<void> {

--- a/background/services/analytics/tests/index.integration.test.ts
+++ b/background/services/analytics/tests/index.integration.test.ts
@@ -11,6 +11,11 @@ import AnalyticsService from ".."
 import { createAnalyticsService } from "../../../tests/factories"
 import PreferenceService from "../../preferences"
 import * as posthog from "../../../lib/posthog"
+import {
+  recordRequestSent,
+  recordRequestSucceeded,
+  resetForTests as resetPerfMetricsForTests,
+} from "../../../lib/perf-metrics"
 
 const { AnalyticsEvent } = posthog
 
@@ -171,6 +176,64 @@ describe("AnalyticsService", () => {
 
       expect(posthog.sendPosthogEvent).not.toBeCalled()
       expect(fetch).not.toBeCalled()
+    })
+  })
+
+  describe("perf metrics flush", () => {
+    beforeEach(async () => {
+      resetPerfMetricsForTests()
+      jest.spyOn(analyticsService, "sendAnalyticsEvent")
+      jest
+        .spyOn(preferenceService, "getAnalyticsPreferences")
+        .mockImplementation(() =>
+          Promise.resolve({
+            isEnabled: true,
+            hasDefaultOnBeenTurnedOn: true,
+          }),
+        )
+
+      await analyticsService["getOrCreateAnalyticsUUID"]()
+    })
+
+    it("does not emit when the counter window is empty", async () => {
+      await analyticsService["flushPerfMetrics"]()
+      expect(analyticsService.sendAnalyticsEvent).not.toHaveBeenCalled()
+    })
+
+    it("emits a single flush event with a windowed snapshot", async () => {
+      recordRequestSent("1", 0)
+      recordRequestSucceeded("1", 0, 120)
+
+      await analyticsService["flushPerfMetrics"]()
+
+      expect(analyticsService.sendAnalyticsEvent).toHaveBeenCalledTimes(1)
+      const [eventName, payload] = (
+        analyticsService.sendAnalyticsEvent as jest.Mock
+      ).mock.calls[0]
+      expect(eventName).toBe(AnalyticsEvent.PERF_METRICS_FLUSH)
+      expect(payload).toMatchObject({
+        chains: {
+          "1": {
+            providers: [
+              expect.objectContaining({
+                providerIndex: 0,
+                requestsSent: 1,
+                requestsSucceeded: 1,
+              }),
+            ],
+          },
+        },
+      })
+      expect(payload.windowDurationMs).toBeGreaterThanOrEqual(0)
+    })
+
+    it("resets counters after a flush so the next window starts clean", async () => {
+      recordRequestSent("1", 0)
+      await analyticsService["flushPerfMetrics"]()
+      ;(analyticsService.sendAnalyticsEvent as jest.Mock).mockClear()
+
+      await analyticsService["flushPerfMetrics"]()
+      expect(analyticsService.sendAnalyticsEvent).not.toHaveBeenCalled()
     })
   })
 })

--- a/background/services/chain/circuit-breaker.ts
+++ b/background/services/chain/circuit-breaker.ts
@@ -1,0 +1,177 @@
+/**
+ * Per-provider circuit breaker used by {@link SerialFallbackProvider} to
+ * suppress traffic toward a provider that is already known to be failing.
+ *
+ * Motivation: when an upstream RPC rate-limits or goes down, the existing
+ * retry/failover logic still issues a fresh request on every send, each
+ * one racing through its own backoff walk before eventually concluding
+ * the provider is bad. Multiplied across concurrent callers and across
+ * tracked networks, this produces a herd that keeps the failing
+ * provider's condition from recovering and keeps the extension busy
+ * retrying work that is guaranteed to fail.
+ *
+ * A circuit breaker replaces that per-call rediscovery with a single
+ * piece of shared state. A run of failures trips it open; while open,
+ * callers skip the provider outright and fall back. After a cooldown it
+ * goes half-open, allowing exactly one probe through. The probe's result
+ * either closes the breaker (recovery) or re-opens it with a longer
+ * cooldown (still down).
+ *
+ * State is held entirely in memory. Service worker restarts reset the
+ * breaker, which is acceptable: the breaker's purpose is to dampen
+ * short-term herd behavior, not to preserve outage history across
+ * lifetimes.
+ */
+
+export type CircuitBreakerState = "closed" | "open" | "half-open"
+
+export type CircuitBreakerOptions = {
+  /** Number of failures within the rolling window that trips the breaker. */
+  failureThreshold: number
+  /** Width of the rolling failure window in milliseconds. */
+  failureWindowMs: number
+  /** Cooldown applied the first time the breaker opens. */
+  initialCooldownMs: number
+  /** Upper bound for cooldowns after repeated re-opens. */
+  maxCooldownMs: number
+  /** Multiplier applied to the cooldown on each re-open. */
+  cooldownBackoffMultiplier: number
+}
+
+export const DEFAULT_CIRCUIT_BREAKER_OPTIONS: CircuitBreakerOptions = {
+  failureThreshold: 5,
+  failureWindowMs: 30_000,
+  initialCooldownMs: 15_000,
+  maxCooldownMs: 2 * 60_000,
+  cooldownBackoffMultiplier: 2,
+}
+
+/**
+ * Callback invoked when the breaker transitions between states. Useful for
+ * emitting analytics counters without coupling the breaker itself to the
+ * perf-metrics module.
+ */
+export type CircuitBreakerListener = (next: CircuitBreakerState) => void
+
+export class CircuitBreaker {
+  private state: CircuitBreakerState = "closed"
+
+  private failureTimestamps: number[] = []
+
+  private openedAt = 0
+
+  private currentCooldownMs: number
+
+  private probeInFlight = false
+
+  private readonly options: CircuitBreakerOptions
+
+  constructor(
+    options: Partial<CircuitBreakerOptions> = {},
+    private readonly onTransition?: CircuitBreakerListener,
+    private readonly now: () => number = Date.now,
+  ) {
+    this.options = { ...DEFAULT_CIRCUIT_BREAKER_OPTIONS, ...options }
+    this.currentCooldownMs = this.options.initialCooldownMs
+  }
+
+  /**
+   * Returns the observable state. In `"open"` and `"half-open"`, pending
+   * cooldown transitions may be driven by calling {@link canRequest}.
+   */
+  getState(): CircuitBreakerState {
+    return this.state
+  }
+
+  /**
+   * Decide whether a request may proceed to the underlying provider.
+   *
+   * - `closed`: always allow.
+   * - `open`: allow only if the cooldown has elapsed, transitioning to
+   *   half-open in that case.
+   * - `half-open`: allow exactly one probe at a time; concurrent callers
+   *   receive `false` so they fall back instead of piling onto the probe.
+   */
+  canRequest(): boolean {
+    if (this.state === "closed") {
+      return true
+    }
+
+    if (this.state === "open") {
+      if (this.now() - this.openedAt < this.currentCooldownMs) {
+        return false
+      }
+      this.transitionTo("half-open")
+    }
+
+    if (this.state === "half-open") {
+      if (this.probeInFlight) {
+        return false
+      }
+      this.probeInFlight = true
+      return true
+    }
+
+    return false
+  }
+
+  /**
+   * Record a successful request. Resets the failure window; in `half-open`
+   * closes the breaker and resets the cooldown back to its initial value.
+   */
+  recordSuccess(): void {
+    this.failureTimestamps = []
+    if (this.state === "half-open") {
+      this.probeInFlight = false
+      this.currentCooldownMs = this.options.initialCooldownMs
+      this.transitionTo("closed")
+    }
+  }
+
+  /**
+   * Record a failed request. In `closed`, trips the breaker if the failure
+   * threshold has been crossed within the rolling window. In `half-open`,
+   * re-opens the breaker with a longer cooldown.
+   */
+  recordFailure(): void {
+    const now = this.now()
+
+    if (this.state === "half-open") {
+      this.probeInFlight = false
+      this.currentCooldownMs = Math.min(
+        this.currentCooldownMs * this.options.cooldownBackoffMultiplier,
+        this.options.maxCooldownMs,
+      )
+      this.openedAt = now
+      this.transitionTo("open")
+      return
+    }
+
+    if (this.state === "open") {
+      // Treat stray failures during open as noise; they don't extend the
+      // cooldown beyond what a failed probe would.
+      return
+    }
+
+    this.failureTimestamps.push(now)
+    const windowStart = now - this.options.failureWindowMs
+    this.failureTimestamps = this.failureTimestamps.filter(
+      (t) => t >= windowStart,
+    )
+
+    if (this.failureTimestamps.length >= this.options.failureThreshold) {
+      this.currentCooldownMs = this.options.initialCooldownMs
+      this.openedAt = now
+      this.failureTimestamps = []
+      this.transitionTo("open")
+    }
+  }
+
+  private transitionTo(next: CircuitBreakerState) {
+    if (this.state === next) {
+      return
+    }
+    this.state = next
+    this.onTransition?.(next)
+  }
+}

--- a/background/services/chain/serial-fallback-provider.ts
+++ b/background/services/chain/serial-fallback-provider.ts
@@ -29,6 +29,7 @@ import TahoAlchemyProvider from "./taho-provider"
 import { getErrorType } from "./errors"
 import TahoRPCProvider from "./taho-rpc-provider"
 import {
+  recordCircuitBreakerTransition,
   recordReconnectAttempt,
   recordReconnectFailed,
   recordReconnectSucceeded,
@@ -38,6 +39,7 @@ import {
   recordSingleFlightCoalesce,
   RequestFailureCategory,
 } from "../../lib/perf-metrics"
+import { CircuitBreaker } from "./circuit-breaker"
 
 export type ProviderCreator = {
   type: "alchemy" | "custom" | "generic"
@@ -332,6 +334,14 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
    */
   #inFlightRequests = new Map<string, Promise<unknown>>()
 
+  /**
+   * One circuit breaker per provider index, created lazily. Protects each
+   * provider from being retried into the ground while it is known to be
+   * failing, and suppresses the periodic primary-recovery attempt while the
+   * primary breaker is open.
+   */
+  #circuitBreakers = new Map<number, CircuitBreaker>()
+
   #cacheSettings = new Map<string, number>(
     Object.entries({
       // TEMPORARY cache for latest account balances to reduce number of rpc calls
@@ -503,7 +513,33 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
         return result
       }
 
-      const result = await this.currentProvider.send(method, params)
+      const breaker = this.breakerFor(this.currentProviderIndex)
+      if (!breaker.canRequest()) {
+        // The current provider is known-bad. Skip straight to the existing
+        // fallback path so we do not issue a request guaranteed to fail and
+        // do not pile onto whatever outage it is sitting out.
+        if (this.currentProviderIndex + 1 < this.providerCreators.length) {
+          return await this.attemptToSendMessageOnNewProvider(messageId)
+        }
+        // No more providers to try this cycle; reset and fail as we would
+        // on an exhausted chain.
+        this.currentProviderIndex = 0
+        this.reconnectProvider()
+        delete this.messagesToSend[messageId]
+        throw new Error("NETWORK_ERROR: circuit open and no fallback available")
+      }
+
+      let result: unknown
+      try {
+        result = await this.currentProvider.send(method, params)
+      } catch (error) {
+        // Any thrown error here represents the breaker's view of a failure;
+        // feeding it into the breaker keeps state machines aligned with the
+        // behavior observed by the existing error-classification path below.
+        breaker.recordFailure()
+        throw error
+      }
+      breaker.recordSuccess()
       // If https://github.com/tc39/proposal-decorators ever gets out of Stage 3
       // cleaning up the messageToSend object seems like a great job for a decorator
       delete this.messagesToSend[messageId]
@@ -651,6 +687,23 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
       delete this.messagesToSend[messageId]
       throw error
     }
+  }
+
+  /**
+   * Returns the circuit breaker for a given provider index, creating it the
+   * first time it is requested. Each breaker wires its transitions into the
+   * perf metrics collector so analytics can track how often providers go down
+   * and how quickly they recover.
+   */
+  private breakerFor(providerIndex: number): CircuitBreaker {
+    let breaker = this.#circuitBreakers.get(providerIndex)
+    if (!breaker) {
+      breaker = new CircuitBreaker({}, (next) =>
+        recordCircuitBreakerTransition(this.chainID, providerIndex, next),
+      )
+      this.#circuitBreakers.set(providerIndex, breaker)
+    }
+    return breaker
   }
 
   addCustomProvider(customProviderCreator: ProviderCreator): void {
@@ -1171,6 +1224,11 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
   private async attemptToReconnectToPrimaryProvider(): Promise<unknown> {
     if (this.currentProviderIndex === 0) {
       // If we are already connected to the primary provider - don't resubscribe
+      return null
+    }
+    if (!this.breakerFor(0).canRequest()) {
+      // Primary is still in cooldown; skip this cycle so the reconnect loop
+      // does not itself become a source of request pressure on a down endpoint.
       return null
     }
     recordReconnectAttempt(this.chainID, 0)

--- a/background/services/chain/serial-fallback-provider.ts
+++ b/background/services/chain/serial-fallback-provider.ts
@@ -28,6 +28,15 @@ import { RpcConfig } from "./db"
 import TahoAlchemyProvider from "./taho-provider"
 import { getErrorType } from "./errors"
 import TahoRPCProvider from "./taho-rpc-provider"
+import {
+  recordReconnectAttempt,
+  recordReconnectFailed,
+  recordReconnectSucceeded,
+  recordRequestFailed,
+  recordRequestSent,
+  recordRequestSucceeded,
+  RequestFailureCategory,
+} from "../../lib/perf-metrics"
 
 export type ProviderCreator = {
   type: "alchemy" | "custom" | "generic"
@@ -143,6 +152,18 @@ type CacheEntry = {
  */
 function backedOffMs(): number {
   return BASE_BACKOFF_MS + 400 * Math.random()
+}
+
+/**
+ * Normalize an arbitrary error thrown during RPC routing into one of the
+ * categories tracked by the perf metrics collector. Unrecognized errors map
+ * to `"unknown-error"`; this stays in sync with {@link getErrorType}.
+ */
+function categorizeError(
+  error: unknown,
+  method: string,
+): RequestFailureCategory {
+  return getErrorType(String(error), method)
 }
 
 /**
@@ -730,13 +751,34 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
       providerIndex: this.currentProviderIndex,
     }
 
-    // Start routing message down our waterfall of rpc providers
-    const result = await this.routeRpcCall(id)
+    const startingProviderIndex = this.currentProviderIndex
+    recordRequestSent(this.chainID, startingProviderIndex)
+    const startTime = Date.now()
 
-    // Cache results for method/param combinations that are frequently called subsequently
-    this.conditionallyCacheResult(result, { method, params })
+    try {
+      // Start routing message down our waterfall of rpc providers
+      const result = await this.routeRpcCall(id)
 
-    return result
+      // Record against the provider that actually served the request, which
+      // may differ from the starting index if we failed over.
+      recordRequestSucceeded(
+        this.chainID,
+        this.currentProviderIndex,
+        Date.now() - startTime,
+      )
+
+      // Cache results for method/param combinations that are frequently called subsequently
+      this.conditionallyCacheResult(result, { method, params })
+
+      return result
+    } catch (error) {
+      recordRequestFailed(
+        this.chainID,
+        this.currentProviderIndex,
+        categorizeError(error, method),
+      )
+      throw error
+    }
   }
 
   /**
@@ -962,6 +1004,8 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
       this.currentProviderIndex = 0
     }
 
+    recordReconnectAttempt(this.chainID, this.currentProviderIndex)
+
     logger.debug(
       "Reconnecting provider at index",
       this.currentProviderIndex,
@@ -978,7 +1022,12 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
 
     this.currentProvider = cachedProvider
 
-    await this.resubscribe(this.currentProvider)
+    const resubscribed = await this.resubscribe(this.currentProvider)
+    if (resubscribed) {
+      recordReconnectSucceeded(this.chainID, this.currentProviderIndex)
+    } else {
+      recordReconnectFailed(this.chainID, this.currentProviderIndex)
+    }
 
     // TODO After a longer backoff, attempt to reset the current provider to 0.
   }
@@ -1052,6 +1101,7 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
       // If we are already connected to the primary provider - don't resubscribe
       return null
     }
+    recordReconnectAttempt(this.chainID, 0)
     const primaryProvider = this.providerCreators[0]()
     // We need to wait before attempting to resubscribe of the primaryProvider's
     // websocket connection will almost always still be in a CONNECTING state when
@@ -1059,6 +1109,7 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
     return waitAnd(WAIT_BEFORE_SUBSCRIBING, async (): Promise<unknown> => {
       const subscriptionsSuccessful = await this.resubscribe(primaryProvider)
       if (!subscriptionsSuccessful) {
+        recordReconnectFailed(this.chainID, 0)
         return
       }
       // Cleanup the subscriptions on the backup provider.
@@ -1066,6 +1117,7 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
       // only set if subscriptions are successful
       this.currentProvider = primaryProvider
       this.currentProviderIndex = 0
+      recordReconnectSucceeded(this.chainID, 0)
     })
   }
 

--- a/background/services/chain/serial-fallback-provider.ts
+++ b/background/services/chain/serial-fallback-provider.ts
@@ -35,6 +35,7 @@ import {
   recordRequestFailed,
   recordRequestSent,
   recordRequestSucceeded,
+  recordSingleFlightCoalesce,
   RequestFailureCategory,
 } from "../../lib/perf-metrics"
 
@@ -73,6 +74,28 @@ export const ALCHEMY_RPC_METHOD_PROVIDER_ROUTING = {
     "eth_call", // this is causing issues on arbitrum with ankr and is used heavily by uniswap
   ],
 } as const
+/**
+ * Methods that must never be coalesced into a shared in-flight request.
+ *
+ * Subscription lifecycle methods produce per-call state (subscription ids)
+ * that cannot be shared between callers. Signing and broadcasting methods
+ * either have side effects or must produce an independent response per call
+ * to support user-visible confirmation flows.
+ */
+const NON_COALESCEABLE_METHODS = new Set([
+  "eth_subscribe",
+  "eth_unsubscribe",
+  "eth_sendTransaction",
+  "eth_sendRawTransaction",
+  "eth_sign",
+  "eth_signTransaction",
+  "eth_signTypedData",
+  "eth_signTypedData_v1",
+  "eth_signTypedData_v3",
+  "eth_signTypedData_v4",
+  "personal_sign",
+])
+
 // Back off by this amount as a base, exponentiated by attempts and jittered.
 const BASE_BACKOFF_MS = 400
 // Retry 3 times before falling back to the next provider.
@@ -297,6 +320,17 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
     {}
 
   #sendCache = new Map<string, CacheEntry>()
+
+  /**
+   * Promises for RPC requests that are currently in flight, keyed by a
+   * canonical method+params signature. New callers issuing the same request
+   * while one is still outstanding receive the in-flight promise rather than
+   * initiating a second provider call.
+   *
+   * Only methods that are safe to share (not signing, not broadcasting, not
+   * subscription lifecycle) are stored here; see {@link NON_COALESCEABLE_METHODS}.
+   */
+  #inFlightRequests = new Map<string, Promise<unknown>>()
 
   #cacheSettings = new Map<string, number>(
     Object.entries({
@@ -742,6 +776,44 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
       return this.cachedChainId
     }
 
+    // Coalesce concurrent identical requests into a single in-flight call.
+    // This is safe for idempotent reads and explicitly skipped for subscription
+    // lifecycle and side-effecting (signing / broadcast) methods so those always
+    // produce an independent provider call per invocation.
+    if (!NON_COALESCEABLE_METHODS.has(method)) {
+      const key = getRPCCacheKey(method, params)
+      const existing = this.#inFlightRequests.get(key)
+      if (existing !== undefined) {
+        recordSingleFlightCoalesce(this.chainID, this.currentProviderIndex)
+        return existing
+      }
+
+      const flight = this.dispatchRequest(method, params)
+      this.#inFlightRequests.set(key, flight)
+      // Clear the slot on both success and failure so the next caller makes
+      // a fresh request. Use `then(cleanup, cleanup)` rather than `finally`
+      // so a rejection does not escape as an unhandled promise on the
+      // cleanup chain; callers still observe the rejection on `flight`.
+      const cleanup = () => {
+        this.#inFlightRequests.delete(key)
+      }
+      flight.then(cleanup, cleanup)
+      return flight
+    }
+
+    return this.dispatchRequest(method, params)
+  }
+
+  /**
+   * Executes a single logical RPC request end-to-end, including metrics and
+   * result caching. Callers must never invoke this directly for coalesceable
+   * methods; {@link send} is responsible for single-flight deduplication
+   * before handing off here.
+   */
+  private async dispatchRequest(
+    method: string,
+    params: unknown[],
+  ): Promise<unknown> {
     // Generate a unique symbol to track the message and store message information
     const id = Symbol(method)
     this.messagesToSend[id] = {

--- a/background/services/chain/tests/circuit-breaker.unit.test.ts
+++ b/background/services/chain/tests/circuit-breaker.unit.test.ts
@@ -1,0 +1,193 @@
+import { CircuitBreaker, CircuitBreakerState } from "../circuit-breaker"
+
+describe("CircuitBreaker", () => {
+  let currentTime: number
+  const now = () => currentTime
+  const advance = (ms: number) => {
+    currentTime += ms
+  }
+
+  beforeEach(() => {
+    currentTime = 1_000_000
+  })
+
+  it("starts closed and allows requests through", () => {
+    const breaker = new CircuitBreaker({}, undefined, now)
+    expect(breaker.getState()).toBe("closed")
+    expect(breaker.canRequest()).toBe(true)
+    expect(breaker.canRequest()).toBe(true)
+  })
+
+  it("trips open when the failure threshold is reached within the window", () => {
+    const transitions: CircuitBreakerState[] = []
+    const breaker = new CircuitBreaker(
+      { failureThreshold: 3, failureWindowMs: 1_000 },
+      (next) => transitions.push(next),
+      now,
+    )
+
+    breaker.recordFailure()
+    breaker.recordFailure()
+    expect(breaker.getState()).toBe("closed")
+    breaker.recordFailure()
+
+    expect(breaker.getState()).toBe("open")
+    expect(breaker.canRequest()).toBe(false)
+    expect(transitions).toEqual(["open"])
+  })
+
+  it("does not trip open when failures fall outside the rolling window", () => {
+    const breaker = new CircuitBreaker(
+      { failureThreshold: 3, failureWindowMs: 1_000 },
+      undefined,
+      now,
+    )
+
+    breaker.recordFailure()
+    advance(2_000)
+    breaker.recordFailure()
+    advance(2_000)
+    breaker.recordFailure()
+
+    expect(breaker.getState()).toBe("closed")
+  })
+
+  it("transitions to half-open and allows exactly one probe after cooldown", () => {
+    const transitions: CircuitBreakerState[] = []
+    const breaker = new CircuitBreaker(
+      {
+        failureThreshold: 1,
+        failureWindowMs: 1_000,
+        initialCooldownMs: 500,
+      },
+      (next) => transitions.push(next),
+      now,
+    )
+
+    breaker.recordFailure()
+    expect(breaker.getState()).toBe("open")
+    expect(breaker.canRequest()).toBe(false)
+
+    advance(500)
+    // First canRequest after cooldown elapses transitions to half-open and
+    // releases the probe.
+    expect(breaker.canRequest()).toBe(true)
+    expect(breaker.getState()).toBe("half-open")
+    // A second caller while the probe is in-flight is rejected.
+    expect(breaker.canRequest()).toBe(false)
+    expect(transitions).toEqual(["open", "half-open"])
+  })
+
+  it("closes on a successful half-open probe and resets cooldown", () => {
+    const transitions: CircuitBreakerState[] = []
+    const breaker = new CircuitBreaker(
+      {
+        failureThreshold: 1,
+        failureWindowMs: 1_000,
+        initialCooldownMs: 500,
+        maxCooldownMs: 10_000,
+        cooldownBackoffMultiplier: 2,
+      },
+      (next) => transitions.push(next),
+      now,
+    )
+
+    breaker.recordFailure()
+    advance(500)
+    expect(breaker.canRequest()).toBe(true)
+    breaker.recordSuccess()
+
+    expect(breaker.getState()).toBe("closed")
+    expect(breaker.canRequest()).toBe(true)
+    expect(transitions).toEqual(["open", "half-open", "closed"])
+  })
+
+  it("re-opens with a longer cooldown when the probe fails", () => {
+    const transitions: CircuitBreakerState[] = []
+    const breaker = new CircuitBreaker(
+      {
+        failureThreshold: 1,
+        failureWindowMs: 1_000,
+        initialCooldownMs: 500,
+        maxCooldownMs: 10_000,
+        cooldownBackoffMultiplier: 2,
+      },
+      (next) => transitions.push(next),
+      now,
+    )
+
+    breaker.recordFailure()
+    advance(500)
+    expect(breaker.canRequest()).toBe(true)
+    breaker.recordFailure()
+
+    // Should now be open again, with doubled cooldown (1_000 ms).
+    expect(breaker.getState()).toBe("open")
+    advance(500)
+    expect(breaker.canRequest()).toBe(false)
+    advance(500)
+    expect(breaker.canRequest()).toBe(true)
+
+    expect(transitions).toEqual(["open", "half-open", "open", "half-open"])
+  })
+
+  it("caps exponential cooldown at maxCooldownMs", () => {
+    const breaker = new CircuitBreaker(
+      {
+        failureThreshold: 1,
+        failureWindowMs: 1_000,
+        initialCooldownMs: 1_000,
+        maxCooldownMs: 2_000,
+        cooldownBackoffMultiplier: 10,
+      },
+      undefined,
+      now,
+    )
+
+    breaker.recordFailure()
+    advance(1_000)
+    breaker.canRequest()
+    breaker.recordFailure()
+
+    // Cooldown would be 10x (= 10_000) but is capped at 2_000.
+    advance(1_999)
+    expect(breaker.canRequest()).toBe(false)
+    advance(1)
+    expect(breaker.canRequest()).toBe(true)
+  })
+
+  it("ignores stray failures while fully open without extending the cooldown", () => {
+    const breaker = new CircuitBreaker(
+      {
+        failureThreshold: 1,
+        failureWindowMs: 1_000,
+        initialCooldownMs: 500,
+      },
+      undefined,
+      now,
+    )
+
+    breaker.recordFailure()
+    advance(100)
+    breaker.recordFailure()
+    breaker.recordFailure()
+    advance(400)
+    // Cooldown should still elapse at 500ms from the original open.
+    expect(breaker.canRequest()).toBe(true)
+  })
+
+  it("resets the failure window on a success while closed", () => {
+    const breaker = new CircuitBreaker(
+      { failureThreshold: 3, failureWindowMs: 60_000 },
+      undefined,
+      now,
+    )
+
+    breaker.recordFailure()
+    breaker.recordFailure()
+    breaker.recordSuccess()
+    breaker.recordFailure()
+    breaker.recordFailure()
+    expect(breaker.getState()).toBe("closed")
+  })
+})

--- a/background/services/chain/tests/serial-fallback-provider.circuit-breaker.integration.test.ts
+++ b/background/services/chain/tests/serial-fallback-provider.circuit-breaker.integration.test.ts
@@ -1,0 +1,93 @@
+import { JsonRpcProvider } from "@ethersproject/providers"
+import Sinon, * as sinon from "sinon"
+import { ETHEREUM } from "../../../constants"
+import SerialFallbackProvider from "../serial-fallback-provider"
+import { CircuitBreaker } from "../circuit-breaker"
+import {
+  resetForTests as resetPerfMetricsForTests,
+  snapshotAndReset,
+} from "../../../lib/perf-metrics"
+
+const sandbox = sinon.createSandbox()
+
+/**
+ * Force-trip the breaker for a specific provider index without waiting for
+ * the real failure threshold to be crossed. Tests a narrow, observable piece
+ * of behavior: that an open breaker redirects traffic to the next provider
+ * and that a healthy breaker leaves routing unchanged.
+ */
+function tripBreakerOpen(
+  provider: SerialFallbackProvider,
+  providerIndex: number,
+): CircuitBreaker {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/dot-notation
+  const breaker: CircuitBreaker = (provider as any)["breakerFor"](providerIndex)
+  for (let i = 0; i < 10; i += 1) {
+    breaker.recordFailure()
+  }
+  return breaker
+}
+
+describe("SerialFallbackProvider circuit breaker integration", () => {
+  let fallbackProvider: SerialFallbackProvider
+  let genericSendStub: Sinon.SinonStub
+  let alchemySendStub: Sinon.SinonStub
+
+  beforeEach(() => {
+    resetPerfMetricsForTests()
+    const mockGenericProvider = new JsonRpcProvider("fake-rpc-url")
+    const mockAlchemyProvider = new JsonRpcProvider("fake-alchemy-url")
+    genericSendStub = sandbox
+      .stub(mockGenericProvider, "send")
+      .callsFake(async () => "generic")
+    alchemySendStub = sandbox
+      .stub(mockAlchemyProvider, "send")
+      .callsFake(async () => "alchemy")
+    fallbackProvider = new SerialFallbackProvider(ETHEREUM.chainID, [
+      { type: "generic", creator: () => mockGenericProvider },
+      { type: "alchemy", creator: () => mockAlchemyProvider },
+    ])
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it("skips an open-breaker provider and routes to the next provider", async () => {
+    tripBreakerOpen(fallbackProvider, 0)
+
+    const result = await fallbackProvider.send("eth_getBlockByNumber", [
+      "0x1",
+      false,
+    ])
+
+    expect(result).toBe("alchemy")
+    // The generic provider should not have been called for eth_getBlockByNumber.
+    expect(
+      genericSendStub.args.filter((args) => args[0] === "eth_getBlockByNumber")
+        .length,
+    ).toBe(0)
+    // Alchemy served it instead.
+    expect(
+      alchemySendStub.args.filter((args) => args[0] === "eth_getBlockByNumber")
+        .length,
+    ).toBeGreaterThan(0)
+  })
+
+  it("records the breaker transition to open in perf metrics", async () => {
+    tripBreakerOpen(fallbackProvider, 0)
+    const snapshot = snapshotAndReset()
+    const primary = snapshot.chains[ETHEREUM.chainID].providers.find(
+      (p) => p.providerIndex === 0,
+    )!
+    expect(primary.circuitBreakerOpens).toBe(1)
+  })
+
+  it("leaves routing unchanged when the breaker is closed", async () => {
+    const result = await fallbackProvider.send("eth_getBlockByNumber", [
+      "0x1",
+      false,
+    ])
+    expect(result).toBe("generic")
+  })
+})

--- a/background/services/chain/tests/serial-fallback-provider.single-flight.integration.test.ts
+++ b/background/services/chain/tests/serial-fallback-provider.single-flight.integration.test.ts
@@ -1,0 +1,184 @@
+import { JsonRpcProvider } from "@ethersproject/providers"
+import Sinon, * as sinon from "sinon"
+import { ETHEREUM } from "../../../constants"
+import SerialFallbackProvider from "../serial-fallback-provider"
+import {
+  resetForTests as resetPerfMetricsForTests,
+  snapshotAndReset,
+} from "../../../lib/perf-metrics"
+
+const sandbox = sinon.createSandbox()
+
+/**
+ * Promise that exposes its resolver, so a test can hold a request in-flight
+ * and only release it once the coalescing assertion has been made.
+ */
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason: unknown) => void
+} {
+  let resolve!: (value: T) => void
+  let reject!: (reason: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe("SerialFallbackProvider single-flight coalescing", () => {
+  let fallbackProvider: SerialFallbackProvider
+  let genericSendStub: Sinon.SinonStub
+  let alchemySendStub: Sinon.SinonStub
+
+  beforeEach(() => {
+    resetPerfMetricsForTests()
+    const mockGenericProvider = new JsonRpcProvider("fake-rpc-url")
+    const mockAlchemyProvider = new JsonRpcProvider("fake-alchemy-url")
+    genericSendStub = sandbox
+      .stub(mockGenericProvider, "send")
+      .callsFake(async () => "success")
+    alchemySendStub = sandbox
+      .stub(mockAlchemyProvider, "send")
+      .callsFake(async () => "success")
+    fallbackProvider = new SerialFallbackProvider(ETHEREUM.chainID, [
+      { type: "generic", creator: () => mockGenericProvider },
+      { type: "alchemy", creator: () => mockAlchemyProvider },
+    ])
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it("coalesces concurrent identical requests into a single provider call", async () => {
+    const gate = deferred<string>()
+    genericSendStub
+      .withArgs("eth_getBlockByNumber")
+      .callsFake(() => gate.promise)
+
+    const first = fallbackProvider.send("eth_getBlockByNumber", ["0x1", false])
+    const second = fallbackProvider.send("eth_getBlockByNumber", ["0x1", false])
+    const third = fallbackProvider.send("eth_getBlockByNumber", ["0x1", false])
+
+    // All three callers should be waiting on the single underlying promise.
+    expect(
+      genericSendStub.args.filter((args) => args[0] === "eth_getBlockByNumber")
+        .length,
+    ).toBe(1)
+
+    gate.resolve("block")
+    await expect(first).resolves.toBe("block")
+    await expect(second).resolves.toBe("block")
+    await expect(third).resolves.toBe("block")
+
+    expect(
+      genericSendStub.args.filter((args) => args[0] === "eth_getBlockByNumber")
+        .length,
+    ).toBe(1)
+
+    const snapshot = snapshotAndReset()
+    expect(
+      snapshot.chains[ETHEREUM.chainID].providers[0].singleFlightCoalesces,
+    ).toBe(2)
+  })
+
+  it("does not coalesce requests whose params differ", async () => {
+    genericSendStub
+      .withArgs("eth_getBlockByNumber")
+      .callsFake(
+        async (_method, params: unknown[]) => `block-${String(params[0])}`,
+      )
+
+    const [a, b] = await Promise.all([
+      fallbackProvider.send("eth_getBlockByNumber", ["0x1", false]),
+      fallbackProvider.send("eth_getBlockByNumber", ["0x2", false]),
+    ])
+
+    expect(a).toBe("block-0x1")
+    expect(b).toBe("block-0x2")
+    expect(
+      genericSendStub.args.filter((args) => args[0] === "eth_getBlockByNumber")
+        .length,
+    ).toBe(2)
+  })
+
+  it("starts a fresh provider call after the shared promise settles", async () => {
+    let callCount = 0
+    genericSendStub.withArgs("eth_getBlockByNumber").callsFake(async () => {
+      callCount += 1
+      return `block-${callCount}`
+    })
+
+    const first = await fallbackProvider.send("eth_getBlockByNumber", [
+      "0x1",
+      false,
+    ])
+    const second = await fallbackProvider.send("eth_getBlockByNumber", [
+      "0x1",
+      false,
+    ])
+
+    // Sequential calls (not concurrent) each perform their own provider hit
+    // for a method that is not in the read-through cache.
+    expect(first).toBe("block-1")
+    expect(second).toBe("block-2")
+    expect(callCount).toBe(2)
+  })
+
+  it("does not coalesce eth_sendRawTransaction even with identical params", async () => {
+    // eth_sendRawTransaction is always routed to the alchemy provider.
+    let txCount = 0
+    alchemySendStub.callsFake(async (method: string) => {
+      if (method === "eth_sendRawTransaction") {
+        txCount += 1
+        return `tx-${txCount}`
+      }
+      return "success"
+    })
+
+    const [a, b] = await Promise.all([
+      fallbackProvider.send("eth_sendRawTransaction", ["0xdeadbeef"]),
+      fallbackProvider.send("eth_sendRawTransaction", ["0xdeadbeef"]),
+    ])
+
+    expect(a).toBe("tx-1")
+    expect(b).toBe("tx-2")
+    expect(txCount).toBe(2)
+  })
+
+  it("propagates a shared rejection to all followers and clears the in-flight slot", async () => {
+    const gate = deferred<string>()
+    let callCount = 0
+    genericSendStub.callsFake(async (method: string) => {
+      if (method === "eth_getBalance") {
+        callCount += 1
+        if (callCount === 1) {
+          return gate.promise
+        }
+        return "0x42"
+      }
+      return "success"
+    })
+
+    const first = fallbackProvider.send("eth_getBalance", ["0xabc", "latest"])
+    const second = fallbackProvider.send("eth_getBalance", ["0xabc", "latest"])
+
+    // Reject with an error that routeRpcCall treats as a non-retryable,
+    // uncategorized failure so it propagates directly to our callers.
+    gate.reject(new Error("single-flight terminal failure"))
+
+    await expect(first).rejects.toThrow("single-flight terminal failure")
+    await expect(second).rejects.toThrow("single-flight terminal failure")
+
+    // Now that the in-flight slot has been cleared, a subsequent call goes
+    // to the provider again rather than inheriting the rejected promise.
+    const third = await fallbackProvider.send("eth_getBalance", [
+      "0xabc",
+      "latest",
+    ])
+    expect(third).toBe("0x42")
+    expect(callCount).toBe(2)
+  })
+})

--- a/background/services/redux/store.ts
+++ b/background/services/redux/store.ts
@@ -18,6 +18,7 @@ import { allAliases } from "../../redux-slices/utils"
 
 import { diff as deepDiff, patch } from "./differ"
 import logger from "../../lib/logger"
+import { recordReduxDiff, recordReduxPersist } from "../../lib/perf-metrics"
 
 // Manifest v3/webext-redux v3 requirement, create at the top level to properly
 // attach to event handlers.
@@ -43,12 +44,15 @@ const devToolsSanitizer = (input: unknown) => {
 
 async function persistStoreBsae<T>(state: T) {
   if (process.env.WRITE_REDUX_CACHE === "true") {
+    const startedAt = Date.now()
     // Browser extension storage supports JSON natively, despite that we have
     // to stringify to preserve BigInts
+    const encoded = encodeJSON(state)
     await browser.storage.local.set({
-      state: encodeJSON(state),
+      state: encoded,
       version: REDUX_STATE_VERSION,
     })
+    recordReduxPersist(Date.now() - startedAt, encoded.length)
   }
 }
 
@@ -171,7 +175,9 @@ export function initializeStore<ThunkArgType>(
   const queueUpdate = debounce(
     (lastState, newState, updateFn) => {
       if (lastState !== newState) {
+        const diffStartedAt = Date.now()
         const diff = deepDiff(lastState, newState)
+        recordReduxDiff(Date.now() - diffStartedAt)
 
         if (diff !== undefined) {
           updateFn(newState, [diff])


### PR DESCRIPTION
## Summary

Two-part change aimed at the retry-storm and redux-churn behavior we see when
an upstream RPC rate-limits or drops: first, give the chain provider layer
observability; second, stop the provider from amplifying outages into herds.

The provider today rediscovers an unhealthy endpoint on every call (each call
walks its own 3-retry × fallback × reconnect path), and concurrent identical
requests each perform that walk independently. Multiplied across callers and
tracked networks this produces the 10–90 second redux serialization spikes
observed in real sessions, since every failed path and every retry feeds
state updates that the store must diff and persist.

This PR lands the first two pieces of the plan we discussed:

- **Visibility.** A process-wide perf metrics collector tracks per-chain,
  per-provider counters for requests sent / succeeded / failed (by error
  category), reconnect attempts and outcomes, single-flight coalesces, and
  circuit-breaker transitions, plus a small duration histogram. The analytics
  service drains the collector every 3 hours and emits a single
  `Performance Metrics Flush` PostHog event per window, respecting existing
  opt-in logic. Empty windows produce no event.
- **Single-flight coalescing.** Concurrent identical RPC calls now share one
  in-flight provider call. Subscription lifecycle and side-effecting methods
  (signing, broadcast) are explicitly excluded. Turns N concurrent callers
  into one underlying network round-trip and one shared retry cycle.
- **Per-provider circuit breaker.** Each provider index has its own
  closed/open/half-open breaker with exponential cooldown. An open breaker
  short-circuits `routeRpcCall` directly to the next provider rather than
  issuing a request guaranteed to fail, and suppresses the 10-second primary
  recovery loop from probing a provider that is still in cooldown. Successful
  and failed provider responses drive the breaker directly.

What this does **not** include (future work, also discussed):
- Redux-side batching of `blockPrices` / `activities` / balance updates
- Activity slice migration from arrays to keyed records
- `objectHash` for jsondiffpatch on keyed collections
- Splitting persisted vs. UI-synced state to move `encodeJSON` off the hot path

## Design notes

### Metrics shape
Flat counters keyed by `chainID → providerIndex` keep the collector cheap and
the PostHog payload small (a few kilobytes at most). Request durations are
binned into 7 fixed buckets + overflow so memory is bounded regardless of
traffic volume. `snapshotAndReset` hands back the window atomically so
producers never have to coordinate.

### Coalescing safety
Keying uses the same canonical signature the existing RPC cache uses
(`getRPCCacheKey`), so the two mechanisms stay consistent. Followers inherit
the leader's rejection on failure; the in-flight slot is cleared as soon as
the promise settles so the next caller initiates a fresh request rather than
inheriting a stale or rejected value. Cleanup uses `then(cleanup, cleanup)`
rather than `finally` so a rejection on the dispatched request does not
escape as an unhandled promise rejection on the bookkeeping chain.

### Circuit breaker tuning
Defaults: 5 failures in a 30s window trip the breaker; initial cooldown 15s,
doubling per re-open up to a 2-minute ceiling. These are per-provider-index
and stored in a `Map<number, CircuitBreaker>`, created lazily. State is in
memory only; service-worker restart resets, which is acceptable given the
breaker's purpose is short-term herd dampening rather than outage history.

The breaker lives behind a `breakerFor(providerIndex)` method so tests can
force-trip it without fighting real failure thresholds. Transitions are
emitted to the perf collector via a callback, keeping the breaker itself
decoupled from analytics.

### Commit structure
Five atomic commits, each standing alone and each building cleanly:
1. Perf metrics collector (pure module, no call sites yet)
2. Analytics flush on 3h cadence (producer/consumer wiring)
3. Instrument SerialFallbackProvider (counters only, behavior unchanged)
4. Single-flight coalescing (+ integration tests)
5. Per-provider circuit breaker (+ unit and integration tests)

## Test plan

- [x] `background/lib/tests/perf-metrics.unit.test.ts` — collector aggregation,
      histogram bucketing, reset semantics
- [x] `background/services/analytics/tests/index.integration.test.ts` — flush
      emits a single event with the snapshot, no-op on empty window, counters
      reset after flush
- [x] `background/services/chain/tests/serial-fallback-provider.integration.test.ts`
      — pre-existing 16 tests still pass (behavior-unchanged instrumentation)
- [x] `background/services/chain/tests/serial-fallback-provider.single-flight.integration.test.ts`
      — concurrent coalescing, differing params not coalesced, fresh call
      after settle, no coalesce for `eth_sendRawTransaction`, shared rejection
      clears slot
- [x] `background/services/chain/tests/circuit-breaker.unit.test.ts` —
      threshold, rolling window, half-open probe semantics, exponential
      cooldown, cap, stray failures while open, window reset on success
- [x] `background/services/chain/tests/serial-fallback-provider.circuit-breaker.integration.test.ts`
      — open breaker redirects to fallback, records transition, closed
      breaker leaves routing unchanged
- [x] ESLint clean on all touched files
- [ ] Manual smoke in a dev build: load extension with the dev RPC set to a
      low rate-limit endpoint, confirm counters appear in the flush event and
      that dev-tools shows fewer concurrent routeRpcCall paths