### PR TITLE
Preserve Ledger device type on disconnect events

### DIFF
--- a/background/services/ledger/index.ts
+++ b/background/services/ledger/index.ts
@@ -174,6 +174,8 @@ async function generateLedgerId(
 export default class LedgerService extends BaseService<Events> {
   #currentLedgerId: string | null = null
 
+  #currentLedgerType: LedgerType | null = null
+
   transport: Transport | undefined = undefined
 
   #lastOperationPromise = Promise.resolve()
@@ -228,6 +230,7 @@ export default class LedgerService extends BaseService<Events> {
         const normalizedID = normalizeEVMAddress(id)
 
         this.#currentLedgerId = `${LedgerTypeAsString[type]}_${normalizedID}`
+        this.#currentLedgerType = type
 
         this.emitter.emit("connected", {
           id: this.#currentLedgerId,
@@ -289,10 +292,11 @@ export default class LedgerService extends BaseService<Events> {
 
       this.emitter.emit("disconnected", {
         id: this.#currentLedgerId,
-        type: LedgerType.LEDGER_NANO_S,
+        type: this.#currentLedgerType ?? LedgerType.UNKNOWN,
       })
 
       this.#currentLedgerId = null
+      this.#currentLedgerType = null
     }
 
   protected override async internalStartService(): Promise<void> {


### PR DESCRIPTION
## Summary

- keep the Ledger device type detected during connection
- emit that same type when the current Ledger disconnects instead of always reporting Nano S

## Context

#3833 added detection for newer Ledger devices such as Stax and Flex. The connection events now carry the detected device type, but the disconnect event still hard-coded `LEDGER_NANO_S`, which could make downstream state consumers see a different device family after unplugging the same Ledger.

## Tests

- `git diff --check`
- Not run: `yarn eslint background/services/ledger/index.ts` (Corepack failed while downloading Yarn from `registry.yarnpkg.com` with `ECONNRESET`)
