### PR TITLE
Fix LedgerService stop hook

### DIFF
--- a/background/services/ledger/index.ts
+++ b/background/services/ledger/index.ts
@@ -302,7 +302,7 @@ export default class LedgerService extends BaseService<Events> {
   }
 
   protected override async internalStopService(): Promise<void> {
-    await super.internalStartService() // Not needed, but better to stick to the patterns
+    await super.internalStopService() // Not needed, but better to stick to the patterns
 
     navigator.usb.removeEventListener("disconnect", this.#handleUSBDisconnect)
     navigator.usb.removeEventListener("connect", this.#handleUSBConnect)


### PR DESCRIPTION
## Summary

- Fix `LedgerService.internalStopService()` to call `super.internalStopService()`.
- Keep the existing USB listener cleanup unchanged.

The stop hook currently calls the base start hook, which bypasses the base stop lifecycle path when LedgerService shuts down.

## Tests

- `git diff --check`

Not run locally: `yarn eslint background/services/ledger/index.ts` could not run because this clean worktree does not have dependencies installed (`Command "eslint" not found`).
